### PR TITLE
add projection map, canonincal map, unittest

### DIFF
--- a/Wrappers/Python/cil/optimisation/operators/ProjectionMap.py
+++ b/Wrappers/Python/cil/optimisation/operators/ProjectionMap.py
@@ -1,0 +1,150 @@
+from cil.optimisation.operators import LinearOperator
+from cil.framework import BlockGeometry
+
+
+
+class ProjectionMap(LinearOperator):
+
+    r""" Projection Map or Canonincal Projection (https://en.wikipedia.org/wiki/Projection_(mathematics))
+    
+    takes an element x = (x_{0},\dots,x_{i},\dots,x_{n}}) from a Cartesian product space X_{1}\times\cdots\times X_{n}\rightarrow X_{i}
+
+    and projects it to element x_{i} specified by the index i.
+
+    .. math:: \pi_{i}: X_{1}\times\cdots\times X_{n}\rightarrow X_{i}
+
+    .. math:: \pi_{i}(x_{0},\dots,x_{i},\dots,x_{n}) = x_{i}
+
+    The adjoint operation, is defined as 
+
+    .. math:: \pi_{i}^{*}(x_{i}) = (0, \cdots, x_{i}, \cdots, 0)
+
+    :param domain_geometry: The domain of the Projection Map. A BlockGeometry is expected
+    :type domain_geometry: `BlockGeometry`
+    :param index: Index to project to the corresponding ImageGeometry X_{index}
+    :type index: int   
+    :return: returns a DataContainer 
+    :rtype: DataContainer    
+
+    """
+
+    
+    def __init__(self, domain_geometry, index, range_geometry=None):
+        
+        self.index = index
+
+        if not isinstance(domain_geometry, BlockGeometry):
+            raise ValueError("BlockGeometry is expected, {} is passed.".format(domain_geometry.__class__.__name__))
+
+        if self.index > len(domain_geometry.geometries):
+            raise ValueError("Index = {} is larger than the total number of geometries = {}".format(index, len(domain_geometry.geometries)))
+
+        if range_geometry is None:
+            range_geometry = domain_geometry.geometries[self.index]
+            
+        super(ProjectionMap, self).__init__(domain_geometry=domain_geometry, 
+                                           range_geometry=range_geometry)   
+        
+    def direct(self,x,out=None):
+                        
+        if out is None:
+            return x[self.index]
+        else:
+            out.fill(x[self.index])
+    
+    def adjoint(self,x, out=None):
+        
+        if out is None:
+            tmp = self.domain_geometry().allocate()
+            tmp[self.index].fill(x)            
+            return tmp
+        else:
+            out[self.index].fill(x) 
+
+if __name__ == '__main__':
+
+    from cil.framework import ImageGeometry, BlockGeometry
+    import numpy as np
+
+    print("Check if direct is correct")
+    ig1 = ImageGeometry(3,4)
+    ig2 = ImageGeometry(5,6)
+    ig3 = ImageGeometry(5,6,4)
+
+    bg = BlockGeometry(ig1,ig2, ig3)
+
+    x = bg.allocate('random')
+    x0 = x[0]
+    x1 = x[1]
+    x2 = x[2]
+
+
+    for i in range(3):
+
+        proj_map = ProjectionMap(bg, i)
+
+        # res1 is in ImageData from the X_{i} "ImageGeometry"
+        res1 = proj_map.direct(x)
+
+        # res2 is in ImageData from the X_{i} "ImageGeometry" using out
+        res2 = bg.geometries[i].allocate(0)
+        proj_map.direct(x, out=res2)
+
+        # Assert with and withou out
+        np.testing.assert_array_almost_equal(res1.array, res2.array)
+
+        # Depending on which index is used, check if x0, x1, x2 are the same with res2
+
+        if i==0:            
+            np.testing.assert_array_almost_equal(x0.array, res2.array)
+        elif i==1: 
+            np.testing.assert_array_almost_equal(x1.array, res2.array)   
+        elif i==2:
+            np.testing.assert_array_almost_equal(x2.array, res2.array)  
+        else:
+            pass      
+
+    print("Test passed \n")    
+
+    print("Check if adjoint is correct")
+
+    bg = BlockGeometry(ig1, ig2, ig3, ig1, ig2, ig3)
+
+    x = ig1.allocate('random')
+
+    index=3
+    proj_map = ProjectionMap(bg, index)
+
+    res1 = bg.allocate(0)
+    proj_map.adjoint(x, out=res1)
+
+    # check if all indices return arrays filled with 0, except the input index
+
+    for i in range(len(bg.geometries)):
+
+        if i!=index:
+            np.testing.assert_array_almost_equal(res1[i].array, bg.geometries[i].allocate().array)
+
+    print("Test passed \n")       
+
+    print("Check error messages")
+    # Check if index is correct wrt length of Cartesian Product
+    try:
+        ig = ImageGeometry(3,4)
+        bg = BlockGeometry(ig,ig)
+        index = 3
+        proj_map = ProjectionMap(bg, index)
+    except ValueError as err:
+            print(err) 
+
+    # Check error if an ImageGeometry is passed
+    try:
+        proj_map = ProjectionMap(ig, index)               
+    except ValueError as err:
+        print(err)   
+    print("Test passed \n")           
+
+
+
+    
+

