### PR TITLE
Add reader and writer for NXTomo files

### DIFF
--- a/Wrappers/Python/cil/io/NXTomoReader.py
+++ b/Wrappers/Python/cil/io/NXTomoReader.py
@@ -36,7 +36,7 @@ class NXTomoReader(object):
     https://manual.nexusformat.org/classes/applications/NXtomo.html
     '''
 
-    def __init__(self, nexus_filename=None):
+    def __init__(self, file_name=None):
         '''
         This takes in input as filename and loads the data dataset.
         '''
@@ -44,7 +44,7 @@ class NXTomoReader(object):
         self.dark = None
         self.angles = None
         self.geometry = None
-        self.filename = nexus_filename
+        self.filename = file_name
         self.key_path = 'entry1/tomo_entry/instrument/detector/image_key'
         self.data_path = 'entry1/tomo_entry/data/data'
         self.angle_path = 'entry1/tomo_entry/data/rotation_angle'
@@ -288,9 +288,6 @@ class NXTomoReader(object):
             angles = np.linspace(0, n, n+1, dtype=np.float32)
 
         if ymax-ymin > 1:
-            # Used to set: - do we need?
-            # dist_source_center=None,
-            # dist_center_detector=None
             geometry = AcquisitionGeometry.create_Parallel3D().set_panel(
                 num_pixels=(dims[1], ymax-ymin), pixel_size=(1, 1)).set_angles(
                 angles=angles).set_labels(
@@ -392,7 +389,9 @@ class NXTomoReader(object):
                                            dist_source_center=None,
                                            dist_center_detector=None,
                                            channels=1,
-                                           dimension_labels=['angle', 'vertical', 'horizontal'])
+                                           dimension_labels=[
+                                               'angle', 'vertical',
+                                               'horizontal'])
             out = geometry.allocate()
             if bmax-bmin == 1:
                 out.fill(data.squeeze())

--- a/Wrappers/Python/cil/io/NXTomoReader.py
+++ b/Wrappers/Python/cil/io/NXTomoReader.py
@@ -219,9 +219,9 @@ class NXTomoReader(object):
         data = self.load_projection(dimensions)
         dims = self.get_projection_dimensions()
         geometry = AcquisitionGeometry.create_Parallel3D().set_panel(
-            num_pixels=(dims[1], dims[2]), pixel_size=(1, 1)).set_angles(
+            num_pixels=(dims[2], dims[1]), pixel_size=(1, 1)).set_angles(
             angles=self.get_projection_angles()).set_labels(
-            ['angle', 'horizontal',  'vertical']).set_channels(1)
+            ['angle', 'vertical', 'horizontal']).set_channels(1)
         out = geometry.allocate()
         out.fill(data)
         return out
@@ -258,24 +258,23 @@ class NXTomoReader(object):
                     image_keys = self.get_image_keys()
                     projections = np.array(file[self.data_path])[
                         image_keys == 0]
-
                     if ymin is None:
                         ymin = 0
-                        if ymax > dims[2]:
+                        if ymax > dims[1]:
                             raise ValueError('ymax out of range')
                         data = projections[:, :ymax, :]
                     elif ymax is None:
-                        ymax = dims[2]
+                        ymax = dims[1]
                         if ymin < 0:
                             raise ValueError('ymin out of range')
                         data = projections[:, ymin:, :]
                     else:
-                        if ymax > dims[2]:
+                        if ymax > dims[1]:
                             raise ValueError('ymax out of range')
                         if ymin < 0:
                             raise ValueError('ymin out of range')
 
-                        data = projections[:, :, ymin:ymax]
+                        data = projections[:, ymin:ymax, :]
 
         except Exception:
             print("Error reading nexus file")
@@ -289,15 +288,15 @@ class NXTomoReader(object):
 
         if ymax-ymin > 1:
             geometry = AcquisitionGeometry.create_Parallel3D().set_panel(
-                num_pixels=(dims[1], ymax-ymin), pixel_size=(1, 1)).set_angles(
+                num_pixels=(dims[2], ymax-ymin), pixel_size=(1, 1)).set_angles(
                 angles=angles).set_labels(
-                    ['angle', 'horizontal', 'vertical']).set_channels(1)
+                    ['angle', 'vertical', 'horizontal']).set_channels(1)
             out = geometry.allocate()
             out.fill(data)
             return out
         elif ymax-ymin == 1:
             geometry = AcquisitionGeometry.create_Parallel2D().set_panel(
-                num_pixels=(dims[1]), pixel_size=(1, 1)).set_angles(
+                num_pixels=(dims[2]), pixel_size=(1, 1)).set_angles(
                 angles=angles).set_labels(
                     ['angle', 'horizontal']).set_channels(1)
             out = geometry.allocate()
@@ -323,7 +322,7 @@ class NXTomoReader(object):
                 dims = file[self.data_path].shape
 
             ymin = 0
-            ymax = dims[2]
+            ymax = dims[1]
 
             return self.get_acquisition_data_subset(ymin=ymin, ymax=ymax)
 

--- a/Wrappers/Python/cil/io/NXTomoReader.py
+++ b/Wrappers/Python/cil/io/NXTomoReader.py
@@ -219,9 +219,9 @@ class NXTomoReader(object):
         data = self.load_projection(dimensions)
         dims = self.get_projection_dimensions()
         geometry = AcquisitionGeometry.create_Parallel3D().set_panel(
-            num_pixels=(dims[2], dims[1]), pixel_size=(1, 1)).set_angles(
+            num_pixels=(dims[1], dims[2]), pixel_size=(1, 1)).set_angles(
             angles=self.get_projection_angles()).set_labels(
-            ['angle', 'vertical', 'horizontal']).set_channels(1)
+            ['angle', 'horizontal',  'vertical']).set_channels(1)
         out = geometry.allocate()
         out.fill(data)
         return out
@@ -258,23 +258,24 @@ class NXTomoReader(object):
                     image_keys = self.get_image_keys()
                     projections = np.array(file[self.data_path])[
                         image_keys == 0]
+
                     if ymin is None:
                         ymin = 0
-                        if ymax > dims[1]:
+                        if ymax > dims[2]:
                             raise ValueError('ymax out of range')
                         data = projections[:, :ymax, :]
                     elif ymax is None:
-                        ymax = dims[1]
+                        ymax = dims[2]
                         if ymin < 0:
                             raise ValueError('ymin out of range')
                         data = projections[:, ymin:, :]
                     else:
-                        if ymax > dims[1]:
+                        if ymax > dims[2]:
                             raise ValueError('ymax out of range')
                         if ymin < 0:
                             raise ValueError('ymin out of range')
 
-                        data = projections[:, ymin:ymax, :]
+                        data = projections[:, :, ymin:ymax]
 
         except Exception:
             print("Error reading nexus file")
@@ -291,15 +292,15 @@ class NXTomoReader(object):
             # dist_source_center=None,
             # dist_center_detector=None
             geometry = AcquisitionGeometry.create_Parallel3D().set_panel(
-                num_pixels=(dims[2], ymax-ymin), pixel_size=(1, 1)).set_angles(
+                num_pixels=(dims[1], ymax-ymin), pixel_size=(1, 1)).set_angles(
                 angles=angles).set_labels(
-                    ['angle', 'vertical', 'horizontal']).set_channels(1)
+                    ['angle', 'horizontal', 'vertical']).set_channels(1)
             out = geometry.allocate()
             out.fill(data)
             return out
         elif ymax-ymin == 1:
             geometry = AcquisitionGeometry.create_Parallel2D().set_panel(
-                num_pixels=(dims[2]), pixel_size=(1, 1)).set_angles(
+                num_pixels=(dims[1]), pixel_size=(1, 1)).set_angles(
                 angles=angles).set_labels(
                     ['angle', 'horizontal']).set_channels(1)
             out = geometry.allocate()
@@ -325,7 +326,7 @@ class NXTomoReader(object):
                 dims = file[self.data_path].shape
 
             ymin = 0
-            ymax = dims[1]
+            ymax = dims[2]
 
             return self.get_acquisition_data_subset(ymin=ymin, ymax=ymax)
 

--- a/Wrappers/Python/cil/io/NXTomoReader.py
+++ b/Wrappers/Python/cil/io/NXTomoReader.py
@@ -1,0 +1,368 @@
+# -*- coding: utf-8 -*-
+#  CCP in Tomographic Imaging (CCPi) Core Imaging Library (CIL).
+
+#   Copyright 2017 UKRI-STFC
+#   Copyright 2017 University of Manchester
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from cil.framework import AcquisitionGeometry
+import numpy as np
+
+h5pyAvailable = True
+try:
+    from h5py import File as NexusFile
+except ImportError:
+    h5pyAvailable = False
+
+
+class NXTomoReader(object):
+    '''
+    Reader class for loading Nexus files. 
+    '''
+
+    def __init__(self, nexus_filename=None):
+        '''
+        This takes in input as filename and loads the data dataset.
+        '''
+        self.flat = None
+        self.dark = None
+        self.angles = None
+        self.geometry = None
+        self.filename = nexus_filename
+        self.key_path = 'entry1/tomo_entry/instrument/detector/image_key'
+        self.data_path = 'entry1/tomo_entry/data/data'
+        self.angle_path = 'entry1/tomo_entry/data/rotation_angle'
+
+    def get_image_keys(self):
+        try:
+            with NexusFile(self.filename, 'r') as file:
+                return np.array(file[self.key_path])
+        except KeyError as ke:
+            raise KeyError("get_image_keys: ", ke.args[0], self.key_path)
+
+    def load(self, dimensions=None, image_key_id=0):
+        '''
+        This is generic loading function of flat field, dark field and projection data.
+        '''
+        if not h5pyAvailable:
+            raise Exception("Error: h5py is not installed")
+        if self.filename is None:
+            return
+        try:
+            with NexusFile(self.filename, 'r') as file:
+                image_keys = np.array(file[self.key_path])
+                projections = None
+                if dimensions == None:
+                    projections = np.array(file[self.data_path])
+                    result = projections[image_keys == image_key_id]
+                    return result
+                else:
+                    # When dimensions are specified they need to be mapped to image_keys
+                    index_array = np.where(image_keys == image_key_id)
+                    projection_indexes = index_array[0][dimensions[0]]
+                    new_dimensions = list(dimensions)
+                    new_dimensions[0] = projection_indexes
+                    new_dimensions = tuple(new_dimensions)
+                    result = np.array(file[self.data_path][new_dimensions])
+                    return result
+        except Exception:
+            print("Error reading nexus file")
+            raise
+
+    def load_projection(self, dimensions=None):
+        '''
+        Loads the projection data from the nexus file.
+        returns: numpy array with projection data
+        '''
+        try:
+            if 0 not in self.get_image_keys():
+                raise ValueError("Projections are not in the data. Data Path ",
+                                 self.data_path)
+        except KeyError as ke:
+            raise KeyError(ke.args[0], self.data_path)
+        return self.load(dimensions, 0)
+
+    def load_flat(self, dimensions=None):
+        '''
+        Loads the flat field data from the nexus file.
+        returns: numpy array with flat field data
+        '''
+        try:
+            if 1 not in self.get_image_keys():
+                raise ValueError("Flats are not in the data. Data Path ",
+                                 self.data_path)
+        except KeyError as ke:
+            raise KeyError(ke.args[0], self.data_path)
+        return self.load(dimensions, 1)
+
+    def load_dark(self, dimensions=None):
+        '''
+        Loads the Dark field data from the nexus file.
+        returns: numpy array with dark field data
+        '''
+        try:
+            if 2 not in self.get_image_keys():
+                raise ValueError("Darks are not in the data. Data Path ",
+                                 self.data_path)
+        except KeyError as ke:
+            raise KeyError(ke.args[0], self.data_path)
+        return self.load(dimensions, 2)
+
+    def get_projection_angles(self):
+        '''
+        This function returns the projection angles
+        '''
+        if not h5pyAvailable:
+            raise Exception("Error: h5py is not installed")
+        if self.filename is None:
+            return
+        try:
+            with NexusFile(self.filename, 'r') as file:
+                angles = np.array(file[self.angle_path], np.float32)
+                image_keys = np.array(file[self.key_path])
+                return angles[image_keys == 0]
+        except Exception:
+            print("get_projection_angles Error reading nexus file")
+            raise
+
+    def get_sinogram_dimensions(self):
+        '''
+        Return the dimensions of the dataset
+        '''
+        if not h5pyAvailable:
+            raise Exception("Error: h5py is not installed")
+        if self.filename is None:
+            return
+        try:
+            with NexusFile(self.filename, 'r') as file:
+                projections = file[self.data_path]
+                image_keys = np.array(file[self.key_path])
+                dims = list(projections.shape)
+                dims[0] = dims[1]
+                dims[1] = np.sum(image_keys == 0)
+                return tuple(dims)
+        except:
+            print("Error reading nexus file")
+            raise
+
+    def get_projection_dimensions(self):
+        '''
+        Return the dimensions of the dataset
+        '''
+        if not h5pyAvailable:
+            raise Exception("Error: h5py is not installed")
+        if self.filename is None:
+            return
+        try:
+            with NexusFile(self.filename, 'r') as file:
+                try:
+                    projections = file[self.data_path]
+                except KeyError as ke:
+                    raise KeyError('Error: data path {0} not found\n{1}'
+                                   .format(self.data_path,
+                                           ke.args[0]))
+                #image_keys = np.array(file[self.key_path])
+                image_keys = self.get_image_keys()
+                dims = list(projections.shape)
+                dims[0] = np.sum(image_keys == 0)
+                return tuple(dims)
+        except Exception:
+            print(
+                "Warning: Error reading image_keys trying accessing data on ", self.data_path)
+            with NexusFile(self.filename, 'r') as file:
+                dims = file[self.data_path].shape
+                return tuple(dims)
+
+    def get_acquisition_data(self, dimensions=None):
+        '''
+        This method load the acquisition data and given dimension and returns an AcquisitionData Object
+        '''
+        data = self.load_projection(dimensions)
+        dims = self.get_projection_dimensions()
+        geometry = AcquisitionGeometry.create_Parallel3D().set_panel(
+            num_pixels=(dims[2], dims[1]), pixel_size=(1, 1)).set_angles(
+            angles=self.get_projection_angles()).set_labels(
+            ['angle', 'vertical', 'horizontal']).set_channels(1)
+        out = geometry.allocate()
+        out.fill(data)
+        return out
+
+    def get_acquisition_data_subset(self, ymin=None, ymax=None):
+        '''
+        This method load the acquisition data and given dimension and returns an AcquisitionData Object
+        '''
+        if not h5pyAvailable:
+            raise Exception("Error: h5py is not installed")
+        if self.filename is None:
+            return
+        try:
+
+            with NexusFile(self.filename, 'r') as file:
+                try:
+                    dims = self.get_projection_dimensions()
+                except KeyError:
+                    pass
+                dims = file[self.data_path].shape
+                if ymin is None and ymax is None:
+
+                    try:
+                        image_keys = self.get_image_keys()
+                        print("image_keys", image_keys)
+                        projections = np.array(file[self.data_path])
+                        data = projections[image_keys == 0]
+                    except KeyError as ke:
+                        print(ke)
+                        data = np.array(file[self.data_path])
+
+                else:
+                    image_keys = self.get_image_keys()
+                    print("image_keys", image_keys)
+                    projections = np.array(file[self.data_path])[
+                        image_keys == 0]
+                    if ymin is None:
+                        ymin = 0
+                        if ymax > dims[1]:
+                            raise ValueError('ymax out of range')
+                        data = projections[:, :ymax, :]
+                    elif ymax is None:
+                        ymax = dims[1]
+                        if ymin < 0:
+                            raise ValueError('ymin out of range')
+                        data = projections[:, ymin:, :]
+                    else:
+                        if ymax > dims[1]:
+                            raise ValueError('ymax out of range')
+                        if ymin < 0:
+                            raise ValueError('ymin out of range')
+
+                        data = projections[:, ymin:ymax, :]
+
+        except Exception:
+            print("Error reading nexus file")
+            raise
+
+        try:
+            angles = self.get_projection_angles()
+        except KeyError:
+            n = data.shape[0]
+            angles = np.linspace(0, n, n+1, dtype=np.float32)
+
+        if ymax-ymin > 1:
+            # Used to set: - do we need?
+            # dist_source_center=None,
+            # dist_center_detector=None
+            geometry = AcquisitionGeometry.create_Parallel3D().set_panel(
+                num_pixels=(dims[2], ymax-ymin), pixel_size=(1, 1)).set_angles(
+                angles=angles).set_labels(
+                    ['angle', 'vertical', 'horizontal']).set_channels(1)
+            out = geometry.allocate()
+            out.fill(data)
+            return out
+        elif ymax-ymin == 1:
+            geometry = AcquisitionGeometry.create_Parallel2D().set_panel(
+                num_pixels=(dims[2]), pixel_size=(1, 1)).set_angles(
+                angles=angles).set_labels(
+                    ['angle', 'horizontal']).set_channels(1)
+            out = geometry.allocate()
+            out.fill(data.squeeze())
+            return out
+
+    def get_acquisition_data_slice(self, y_slice=0):
+        return self.get_acquisition_data_subset(ymin=y_slice, ymax=y_slice+1)
+
+    def get_acquisition_data_whole(self):
+        with NexusFile(self.filename, 'r') as file:
+            try:
+                dims = self.get_projection_dimensions()
+            except KeyError:
+                print("Warning: ")
+                dims = file[self.data_path].shape
+
+            ymin = 0
+            ymax = dims[1] - 1
+
+            return self.get_acquisition_data_subset(ymin=ymin, ymax=ymax)
+
+    def list_file_content(self):
+        try:
+            with NexusFile(self.filename, 'r') as file:
+                file.visit(print)
+        except Exception:
+            print("Error reading nexus file")
+            raise
+
+    def get_acquisition_data_batch(self, bmin=None, bmax=None):
+        if not h5pyAvailable:
+            raise Exception("Error: h5py is not installed")
+        if self.filename is None:
+            return
+        try:
+
+            with NexusFile(self.filename, 'r') as file:
+                try:
+                    dims = self.get_projection_dimensions()
+                except KeyError:
+                    dims = file[self.data_path].shape
+                if bmin is None or bmax is None:
+                    raise ValueError(
+                        'get_acquisition_data_batch: please specify fastest index batch limits')
+
+                if bmin >= 0 and bmin < bmax and bmax <= dims[0]:
+                    data = np.array(file[self.data_path][bmin:bmax])
+                else:
+                    raise ValueError('get_acquisition_data_batch: bmin {0}>0 bmax {1}<{2}'.format(
+                        bmin, bmax, dims[0]))
+
+        except Exception:
+            print("Error reading nexus file")
+            raise
+
+        try:
+            angles = self.get_projection_angles()[bmin:bmax]
+        except KeyError:
+            n = data.shape[0]
+            angles = np.linspace(0, n, n+1, dtype=np.float32)[bmin:bmax]
+
+        if bmax-bmin > 1:
+
+            geometry = AcquisitionGeometry('parallel', '3D',
+                                           angles=angles,
+                                           pixel_num_h=dims[2],
+                                           pixel_size_h=1,
+                                           pixel_num_v=bmax-bmin,
+                                           pixel_size_v=1,
+                                           dist_source_center=None,
+                                           dist_center_detector=None,
+                                           channels=1,
+                                           dimension_labels=['angle', 'vertical', 'horizontal'])
+            out = geometry.allocate()
+            out.fill(data)
+            return out
+
+        elif bmax-bmin == 1:
+            geometry = AcquisitionGeometry('parallel', '2D',
+                                           angles=angles,
+                                           pixel_num_h=dims[2],
+                                           pixel_size_h=1,
+                                           dist_source_center=None,
+                                           dist_center_detector=None,
+                                           channels=1,
+                                           dimension_labels=['angle', 'horizontal'])
+            out = geometry.allocate()
+            out.fill(data.squeeze())
+            return out

--- a/Wrappers/Python/cil/io/NXTomoReader.py
+++ b/Wrappers/Python/cil/io/NXTomoReader.py
@@ -40,11 +40,11 @@ class NXTomoReader(object):
         '''
         This takes in input as filename and loads the data dataset.
         '''
-        self.flat = None
-        self.dark = None
+        self.filename = nexus_filename
+        self.flat_field = None
+        self.dark_field = None
         self.angles = None
         self.geometry = None
-        self.filename = nexus_filename
         self.key_path = 'entry1/tomo_entry/instrument/detector/image_key'
         self.data_path = 'entry1/tomo_entry/data/data'
         self.angle_path = 'entry1/tomo_entry/data/rotation_angle'

--- a/Wrappers/Python/cil/io/NXTomoReader.py
+++ b/Wrappers/Python/cil/io/NXTomoReader.py
@@ -40,11 +40,11 @@ class NXTomoReader(object):
         '''
         This takes in input as filename and loads the data dataset.
         '''
-        self.filename = nexus_filename
-        self.flat_field = None
-        self.dark_field = None
+        self.flat = None
+        self.dark = None
         self.angles = None
         self.geometry = None
+        self.filename = nexus_filename
         self.key_path = 'entry1/tomo_entry/instrument/detector/image_key'
         self.data_path = 'entry1/tomo_entry/data/data'
         self.angle_path = 'entry1/tomo_entry/data/rotation_angle'
@@ -312,7 +312,7 @@ class NXTomoReader(object):
         return self.get_acquisition_data_subset(ymin=y_slice, ymax=y_slice+1)
 
     def get_acquisition_data_whole(self):
-        # Is this necessary?
+        # TODO: Is this necessary?
         '''
         Loads the acquisition data and returns an AcquisitionData Object
         Same behaviour as get_acquisition_data when dimensions is set to None

