### PR TITLE
Add version number to documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,8 +15,10 @@
 import os
 import sys
 import re
-from cil import version
+
 sys.path.insert(0, os.path.abspath('../../Wrappers/Python/'))
+
+from cil import version
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,9 +28,7 @@ copyright = '2017-2021 UKRI-STFC, University of Manchester'
 
 author = 'Edoardo Pasca'
 
-# The short X.Y version
 version = version.version
-version = version.split('-')[0]
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import re
+from cil import version
 sys.path.insert(0, os.path.abspath('../../Wrappers/Python/'))
 
 # -- Project information -----------------------------------------------------
@@ -26,8 +27,9 @@ copyright = '2017-2021 UKRI-STFC, University of Manchester'
 author = 'Edoardo Pasca'
 
 # The short X.Y version
-version = re.sub('^v', '', os.popen('git describe').read().strip())
+version = version.version
 version = version.split('-')[0]
+release = version
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Adds current version number to docs.
Currently we just build docs from master, and label as latest release number