--- a/Wrappers/Python/cil/optimisation/operators/ProjectionMap.py
+++ b/Wrappers/Python/cil/optimisation/operators/ProjectionMap.py
@@ -18,9 +18,9 @@ class ProjectionMap(LinearOperator):
 
     .. math:: \pi_{i}^{*}(x_{i}) = (0, \cdots, x_{i}, \cdots, 0)
 
-    :param domain_geometry: The domain of the Projection Map. A BlockGeometry is expected
+    :param domain_geometry: The domain of the Projection Map. A BlockGeometry is expected.
     :type domain_geometry: `BlockGeometry`
-    :param index: Index to project to the corresponding ImageGeometry X_{index}
+    :param index: Index to project to the corresponding ImageGeometry X_{index}.
     :type index: int   
     :return: returns a DataContainer 
     :rtype: DataContainer    
@@ -47,7 +47,7 @@ class ProjectionMap(LinearOperator):
     def direct(self,x,out=None):
                         
         if out is None:
-            return x[self.index]
+            return x[self.index].copy()
         else:
             out.fill(x[self.index])
     

--- a/Wrappers/Python/cil/optimisation/operators/ProjectionMap.py
+++ b/Wrappers/Python/cil/optimisation/operators/ProjectionMap.py
@@ -54,7 +54,7 @@ class ProjectionMap(LinearOperator):
     def adjoint(self,x, out=None):
         
         if out is None:
-            tmp = self.domain_geometry().allocate()
+            tmp = self.domain_geometry().allocate(0)
             tmp[self.index].fill(x)            
             return tmp
         else:

--- a/Wrappers/Python/cil/optimisation/operators/ProjectionMap.py
+++ b/Wrappers/Python/cil/optimisation/operators/ProjectionMap.py
@@ -5,10 +5,9 @@ from cil.framework import BlockGeometry
 
 class ProjectionMap(LinearOperator):
 
-    r""" Projection Map or Canonincal Projection (https://en.wikipedia.org/wiki/Projection_(mathematics))
+    r""" Projection Map or Canonical Projection (https://en.wikipedia.org/wiki/Projection_(mathematics))
     
-    takes an element x = (x_{0},\dots,x_{i},\dots,x_{n}}) from a Cartesian product space X_{1}\times\cdots\times X_{n}\rightarrow X_{i}
-
+    Takes an element x = (x_{0},\dots,x_{i},\dots,x_{n}}) from a Cartesian product space X_{1}\times\cdots\times X_{n}\rightarrow X_{i}
     and projects it to element x_{i} specified by the index i.
 
     .. math:: \pi_{i}: X_{1}\times\cdots\times X_{n}\rightarrow X_{i}
@@ -43,7 +42,7 @@ class ProjectionMap(LinearOperator):
             range_geometry = domain_geometry.geometries[self.index]
             
         super(ProjectionMap, self).__init__(domain_geometry=domain_geometry, 
-                                           range_geometry=range_geometry)   
+                                            range_geometry=range_geometry)   
         
     def direct(self,x,out=None):
                         
@@ -60,91 +59,4 @@ class ProjectionMap(LinearOperator):
             return tmp
         else:
             out[self.index].fill(x) 