--- a/Wrappers/Python/cil/io/NXTomoWriter.py
+++ b/Wrappers/Python/cil/io/NXTomoWriter.py
@@ -28,7 +28,15 @@ except ImportError:
 
 class NXTomoWriter(object):
 
-    def __init__(self, data=None, file_name=None, flat_fields=None, dark_fields=None):
+    def __init__(
+            self, data=None, file_name=None, flat_fields=None,
+            dark_fields=None):
+        '''
+        data: Acqusistion Data ordered: (angle, horizontal, vertical)
+        file_name: name of nexus file to write to
+        flat_fields: numpy array of flat field data
+        dark_fields: numpy array of dark field data
+        '''
 
         self.data = data
         self.file_name = file_name
@@ -37,14 +45,16 @@ class NXTomoWriter(object):
 
         if ((self.data is not None) and (self.file_name is not None)):
             self.set_up(data=self.data,
-                        file_name=self.file_name, flat_fields=flat_fields, dark_fields=dark_fields)
+                        file_name=self.file_name, flat_fields=flat_fields,
+                        dark_fields=dark_fields)
 
-    def set_up(self,
-               data=None,
-               file_name=None, flat_fields=None, dark_fields=None):
+    def set_up(self, data=None, file_name=None,
+               flat_fields=None, dark_fields=None):
 
         self.data = data
         self.file_name = file_name
