### PR TITLE
Absorption Transmission converter output

### DIFF
--- a/Wrappers/Python/cil/processors/AbsorptionTransmissionConverter.py
+++ b/Wrappers/Python/cil/processors/AbsorptionTransmissionConverter.py
@@ -52,17 +52,12 @@ class AbsorptionTransmissionConverter(DataProcessor):
 
     def process(self, out=None):
 
+        data = self.get_input()
         if out is None:
-        
-            data = self.get_input().copy()
-            data *= -1
-            data.exp(out=data)
-            data *= self.white_level
-        
-            return data
-
+            out = data.multiply(-1.0)          
         else:
+            data.multiply(-1.0, out=out)
 
-            out *= -1
-            out.exp(out=out)
-            out *= self.white_level
+        out.exp(out=out)
+        out.multiply(numpy.float32(self.white_level), out=out)
+        return out

--- a/Wrappers/Python/cil/processors/TransmissionAbsorptionConverter.py
+++ b/Wrappers/Python/cil/processors/TransmissionAbsorptionConverter.py
@@ -59,29 +59,25 @@ class TransmissionAbsorptionConverter(DataProcessor):
 
     def process(self, out=None):
 
+        data = self.get_input()
+
+        white_level = numpy.float32(self.white_level)
+
         if out is None:
-        
-            data = self.get_input().copy()
-            data /= self.white_level
-            data.as_array()[data.as_array() < self.min_intensity] = self.min_intensity
-            
-            try:
-                data.log(out=data)
-            except RuntimeWarning:
-                raise ValueError('Zero encountered in log. Please set threshold to some value to avoid this.')
-                
-            data *= -1
-
-            return data
-        
+            out = data.divide(white_level)
         else:
+            data.divide(white_level, out=out)
 
-            out /= self.white_level
-            out.as_array()[out.as_array() < self.min_intensity] = self.min_intensity
-            
-            try:
-                out.log(out=out)
-            except RuntimeWarning:
-                raise ValueError('Zero encountered in log. Please set threshold to some value to avoid this.')
+        arr = out.as_array()
+        threshold = numpy.float32(self.min_intensity)
+        threshold_indices = arr < threshold
+        arr[threshold_indices] = threshold
+        out.fill(arr)
+
+        try:
+            out.log(out=out)
+        except RuntimeWarning:
+            raise ValueError('Zero encountered in log. Please set threshold to some value to avoid this.')
                 
-            out *= -1
+        out.multiply(-1.0,out=out)
+        return out

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -909,11 +909,11 @@ class TestTransmissionAbsorptionConverter(unittest.TestCase):
         self.assertTrue(data_exp.geometry == AG)
         numpy.testing.assert_allclose(data_exp.as_array(), data_new, rtol=1E-6)
         
-        s.process(out=ad)
+        data_exp.fill(0)
+        s.process(out=data_exp)
         
-        self.assertTrue(ad.geometry == AG)
-        numpy.testing.assert_allclose(data_exp.as_array(), ad.as_array(), rtol=1E-6)
-    
+        self.assertTrue(data_exp.geometry == AG)
+        numpy.testing.assert_allclose(data_exp.as_array(), data_new, rtol=1E-6)
 
 class TestAbsorptionTransmissionConverter(unittest.TestCase):
 
@@ -952,10 +952,11 @@ class TestAbsorptionTransmissionConverter(unittest.TestCase):
         self.assertTrue(data_exp.geometry == AG)
         numpy.testing.assert_allclose(data_exp.as_array(), numpy.exp(-ad.as_array())*10, rtol=1E-6)
         
-        s.process(out=ad)
+        data_exp.fill(0)
+        s.process(out=data_exp)
         
-        self.assertTrue(ad.geometry == AG)
-        numpy.testing.assert_allclose(data_exp.as_array(), ad.as_array(), rtol=1E-6)       
+        self.assertTrue(data_exp.geometry == AG)
+        numpy.testing.assert_allclose(data_exp.as_array(), numpy.exp(-ad.as_array())*10, rtol=1E-6)  
 
 
 class TestMasker(unittest.TestCase):       


### PR DESCRIPTION
closes #870

Change logic to use out if passed.
DataContainer.divide() numpy call returns a new dtype as standard. If it's passed an int32 the numpy backend fails. So the maths will only be done in float32.

Maybe we should have a test on the dtype of `out` at a more fundamental level.

```python
data.dtype
dtype('int32')
out.dtype
dtype('int32')
data.divide(10, out=out)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/tpc56154/miniconda3/envs/cil-dev/lib/python3.8/site-packages/cil/framework/framework.py", line 2237, in divide
    return self.pixel_wise_binary(numpy.divide, other, *args, **kwargs)
  File "/home/tpc56154/miniconda3/envs/cil-dev/lib/python3.8/site-packages/cil/framework/framework.py", line 2200, in pixel_wise_binary
    pwop(self.as_array(), x2, *args, **kwargs )
```