-
-if __name__ == '__main__':
-
-    from cil.framework import ImageGeometry, BlockGeometry
-    import numpy as np
-
-    print("Check if direct is correct")
-    ig1 = ImageGeometry(3,4)
-    ig2 = ImageGeometry(5,6)
-    ig3 = ImageGeometry(5,6,4)
-
-    bg = BlockGeometry(ig1,ig2, ig3)
-
-    x = bg.allocate('random')
-    x0 = x[0]
-    x1 = x[1]
-    x2 = x[2]
-
-
-    for i in range(3):
-
-        proj_map = ProjectionMap(bg, i)
-
-        # res1 is in ImageData from the X_{i} "ImageGeometry"
-        res1 = proj_map.direct(x)
-
-        # res2 is in ImageData from the X_{i} "ImageGeometry" using out
-        res2 = bg.geometries[i].allocate(0)
-        proj_map.direct(x, out=res2)
-
-        # Assert with and withou out
-        np.testing.assert_array_almost_equal(res1.array, res2.array)
-
-        # Depending on which index is used, check if x0, x1, x2 are the same with res2
-
-        if i==0:            
-            np.testing.assert_array_almost_equal(x0.array, res2.array)
-        elif i==1: 
-            np.testing.assert_array_almost_equal(x1.array, res2.array)   
-        elif i==2:
-            np.testing.assert_array_almost_equal(x2.array, res2.array)  
-        else:
-            pass      
-
-    print("Test passed \n")    
-
-    print("Check if adjoint is correct")
-
-    bg = BlockGeometry(ig1, ig2, ig3, ig1, ig2, ig3)
-
-    x = ig1.allocate('random')
-
-    index=3
-    proj_map = ProjectionMap(bg, index)
-
-    res1 = bg.allocate(0)
-    proj_map.adjoint(x, out=res1)
-
-    # check if all indices return arrays filled with 0, except the input index
-
-    for i in range(len(bg.geometries)):
-
-        if i!=index:
-            np.testing.assert_array_almost_equal(res1[i].array, bg.geometries[i].allocate().array)
-
-    print("Test passed \n")       
-
-    print("Check error messages")
-    # Check if index is correct wrt length of Cartesian Product
-    try:
-        ig = ImageGeometry(3,4)
-        bg = BlockGeometry(ig,ig)
-        index = 3
-        proj_map = ProjectionMap(bg, index)
-    except ValueError as err:
-            print(err) 
-
-    # Check error if an ImageGeometry is passed
-    try:
-        proj_map = ProjectionMap(ig, index)               
-    except ValueError as err:
-        print(err)   
-    print("Test passed \n")           
-
-
-
-    
 

--- a/Wrappers/Python/cil/optimisation/operators/__init__.py
+++ b/Wrappers/Python/cil/optimisation/operators/__init__.py
@@ -29,4 +29,5 @@ from .DiagonalOperator import DiagonalOperator
 from .MaskOperator import MaskOperator
 from .ChannelwiseOperator import ChannelwiseOperator
 from .BlurringOperator import BlurringOperator
+from .ProjectionMap import ProjectionMap
 

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -398,7 +398,7 @@ class TestOperator(CCPiTestClass):
             proj_map.direct(x, out=res2)
 
             # Check with and without out
-            numpy.testing.assert_array_almost_equal(res1.array, res2.array)
+            numpy.testing.assert_array_almost_equal(res1.as_array(), res2.as_array())
 
             # Depending on which index is used, check if x0, x1, x2 are the same with res2
             if i==0:            
@@ -443,6 +443,10 @@ class TestOperator(CCPiTestClass):
             proj_map = ProjectionMap(ig, index)               
         except ValueError as err:
             print(err)           
+
+        # check adjoint 
+         
+            
     
 class TestGradients(CCPiTestClass): 
     def setUp(self):

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -402,11 +402,11 @@ class TestOperator(CCPiTestClass):
 
             # Depending on which index is used, check if x0, x1, x2 are the same with res2
             if i==0:            
-                numpy.testing.assert_array_almost_equal(x0.array, res2.array)
+                numpy.testing.assert_array_almost_equal(x0.as_array(), res2.as_array())
             elif i==1: 
-                numpy.testing.assert_array_almost_equal(x1.array, res2.array)   
+                numpy.testing.assert_array_almost_equal(x1.as_array(), res2.as_array())   
             elif i==2:
-                numpy.testing.assert_array_almost_equal(x2.array, res2.array)  
+                numpy.testing.assert_array_almost_equal(x2.as_array(), res2.as_array())  
             else:
                 pass      
 

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -381,7 +381,7 @@ class TestOperator(CCPiTestClass):
 
         # Create BlockGeometry
         bg = BlockGeometry(ig1,ig2, ig3)
-        x = bg.allocate('random')
+        x = bg.allocate(10)
 
         # Extract containers
         x0, x1, x2 = x[0], x[1], x[2]
@@ -413,7 +413,7 @@ class TestOperator(CCPiTestClass):
         # Check if adjoint is correct
 
         bg = BlockGeometry(ig1, ig2, ig3, ig1, ig2, ig3)
-        x = ig1.allocate('random')
+        x = ig1.allocate(20)
 
         index=3
         proj_map = ProjectionMap(bg, index)
@@ -444,7 +444,6 @@ class TestOperator(CCPiTestClass):
         except ValueError as err:
             print(err)           
 
-        # check adjoint 
          
             
     

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -374,18 +374,17 @@ class TestOperator(CCPiTestClass):
 
     def test_ProjectionMap(self):
 
-        print("Check if direct is correct")
+        # Check if direct is correct
         ig1 = ImageGeometry(3,4)
         ig2 = ImageGeometry(5,6)
         ig3 = ImageGeometry(5,6,4)
 
+        # Create BlockGeometry
         bg = BlockGeometry(ig1,ig2, ig3)
-
         x = bg.allocate('random')
-        x0 = x[0]
-        x1 = x[1]
-        x2 = x[2]
 
+        # Extract containers
+        x0, x1, x2 = x[0], x[1], x[2]
 
         for i in range(3):
 
@@ -398,11 +397,10 @@ class TestOperator(CCPiTestClass):
             res2 = bg.geometries[i].allocate(0)
             proj_map.direct(x, out=res2)
 
-            # Assert with and withou out
+            # Check with and without out
             numpy.testing.assert_array_almost_equal(res1.array, res2.array)
 
             # Depending on which index is used, check if x0, x1, x2 are the same with res2
-
             if i==0:            
                 numpy.testing.assert_array_almost_equal(x0.array, res2.array)
             elif i==1: 
@@ -412,12 +410,9 @@ class TestOperator(CCPiTestClass):
             else:
                 pass      
 
-        print("Test passed \n")    
-
-        print("Check if adjoint is correct")
+        # Check if adjoint is correct
 
         bg = BlockGeometry(ig1, ig2, ig3, ig1, ig2, ig3)
-
         x = ig1.allocate('random')
 
         index=3
@@ -431,11 +426,9 @@ class TestOperator(CCPiTestClass):
         for i in range(len(bg.geometries)):
 
             if i!=index:
-                numpy.testing.assert_array_almost_equal(res1[i].array, bg.geometries[i].allocate().array)
+                numpy.testing.assert_array_almost_equal(res1[i].array, bg.geometries[i].allocate().array)   
 
-        print("Test passed \n")       
-
-        print("Check error messages")
+        # Check error messages
         # Check if index is correct wrt length of Cartesian Product
         try:
             ig = ImageGeometry(3,4)
@@ -449,9 +442,7 @@ class TestOperator(CCPiTestClass):
         try:
             proj_map = ProjectionMap(ig, index)               
         except ValueError as err:
-            print(err)   
-        print("Test passed \n")           
-
+            print(err)           
     
 class TestGradients(CCPiTestClass): 
     def setUp(self):

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -16,7 +16,7 @@
 #   limitations under the License.
 
 import unittest
-from cil.framework import ImageGeometry, VectorGeometry, ImageData, BlockDataContainer, DataContainer
+from cil.framework import ImageGeometry, BlockGeometry, VectorGeometry, ImageData, BlockDataContainer, DataContainer
 from cil.optimisation.operators import BlockOperator,\
     FiniteDifferenceOperator, SymmetrisedGradientOperator
 import numpy
@@ -25,7 +25,7 @@ from cil.optimisation.operators import GradientOperator, IdentityOperator,\
     DiagonalOperator, MaskOperator, ChannelwiseOperator, BlurringOperator
 from cil.optimisation.operators import LinearOperator, MatrixOperator
 import numpy   