+        self.flat_fields = flat_fields
+        self.dark_fields = dark_fields
 
         if not ((isinstance(self.data, ImageData)) or
                 (isinstance(self.data, AcquisitionData))):
@@ -56,10 +66,10 @@ class NXTomoWriter(object):
             raise Exception('h5py is not available, cannot write NEXUS files.')
 
     def _initialise_nexus_file(self, f, data_len):
+        ''' Creates empty data-structure for NXTomo file:'''
         height = self.data.as_array().shape[1]
         width = self.data.as_array().shape[2]
 
-        # Create empty data-structure for NXTomo file:
         entry = f.create_group('entry1')
         entry.attrs['NX_class'] = 'NXentry'
 
@@ -81,7 +91,8 @@ class NXTomoWriter(object):
         data.attrs['NX_class'] = 'NXdata'
 
         dataset = detector.create_dataset(
-            'data', (data_len, height, width), np.float32)  # was dtype=np.uint16)
+            'data', (data_len, height, width), np.uint32)
+        # was dtype=np.uint16 in EPAC code, is float32 in NEXUSDataWriter
         # TODO: figure out what type we should write
         dataset.attrs['long_name'] = 'X-ray counts'
 

--- a/Wrappers/Python/cil/io/NXTomoWriter.py
+++ b/Wrappers/Python/cil/io/NXTomoWriter.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+#   This work is part of the Core Imaging Library (CIL) developed by CCPi
+#   (Collaborative Computational Project in Tomographic Imaging), with
+#   substantial contributions by UKRI-STFC and University of Manchester.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+import os
+from cil.framework import AcquisitionData, ImageData
+
+
+h5pyAvailable = True
+try:
+    import h5py
+except ImportError:
+    h5pyAvailable = False
+
+
+class NXTomoWriter(object):
+
+    def __init__(self, data=None, filename=None, flats=[], darks=[]):
+
+        self.data = data
+        self.file_name = filename
+        self.flats = flats
+        self.darks = darks
+
+        if ((self.data is not None) and (self.file_name is not None)):
+            self.set_up(data=self.data,
+                        file_name=self.file_name, flats=flats, darks=darks)
+
+    def set_up(self,
+               data=None,
+               file_name=None, flats=None, darks=None):
+
+        self.data = data
+        self.file_name = file_name
+
+        if not ((isinstance(self.data, ImageData)) or
+                (isinstance(self.data, AcquisitionData))):
+            raise Exception('Writer supports only following data types:\n' +
+                            ' - ImageData\n - AcquisitionData')
+
+        # check that h5py library is installed
+        if h5pyAvailable is False:
+            raise Exception('h5py is not available, cannot write NEXUS files.')
+
+    def initialise_nexus_file(self, f):
+        data_len = self.data.as_array(
+        ).shape[0] + self.flats.shape[0] + self.darks.shape[0]
+        height = self.data.as_array().shape[1]
+        width = self.data.as_array().shape[2]  # TODO: check ordering
+
+        # Create empty data-structure for NXTomo file:
+        entry = f.create_group('entry1')
+        entry.attrs['NX_class'] = 'NXentry'
+
+        entry = entry.create_group('tomo_entry')
+        entry.attrs['NX_class'] = 'NXsubentry'
+        entry['definition'] = 'NXtomo'
+
+        instrument = entry.create_group('instrument')
+        instrument.attrs['NX_class'] = 'NXinstrument'
+
+        detector = instrument.create_group('detector')
+        detector.attrs['NX_class'] = 'NXdetector'
+
+        sample = entry.create_group('sample')
+        sample.attrs['NX_class'] = 'NXsample'
+        sample['name'] = 'anonymous sample'
+
+        data = entry.create_group('data')
+        data.attrs['NX_class'] = 'NXdata'
+
+        dataset = detector.create_dataset(
+            'data', (data_len, height, width), np.float32)  # was dtype=np.uint16)
+        dataset.attrs['long_name'] = 'X-ray counts'
+
+        imagekeyset = detector.create_dataset(
+            'image_key', (data_len,), dtype=np.uint8)
+
+        rotationset = sample.create_dataset(
+            'rotation_angle', (data_len,), dtype=np.float32)
+        rotationset.attrs['units'] = 'degrees'
+        rotationset.attrs['long_name'] = 'Rotation angle'
+
+        data['data'] = dataset
+        dataset.attrs['target'] = dataset.name
+        data['rotation_angle'] = rotationset
+        rotationset.attrs['target'] = rotationset.name
+        data['image_key'] = imagekeyset
+        imagekeyset.attrs['target'] = imagekeyset.name
+
+        data.attrs['signal'] = 'data'
+        data.attrs.create('axes', ['rotation_angle', '.', '.'],
+                          dtype=h5py.special_dtype(vlen=str))
+        data.attrs['rotation_angle_indices'] = 0
+
+        # Now add in CIL identifier that we have AcquisitionData:
+        data.attrs['data_type'] = 'AcquisitionData'
+
+        return dataset, rotationset, imagekeyset
+
+    def write(self):
+        # if the folder does not exist, create the folder
+        if not os.path.isdir(os.path.dirname(self.file_name)):
+            os.mkdir(os.path.dirname(self.file_name))
+
+        # create the file
+        with h5py.File(self.file_name, 'w') as f:
+            dataset, rotationset, imagekeyset = self.initialise_nexus_file(f)
+            print(type(dataset), type(rotationset), type(imagekeyset))
+            # set up dataset attributes
+            if (isinstance(self.data, ImageData)):
+                print("Can't write ImageData to NXTomo file")
+            
+            # set up dataset attributes
+            data_len = self.data.as_array(
+            ).shape[0] + self.flats.shape[0] + self.darks.shape[0]
+            height = self.data.as_array().shape[1]
+            width = self.data.as_array().shape[2]
+            data_to_write = self.data.as_array()
+
+            data_to_write = np.empty((data_len, height, width))
+            for i in range(data_len):
+                if i < self.flats.shape[0]:
+                    data_to_write[i] = self.flats[i]
+                elif i < (self.flats.shape[0] + self.darks.shape[0]):
+                    data_to_write[i] = self.darks[i-self.flats.shape[0]]
+                else:
+                    data_to_write[i] = self.data.as_array(
+                    )[i-self.darks.shape[0]-self.flats.shape[0]]
+
+            dataset[...] = data_to_write
+
+            # image key:
+            data_len = self.data.as_array().shape[0]
+            flats_len = self.flats.shape[0]
+            darks_len = self.darks.shape[0]
+            imagekey = [1] * flats_len + [2] * darks_len + [0] * data_len
+            imagekeyset[...] = imagekey
+
+            # next is angles:
+            rotation = self.data.geometry.config.angles.angle_data
+            rotation = np.insert(
+                rotation, 0, [rotation[0]] * (flats_len + darks_len))
+            rotationset[...] = rotation

--- a/Wrappers/Python/cil/io/NXTomoWriter.py
+++ b/Wrappers/Python/cil/io/NXTomoWriter.py
@@ -32,7 +32,7 @@ class NXTomoWriter(object):
             self, data=None, file_name=None, flat_fields=None,
             dark_fields=None):
         '''
-        data: Acqusistion Data ordered: (angle, horizontal, vertical)
+        data: Acqusistion Data ordered: (angle, vertical, horizontal)
         file_name: name of nexus file to write to
         flat_fields: numpy array of flat field data
         dark_fields: numpy array of dark field data

--- a/Wrappers/Python/cil/io/__init__.py
+++ b/Wrappers/Python/cil/io/__init__.py
@@ -16,8 +16,9 @@
 #   limitations under the License.
 from .NEXUSDataReader import NEXUSDataReader
 from .NEXUSDataWriter import NEXUSDataWriter
+from .NXTomoReader import NXTomoReader
+from .NXTomoWriter import NXTomoWriter
 from .NikonDataReader import NikonDataReader
 from .TIFF import TIFFWriter
 from .TIFF import TIFFStackReader
-# from .TIFFStackReader import TIFFStackReader
 from .TXRMDataReader import TXRMDataReader

--- a/Wrappers/Python/test/test_NXTomoReader.py
+++ b/Wrappers/Python/test/test_NXTomoReader.py
@@ -34,13 +34,13 @@ class TestNXTomoReaderWriter(unittest.TestCase):
             os.mkdir(self.data_dir)
 
         angles = [i for i in range(0,91)]
-        num_pixels = [135, 160] # horizontal, vertical
+        num_pixels = [160, 135] # horizontal, vertical
         
 
         self.ag3d = AcquisitionGeometry.create_Parallel3D()\
                                     .set_angles(angles)\
                                     .set_panel(num_pixels, origin='top-right')\
-                                    .set_labels(['angle', 'horizontal',   'vertical'])
+                                    .set_labels(['angle', 'horizontal',  'vertical'])
 
         self.ad3d = self.ag3d.allocate('random_int')
 
@@ -179,14 +179,14 @@ class TestNXTomoReaderWriter(unittest.TestCase):
         projections_part = nr.get_acquisition_data_subset(
             ymin=5, ymax=10).as_array()
         numpy.testing.assert_array_equal(
-            projections_part, projections_full[:, 5:10, :])
+            projections_part, projections_full[:, :,  5:10])
 
     def test_get_acquisition_data_slice(self):
         nr = NXTomoReader(self.file_name)
         projections_full = nr.load_projection()
         projections_part = nr.get_acquisition_data_slice(y_slice=5).as_array()
         numpy.testing.assert_array_equal(
-            projections_part, projections_full[:, 5, :])
+            projections_part, projections_full[:, :, 5])
 
     def test_get_acquisition_data_batch(self):
         nr = NXTomoReader(self.file_name)

--- a/Wrappers/Python/test/test_NXTomoReader.py
+++ b/Wrappers/Python/test/test_NXTomoReader.py
@@ -21,20 +21,20 @@
 Unit tests for Readers
 @author: Mr. Srikanth Nagella
 '''