-from cil.optimisation.operators import SumOperator,  ZeroOperator, CompositionOperator
+from cil.optimisation.operators import SumOperator,  ZeroOperator, CompositionOperator, ProjectionMap
 
 from cil.utilities import dataexample
 import os
@@ -200,7 +200,7 @@ class TestOperator(CCPiTestClass):
         
         # Parameters for point spread function PSF (size and std)
         ks          = 11; 
-        ksigma      = 5.0;
+        ksigma      = 5.0
         
         # Create 1D PSF and 2D as outer product, then normalise.
         w           = numpy.exp(-numpy.arange(-(ks-1)/2,(ks-1)/2+1)**2/(2*ksigma**2))
@@ -372,11 +372,87 @@ class TestOperator(CCPiTestClass):
         for n in [norm, norm2, norm3, norm4, norm5]:
             print ("norm {}", format(n))
 
+    def test_ProjectionMap(self):
+
+        print("Check if direct is correct")
+        ig1 = ImageGeometry(3,4)
+        ig2 = ImageGeometry(5,6)
+        ig3 = ImageGeometry(5,6,4)
+
+        bg = BlockGeometry(ig1,ig2, ig3)
+
+        x = bg.allocate('random')
+        x0 = x[0]
+        x1 = x[1]
+        x2 = x[2]
+
+
+        for i in range(3):
+
+            proj_map = ProjectionMap(bg, i)
+
+            # res1 is in ImageData from the X_{i} "ImageGeometry"
+            res1 = proj_map.direct(x)
+
+            # res2 is in ImageData from the X_{i} "ImageGeometry" using out
+            res2 = bg.geometries[i].allocate(0)
+            proj_map.direct(x, out=res2)
+
+            # Assert with and withou out
+            numpy.testing.assert_array_almost_equal(res1.array, res2.array)
+
+            # Depending on which index is used, check if x0, x1, x2 are the same with res2
+
+            if i==0:            
+                numpy.testing.assert_array_almost_equal(x0.array, res2.array)
+            elif i==1: 
+                numpy.testing.assert_array_almost_equal(x1.array, res2.array)   
+            elif i==2:
+                numpy.testing.assert_array_almost_equal(x2.array, res2.array)  
+            else:
+                pass      
+
+        print("Test passed \n")    
+
+        print("Check if adjoint is correct")
+
+        bg = BlockGeometry(ig1, ig2, ig3, ig1, ig2, ig3)
+
+        x = ig1.allocate('random')
+
+        index=3
+        proj_map = ProjectionMap(bg, index)
+
+        res1 = bg.allocate(0)
+        proj_map.adjoint(x, out=res1)
+
+        # check if all indices return arrays filled with 0, except the input index
+
+        for i in range(len(bg.geometries)):
+
+            if i!=index:
+                numpy.testing.assert_array_almost_equal(res1[i].array, bg.geometries[i].allocate().array)
+
+        print("Test passed \n")       
+
+        print("Check error messages")
+        # Check if index is correct wrt length of Cartesian Product
+        try:
+            ig = ImageGeometry(3,4)
+            bg = BlockGeometry(ig,ig)
+            index = 3
+            proj_map = ProjectionMap(bg, index)
+        except ValueError as err:
+                print(err) 
+
+        # Check error if an ImageGeometry is passed
+        try:
+            proj_map = ProjectionMap(ig, index)               
+        except ValueError as err:
+            print(err)   
+        print("Test passed \n")           
+
     
-
-        
-
-
 class TestGradients(CCPiTestClass): 
     def setUp(self):
         N, M = 20, 30

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -426,7 +426,7 @@ class TestOperator(CCPiTestClass):
         for i in range(len(bg.geometries)):
 
             if i!=index:
-                numpy.testing.assert_array_almost_equal(res1[i].array, bg.geometries[i].allocate().array)   
+                numpy.testing.assert_array_almost_equal(res1[i].as_array(), bg.geometries[i].allocate().as_array())   
 
         # Check error messages
         # Check if index is correct wrt length of Cartesian Product


### PR DESCRIPTION
This ProjectionMap is used for the `JointTotalVariation` reconstruction for the Fully3D and It is quite useful.

- [x] Unittests  added and passed.
- [x] Add `ProjectionMap` in __init__ for correct import.