+import os
 import unittest
 
 import numpy.testing
 import wget
-import os
+from cil.framework import AcquisitionGeometry
 from cil.io import NXTomoReader
-from cil.framework import AcquisitionData, AcquisitionGeometry, ImageData, AcquisitionGeometry
 
 
 class TestNXTomoReader(unittest.TestCase):
 
     def setUp(self):
-        # wget.download(
-        #     'https://github.com/DiamondLightSource/Savu/raw/master/test_data/data/24737_fd.nxs')
+        wget.download(
+            'https://github.com/DiamondLightSource/Savu/raw/master/test_data/data/24737_fd.nxs')
         self.filename = '24737_fd.nxs'
         # self.data_dir = os.path.join(os.getcwd(), 'test_nxtomo')
         # if not os.path.exists(self.data_dir):
@@ -54,8 +54,8 @@ class TestNXTomoReader(unittest.TestCase):
         # self.image_key_ids[0] = 1
         # self.image_key_ids[1] = 2
 
-    # def tearDown(self):
-    #     os.remove(self.filename)
+    def tearDown(self):
+        os.remove(self.filename)
 
     def test_get_dimensions(self):
         nr = NXTomoReader(self.filename)
@@ -187,7 +187,8 @@ class TestNXTomoReader(unittest.TestCase):
     def test_get_acquisition_data_batch(self):
         nr = NXTomoReader(self.filename)
         projections_full = nr.load_projection()
-        projections_part = nr.get_acquisition_data_batch(bmin=5, bmax=7).as_array()
+        projections_part = nr.get_acquisition_data_batch(
+            bmin=5, bmax=7).as_array()
         numpy.testing.assert_array_equal(
             projections_part, projections_full[5:7, :, :])
 

--- a/Wrappers/Python/test/test_NXTomoReader.py
+++ b/Wrappers/Python/test/test_NXTomoReader.py
@@ -47,8 +47,8 @@ class TestNXTomoReaderWriter(unittest.TestCase):
         self.flat_field_3d = numpy.random.randint(0, 100, size=num_pixels)
         self.dark_field_3d = numpy.random.randint(0, 100, size=num_pixels)
 
-        self.filename = os.path.join(self.data_dir, 'test_nxtomo_ad3d.nxs')
-        writer = NXTomoWriter(data=self.ad3d, filename=self.filename,
+        self.file_name = os.path.join(self.data_dir, 'test_nxtomo_ad3d.nxs')
+        writer = NXTomoWriter(data=self.ad3d, file_name=self.file_name,
             dark_fields=self.dark_field_3d, flat_fields=self.flat_field_3d)
         writer.write()
 
@@ -59,23 +59,23 @@ class TestNXTomoReaderWriter(unittest.TestCase):
         shutil.rmtree(self.data_dir)
 
     def test_get_dimensions(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         self.assertEqual(nr.get_sinogram_dimensions(),
                          self.sinogram_dims, "Sinogram dimensions are not correct")
 
     def test_get_projection_dimensions(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         self.assertEqual(nr.get_projection_dimensions(
         ), self.projection_dims, "Projection dimensions are not correct")
 
     def test_load_projection_without_dimensions(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         projections = nr.load_projection()
         self.assertEqual(projections.shape, self.projection_dims,
                          "Loaded projection data dimensions are not correct")
 
     def test_load_projection_with_dimensions(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         slice_extent = [1, self.projection_dims[1], self.projection_dims[2]]
         projections = nr.load_projection(
             (slice(0, slice_extent[0]), slice(0, slice_extent[1]), slice(0, slice_extent[2])))
@@ -83,7 +83,7 @@ class TestNXTomoReaderWriter(unittest.TestCase):
                          "Loaded projection data dimensions are not correct")
 
     def test_load_projection_compare_single(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         projections_full = nr.load_projection()
         slice_extent = [1, self.projection_dims[1], self.projection_dims[2]]
         projections_part = nr.load_projection(
@@ -92,7 +92,7 @@ class TestNXTomoReaderWriter(unittest.TestCase):
             projections_part, projections_full[0:1, :, :])
 
     def test_load_projection_compare_multi(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         projections_full = nr.load_projection()
         slice_extent = [3, self.projection_dims[1], self.projection_dims[2]]
         projections_part = nr.load_projection(
@@ -101,7 +101,7 @@ class TestNXTomoReaderWriter(unittest.TestCase):
             projections_part, projections_full[0:slice_extent[0], :, :])
 
     def test_load_projection_compare_random(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         projections_full = nr.load_projection()
         projections_part = nr.load_projection(
             (slice(1, 8), slice(5, 10), slice(8, 20)))
@@ -109,7 +109,7 @@ class TestNXTomoReaderWriter(unittest.TestCase):
             projections_part, projections_full[1:8, 5:10, 8:20])
 
     def test_load_projection_compare_full(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         projections_full = nr.load_projection()
         projections_part = nr.load_projection(
             (slice(None, None), slice(None, None), slice(None, None)))
@@ -117,27 +117,27 @@ class TestNXTomoReaderWriter(unittest.TestCase):
             projections_part, projections_full[:, :, :])
 
     def test_load_flat_compare_full(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         flats_full = nr.load_flat()
         flats_part = nr.load_flat(
             (slice(None, None), slice(None, None), slice(None, None)))
         numpy.testing.assert_array_equal(flats_part, flats_full[:, :, :])
 
     def test_load_dark_compare_full(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         darks_full = nr.load_dark()
         darks_part = nr.load_dark(
             (slice(None, None), slice(None, None), slice(None, None)))
         numpy.testing.assert_array_equal(darks_part, darks_full[:, :, :])
 
     def test_projection_angles(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         angles = nr.get_projection_angles()
         self.assertEqual(angles.shape, (91,),
                          "Loaded projection number of angles are not correct")
 
     def test_get_acquisition_data(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         acq_data = nr.get_acquisition_data()
         self.assertEqual(acq_data.geometry.geom_type, 'parallel')
         self.assertEqual(acq_data.geometry.angles.shape, (self.projection_dims[0],),
@@ -152,7 +152,7 @@ class TestNXTomoReaderWriter(unittest.TestCase):
                          'AcquisitionGeometry.pixel_size_v is not correct')
 
     def test_get_acquisition_data_whole(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         acq_data = nr.get_acquisition_data()
         acq_data_whole = nr.get_acquisition_data_whole()
         self.assertEqual(acq_data.geometry.geom_type,
@@ -174,7 +174,7 @@ class TestNXTomoReaderWriter(unittest.TestCase):
                          'AcquisitionGeometry.pixel_size_v is not correct')
 
     def test_get_acquisition_data_subset(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         projections_full = nr.load_projection()
         projections_part = nr.get_acquisition_data_subset(
             ymin=5, ymax=10).as_array()
@@ -182,14 +182,14 @@ class TestNXTomoReaderWriter(unittest.TestCase):
             projections_part, projections_full[:, 5:10, :])
 
     def test_get_acquisition_data_slice(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         projections_full = nr.load_projection()
         projections_part = nr.get_acquisition_data_slice(y_slice=5).as_array()
         numpy.testing.assert_array_equal(
             projections_part, projections_full[:, 5, :])
 
     def test_get_acquisition_data_batch(self):
-        nr = NXTomoReader(self.filename)
+        nr = NXTomoReader(self.file_name)
         projections_full = nr.load_projection()
         projections_part = nr.get_acquisition_data_batch(
             bmin=5, bmax=7).as_array()

--- a/Wrappers/Python/test/test_NXTomoReader.py
+++ b/Wrappers/Python/test/test_NXTomoReader.py
@@ -27,17 +27,35 @@ import numpy.testing
 import wget
 import os
 from cil.io import NXTomoReader
+from cil.framework import AcquisitionData, AcquisitionGeometry, ImageData, AcquisitionGeometry
 
 
 class TestNXTomoReader(unittest.TestCase):
 
     def setUp(self):
-        wget.download(
-            'https://github.com/DiamondLightSource/Savu/raw/master/test_data/data/24737_fd.nxs')
+        # wget.download(
+        #     'https://github.com/DiamondLightSource/Savu/raw/master/test_data/data/24737_fd.nxs')
         self.filename = '24737_fd.nxs'
+        # self.data_dir = os.path.join(os.getcwd(), 'test_nxtomo')
+        # if not os.path.exists(self.data_dir):
+        #     os.mkdir(self.data_dir)
 
-    def tearDown(self):
-        os.remove(self.filename)
+        # self.ag3d = AcquisitionGeometry.create_Parallel3D()\
+        #     .set_angles([i for i in range(0, 181, 2)])\
+        #     .set_panel([135, 160])\
+        #     .set_channels(1)\
+        #     .set_labels(['horizontal', 'vertical', 'angle'])
+
+        # self.ad3d = self.ag3d.allocate('random_int')
+
+        # self.flats = numpy.ones(shape=(1, 135, 160))
+        # self.darks = numpy.zeros(shape=(1, 135, 160))
+        # self.image_key_ids = numpy.zeros(shape=(93,135,160))
+        # self.image_key_ids[0] = 1
+        # self.image_key_ids[1] = 2
+
+    # def tearDown(self):
+    #     os.remove(self.filename)
 
     def test_get_dimensions(self):
         nr = NXTomoReader(self.filename)
@@ -114,7 +132,65 @@ class TestNXTomoReader(unittest.TestCase):
         self.assertEqual(angles.shape, (91,),
                          "Loaded projection number of angles are not correct")
 
+    def test_get_acquition_data(self):
+        nr = NXTomoReader(self.filename)
+        acq_data = nr.get_acquisition_data()
+        self.assertEqual(acq_data.geometry.geom_type, 'parallel')
+        self.assertEqual(acq_data.geometry.angles.shape, (91,),
+                         'AcquisitionGeometry.angles is not correct')
+        self.assertEqual(acq_data.geometry.pixel_num_h, 160,
+                         'AcquisitionGeometry.pixel_num_h is not correct')
+        self.assertEqual(acq_data.geometry.pixel_size_h, 1,
+                         'AcquisitionGeometry.pixel_size_h is not correct')
+        self.assertEqual(acq_data.geometry.pixel_num_v, 135,
+                         'AcquisitionGeometry.pixel_num_v is not correct')
+        self.assertEqual(acq_data.geometry.pixel_size_v, 1,
+                         'AcquisitionGeometry.pixel_size_v is not correct')
+
+    def test_get_acquisition_data_whole(self):
+        nr = NXTomoReader(self.filename)
+        acq_data = nr.get_acquisition_data()
+        acq_data_whole = nr.get_acquisition_data_whole()
+        self.assertEqual(acq_data.geometry.geom_type,
+                         acq_data_whole.geometry.geom_type)
+        self.assertEqual(acq_data.geometry.angles.shape,
+                         acq_data_whole.geometry.angles.shape,
+                         'AcquisitionGeometry.angles is not correct')
+        self.assertEqual(acq_data.geometry.pixel_num_h,
+                         acq_data_whole.geometry.pixel_num_h,
+                         'AcquisitionGeometry.pixel_num_h is not correct')
+        self.assertEqual(acq_data.geometry.pixel_size_h,
+                         acq_data_whole.geometry.pixel_size_h,
+                         'AcquisitionGeometry.pixel_size_h is not correct')
+        self.assertEqual(acq_data.geometry.pixel_num_v,
+                         acq_data_whole.geometry.pixel_num_v,
+                         'AcquisitionGeometry.pixel_num_v is not correct')
+        self.assertEqual(acq_data.geometry.pixel_size_v,
+                         acq_data_whole.geometry.pixel_size_v,
+                         'AcquisitionGeometry.pixel_size_v is not correct')
+
+    def test_get_acquisition_data_subset(self):
+        nr = NXTomoReader(self.filename)
+        projections_full = nr.load_projection()
+        projections_part = nr.get_acquisition_data_subset(
+            ymin=5, ymax=10).as_array()
+        numpy.testing.assert_array_equal(
+            projections_part, projections_full[:, 5:10, :])
+
+    def test_get_acquisition_data_slice(self):
+        nr = NXTomoReader(self.filename)
+        projections_full = nr.load_projection()
+        projections_part = nr.get_acquisition_data_slice(y_slice=5).as_array()
+        numpy.testing.assert_array_equal(
+            projections_part, projections_full[:, 5, :])
+
+    def test_get_acquisition_data_batch(self):
+        nr = NXTomoReader(self.filename)
+        projections_full = nr.load_projection()
+        projections_part = nr.get_acquisition_data_batch(bmin=5, bmax=7).as_array()
+        numpy.testing.assert_array_equal(
+            projections_part, projections_full[5:7, :, :])
+
 
 if __name__ == "__main__":
-    #import sys;sys.argv = ['', 'TestNXTomoReader.testLoad']
     unittest.main()

--- a/Wrappers/Python/test/test_NXTomoReader.py
+++ b/Wrappers/Python/test/test_NXTomoReader.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+#   This work is part of the Core Imaging Library developed by
+#   Visual Analytics and Imaging System Group of the Science Technology
+#   Facilities Council, STFC
+
+#   Copyright 2018 Jakob Jorgensen, Daniil Kazantsev, Edoardo Pasca and Srikanth Nagella
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+'''
+Unit tests for Readers
+@author: Mr. Srikanth Nagella
+'''
+import unittest
+
+import numpy.testing
+import wget
+import os
+from cil.io import NXTomoReader
+
+
+class TestNXTomoReader(unittest.TestCase):
+
+    def setUp(self):
+        wget.download(
+            'https://github.com/DiamondLightSource/Savu/raw/master/test_data/data/24737_fd.nxs')
+        self.filename = '24737_fd.nxs'
+
+    def tearDown(self):
+        os.remove(self.filename)
+
+    def test_get_dimensions(self):
+        nr = NXTomoReader(self.filename)
+        self.assertEqual(nr.get_sinogram_dimensions(),
+                         (135, 91, 160), "Sinogram dimensions are not correct")
+
+    def test_get_projection_dimensions(self):
+        nr = NXTomoReader(self.filename)
+        self.assertEqual(nr.get_projection_dimensions(
+        ), (91, 135, 160), "Projection dimensions are not correct")
+
+    def test_load_projection_without_dimensions(self):
+        nr = NXTomoReader(self.filename)
+        projections = nr.load_projection()
+        self.assertEqual(projections.shape, (91, 135, 160),
+                         "Loaded projection data dimensions are not correct")
+
+    def test_load_projection_with_dimensions(self):
+        nr = NXTomoReader(self.filename)
+        projections = nr.load_projection(
+            (slice(0, 1), slice(0, 135), slice(0, 160)))
+        self.assertEqual(projections.shape, (1, 135, 160),
+                         "Loaded projection data dimensions are not correct")
+
+    def test_load_projection_compare_single(self):
+        nr = NXTomoReader(self.filename)
+        projections_full = nr.load_projection()
+        projections_part = nr.load_projection(
+            (slice(0, 1), slice(0, 135), slice(0, 160)))
+        numpy.testing.assert_array_equal(
+            projections_part, projections_full[0:1, :, :])
+
+    def test_load_projection_compare_multi(self):
+        nr = NXTomoReader(self.filename)
+        projections_full = nr.load_projection()
+        projections_part = nr.load_projection(
+            (slice(0, 3), slice(0, 135), slice(0, 160)))
+        numpy.testing.assert_array_equal(
+            projections_part, projections_full[0:3, :, :])
+
+    def test_load_projection_compare_random(self):
+        nr = NXTomoReader(self.filename)
+        projections_full = nr.load_projection()
+        projections_part = nr.load_projection(
+            (slice(1, 8), slice(5, 10), slice(8, 20)))
+        numpy.testing.assert_array_equal(
+            projections_part, projections_full[1:8, 5:10, 8:20])
+
+    def test_load_projection_compare_full(self):
+        nr = NXTomoReader(self.filename)
+        projections_full = nr.load_projection()
+        projections_part = nr.load_projection(
+            (slice(None, None), slice(None, None), slice(None, None)))
+        numpy.testing.assert_array_equal(
+            projections_part, projections_full[:, :, :])
+
+    def test_load_flat_compare_full(self):
+        nr = NXTomoReader(self.filename)
+        flats_full = nr.load_flat()
+        flats_part = nr.load_flat(
+            (slice(None, None), slice(None, None), slice(None, None)))
+        numpy.testing.assert_array_equal(flats_part, flats_full[:, :, :])
+
+    def test_load_dark_compare_full(self):
+        nr = NXTomoReader(self.filename)
+        darks_full = nr.load_dark()
+        darks_part = nr.load_dark(
+            (slice(None, None), slice(None, None), slice(None, None)))
+        numpy.testing.assert_array_equal(darks_part, darks_full[:, :, :])
+
+    def test_projection_angles(self):
+        nr = NXTomoReader(self.filename)
+        angles = nr.get_projection_angles()
+        self.assertEqual(angles.shape, (91,),
+                         "Loaded projection number of angles are not correct")
+
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'TestNXTomoReader.testLoad']
+    unittest.main()

--- a/Wrappers/Python/test/test_NXTomoReader.py
+++ b/Wrappers/Python/test/test_NXTomoReader.py
@@ -34,13 +34,13 @@ class TestNXTomoReaderWriter(unittest.TestCase):
             os.mkdir(self.data_dir)
 
         angles = [i for i in range(0,91)]
-        num_pixels = [160, 135] # horizontal, vertical
+        num_pixels = [135, 160] # horizontal, vertical
         
 
         self.ag3d = AcquisitionGeometry.create_Parallel3D()\
                                     .set_angles(angles)\
                                     .set_panel(num_pixels, origin='top-right')\
-                                    .set_labels(['angle', 'horizontal',  'vertical'])
+                                    .set_labels(['angle', 'horizontal',   'vertical'])
 
         self.ad3d = self.ag3d.allocate('random_int')
 
@@ -179,14 +179,14 @@ class TestNXTomoReaderWriter(unittest.TestCase):
         projections_part = nr.get_acquisition_data_subset(
             ymin=5, ymax=10).as_array()
         numpy.testing.assert_array_equal(
-            projections_part, projections_full[:, :,  5:10])
+            projections_part, projections_full[:, 5:10, :])
 
     def test_get_acquisition_data_slice(self):
         nr = NXTomoReader(self.file_name)
         projections_full = nr.load_projection()
         projections_part = nr.get_acquisition_data_slice(y_slice=5).as_array()
         numpy.testing.assert_array_equal(
-            projections_part, projections_full[:, :, 5])
+            projections_part, projections_full[:, 5, :])
 
     def test_get_acquisition_data_batch(self):
         nr = NXTomoReader(self.file_name)


### PR DESCRIPTION
Adds ability to read and write the [NXTomo](https://manual.nexusformat.org/classes/applications/NXtomo.html) format.

Reader was modified from [this code](https://github.com/vais-ral/CCPi-Framework/blob/v20.09.1/Wrappers/Python/ccpi/io/reader.py)

Writer makes use of [this code](https://github.com/vais-ral/CCPi-Users-EPAC/blob/main/previous-analysis-code/stephen/nexus_export.py)

Addresses the first part of #744 

I copied over all methods from the original reader code, but I am unsure whether the following are needed:

- `get_acquisition_data_subset ` ,  `get_acquisition_data_batch` and  `get_acquisition_data_subset ` - the same thing can be achieved by using slicing with `get_acquisition_data` if the `dimensions` are set.
-  `get_acquisition_data_whole` - the same thing is returned if you just use  `get_acquisition_data` without` dimensions `set 


From the NXTomo documentation, the data is of shape [nFrames, xSize, ySize], however in the previous code and by visualising NXTomo datasets from EPAC, it is seen that the data is in the order (angles, vertical, horizontal), which is the default for CIL acquisition data.

Another point is I am wondering if we should have some way for the user to specify which integer type they would like to write to the file. By default the NEXUSDataWriter writes out as float32 but the NXTomo format expects the data as ["any representation of an integer number"](https://manual.nexusformat.org/nxdl-types.html#nx-int). I have set it to uint32, but say for example I have a uint16 dataset that I read in and want to write out again then it will double in size!

