### PR TITLE
Write flat and dark field data to the CIL Nexus format

### DIFF
--- a/Wrappers/Python/cil/io/NEXUSDataReader.py
+++ b/Wrappers/Python/cil/io/NEXUSDataReader.py
@@ -227,7 +227,13 @@ class NEXUSDataReader(object):
                     raise ValueError("Projections are not in the data. Data Path ",
                                     self.file_name)
                 else:
-                    data = all_data[image_keys == 0]
+                    angle_index = self._geometry.dimension_labels.index('angle')
+                    if angle_index ==0:
+                        data = all_data[image_keys == 0]
+                    elif angle_index ==1:
+                        data = all_data[:, image_keys == 0]
+                    elif angle_index ==2:
+                        data = all_data[:,:,image_keys == 0]
             else:
                 data = np.array(ds_data, dtype = np.float32)
             
@@ -294,10 +300,14 @@ class NEXUSDataReader(object):
                                     self.file_name)
                 else:
                     print("Image keys: ", image_keys)
-                    data = all_data[image_keys == image_key_id]
-                    if len(data==1):
-                        data = data[0]
-                    print(data)
+                    angle_index = self._geometry.dimension_labels.index('angle')
+                    if angle_index == 0:
+                        data = all_data[image_keys == image_key_id]
+                    elif angle_index == 1:
+                        data = all_data[:, image_keys == image_key_id]
+                    elif angle_index == 2:
+                        data = all_data[:,:,image_keys == image_key_id]
+
             else:
                 raise ValueError("Dark and Flat fields are not saved in the data. Data Path ",
                                     self.file_name)

--- a/Wrappers/Python/cil/io/NEXUSDataReader.py
+++ b/Wrappers/Python/cil/io/NEXUSDataReader.py
@@ -299,7 +299,6 @@ class NEXUSDataReader(object):
                     raise ValueError("Data with image key: ", image_key_id, "is not in the data. Data Path ",
                                     self.file_name)
                 else:
-                    print("Image keys: ", image_keys)
                     angle_index = self._geometry.dimension_labels.index('angle')
                     if angle_index == 0:
                         data = all_data[image_keys == image_key_id]
@@ -307,7 +306,6 @@ class NEXUSDataReader(object):
                         data = all_data[:, image_keys == image_key_id]
                     elif angle_index == 2:
                         data = all_data[:,:,image_keys == image_key_id]
-
             else:
                 raise ValueError("Dark and Flat fields are not saved in the data. Data Path ",
                                     self.file_name)

--- a/Wrappers/Python/cil/io/NEXUSDataWriter.py
+++ b/Wrappers/Python/cil/io/NEXUSDataWriter.py
@@ -193,6 +193,10 @@ class NEXUSDataWriter(object):
         If key is set to None, it is assumed that the fields were taken
         before the projections, and the key is set to a numpy array of 0s,
         with the same number of entries as there are projections in the field data.'''
+        if key is not None:
+            if type(key) not in [np.ndarray, list]:
+                raise TypeError('Dark/flat field key must be one of the following data types:\n' +
+                                ' - np.ndarray\n - list')
         field_shape = list(field_data.shape)
         horizontal_id = list(self.data.dimension_labels).index('horizontal')
         field_shape.pop(horizontal_id)

--- a/Wrappers/Python/cil/io/NEXUSDataWriter.py
+++ b/Wrappers/Python/cil/io/NEXUSDataWriter.py
@@ -217,6 +217,8 @@ class NEXUSDataWriter(object):
         return key
 
     def write(self):
+        ''' writes the data and flat and dark field information
+        (if present) to self.file_name'''
         
         # if the folder does not exist, create the folder
         if not os.path.isdir(os.path.dirname(self.file_name)):

--- a/Wrappers/Python/cil/io/NEXUSDataWriter.py
+++ b/Wrappers/Python/cil/io/NEXUSDataWriter.py
@@ -102,15 +102,18 @@ class NEXUSDataWriter(object):
                 if self.flat_field is not None:
                     if len(self.flat_field.shape) == len(self.data.as_array().shape)-1:
                         flat_fields_len = 1
-                    else:
-                        flat_fields_len = self.flat_field.shape[angles_id]
+                        shape = list(self.flat_field.shape)
+                        shape.insert(angles_id,1)
+                        self.flat_field = self.flat_field.reshape(shape)
+                    flat_fields_len = self.flat_field.shape[angles_id]
                 else:
                     flat_fields_len = 0
                 if self.dark_field is not None:
                     if len(self.dark_field.shape) == len(self.data.as_array().shape)-1:
-                        dark_fields_len = 1
-                    else:
-                        dark_fields_len = self.dark_field.shape[angles_id]
+                        shape = list(self.dark_field.shape)
+                        shape.insert(angles_id,1)
+                        self.dark_field = self.dark_field.reshape(shape)
+                    dark_fields_len = self.dark_field.shape[angles_id]
                 else:
                     dark_fields_len = 0
 
@@ -131,6 +134,7 @@ class NEXUSDataWriter(object):
                         for i in range(0, dark_fields_len):
                             dark_field = np.take(self.dark_field, i, axis=angles_id)
                             data_to_write = np.insert(data_to_write, 0, dark_field, axis=angles_id)
+
                 if self.flat_field is not None:
                     if flat_fields_len ==0:
                         data_to_write = np.insert(data_to_write, 0, self.flat_field, axis=angles_id)

--- a/Wrappers/Python/test/test_NexusReaderWriter.py
+++ b/Wrappers/Python/test/test_NexusReaderWriter.py
@@ -38,6 +38,7 @@ class TestNexusReaderWriter(unittest.TestCase):
                                     .set_channels(6)\
                                     .set_labels(['angle', 'horizontal'])
                                     #.set_labels(['horizontal', 'angle'])
+                                    #TODO: revert to og ordering
 
         self.ad2d = self.ag2d.allocate('random_int')
 
@@ -150,10 +151,11 @@ class TestNexusReaderWriter(unittest.TestCase):
 
     def test_writeAcquisitionData_with_dark_and_flat_fields(self):
         im_size = 5
-        self.flat_field_2d = numpy.ones(im_size)
-        self.dark_field_2d = numpy.zeros(im_size)
-        self.dark_field_position_key = numpy.random.randint(0, 2, im_size)
-        self.flat_field_position_key = numpy.random.randint(0, 2, im_size)
+        angles = 2
+        self.flat_field_2d = numpy.ones((angles, im_size))
+        self.dark_field_2d = numpy.zeros((angles, im_size))
+        self.dark_field_position_key = numpy.random.randint(0, 2, angles)
+        self.flat_field_position_key = numpy.random.randint(0, 2, angles)
 
         writer = NEXUSDataWriter()
         writer.set_up(file_name=os.path.join(self.data_dir, 'test_nexus_ad2d.nxs'),
@@ -164,15 +166,18 @@ class TestNexusReaderWriter(unittest.TestCase):
         self.flat_field_3d = numpy.ones((1, 10, 5))
         self.dark_field_3d = numpy.zeros((1, 10, 5))
 
-        self.dark_field_position_key = numpy.random.randint(0, 2, 1)
+        
         self.flat_field_position_key = numpy.random.randint(0, 2, 1)
+        # below, we will not set the dark field position key.
+        # in this case, it should automatically be set to an
+        # array of zeros with the same shape as the dark_field array
+        self.dark_field_position_key = numpy.zeros((1))
 
         writer = NEXUSDataWriter()
         writer.set_up(file_name=os.path.join(self.data_dir, 'test_nexus_ad3d.nxs'),
                       data=self.ad3d, flat_field=self.flat_field_3d,
                       flat_field_key=self.flat_field_position_key,
-                      dark_field=self.dark_field_3d,
-                      dark_field_key=self.dark_field_position_key)
+                      dark_field=self.dark_field_3d)
         writer.write()
 
         self.readAcquisitionDataAndTest()

--- a/Wrappers/Python/test/test_NexusReaderWriter.py
+++ b/Wrappers/Python/test/test_NexusReaderWriter.py
@@ -36,9 +36,7 @@ class TestNexusReaderWriter(unittest.TestCase):
                                     .set_angles([0, 90, 180],-3.0, 'radian')\
                                     .set_panel(5, 0.2, origin='top-right')\
                                     .set_channels(6)\
-                                    .set_labels(['angle', 'horizontal'])
-                                    #.set_labels(['horizontal', 'angle'])
-                                    #TODO: revert to og ordering
+                                    .set_labels(['horizontal', 'angle'])
 
         self.ad2d = self.ag2d.allocate('random_int')
 
@@ -152,8 +150,8 @@ class TestNexusReaderWriter(unittest.TestCase):
     def test_writeAcquisitionData_with_dark_and_flat_fields(self):
         im_size = 5
         angles = 2
-        self.flat_field_2d = numpy.ones((angles, im_size))
-        self.dark_field_2d = numpy.zeros((angles, im_size))
+        self.flat_field_2d = numpy.ones((im_size, angles))
+        self.dark_field_2d = numpy.zeros((im_size, angles))
         self.dark_field_position_key = numpy.random.randint(0, 2, angles)
         self.flat_field_position_key = numpy.random.randint(0, 2, angles)
 
@@ -166,7 +164,6 @@ class TestNexusReaderWriter(unittest.TestCase):
         self.flat_field_3d = numpy.ones((1, 10, 5))
         self.dark_field_3d = numpy.zeros((1, 10, 5))
 
-        
         self.flat_field_position_key = numpy.random.randint(0, 2, 1)
         # below, we will not set the dark field position key.
         # in this case, it should automatically be set to an

--- a/Wrappers/Python/test/test_NexusReaderWriter.py
+++ b/Wrappers/Python/test/test_NexusReaderWriter.py
@@ -99,7 +99,6 @@ class TestNexusReaderWriter(unittest.TestCase):
         self.assertEqual(ig.voxel_num_y, ig_test.voxel_num_y, 'ImageGeometry is not correct')
         
     def readAcquisitionDataAndTest(self):
-        print("read 2d")
         reader2d = NEXUSDataReader()
         reader2d.set_up(file_name = os.path.join(self.data_dir, 'test_nexus_ad2d.nxs'))
         ad2d = reader2d.read()
@@ -115,11 +114,11 @@ class TestNexusReaderWriter(unittest.TestCase):
         
         if self.dark_field_2d is not None:
             dark_field_2d = reader2d.load_dark()
-            numpy.testing.assert_array_equal(dark_field_2d, self.dark_field_2d.reshape(1,5), 'Dark Field Data is not correct')
+            numpy.testing.assert_array_equal(dark_field_2d, self.dark_field_2d, 'Dark Field Data is not correct')
         
         if self.flat_field_2d is not None:
             flat_field_2d = reader2d.load_flat()
-            numpy.testing.assert_array_equal(flat_field_2d, self.flat_field_2d.reshape(1,5), 'Flat Field Data is not correct')
+            numpy.testing.assert_array_equal(flat_field_2d, self.flat_field_2d, 'Flat Field Data is not correct')
 
         assert ag2d == self.ag2d
         reader3d = NEXUSDataReader()
@@ -150,22 +149,30 @@ class TestNexusReaderWriter(unittest.TestCase):
         assert ag3d == self.ag3d
 
     def test_writeAcquisitionData_with_dark_and_flat_fields(self):
-        print("write 2d")
-        self.flat_field_2d = numpy.ones(5)
-        self.dark_field_2d = numpy.zeros(5)
+        im_size = 5
+        self.flat_field_2d = numpy.ones(im_size)
+        self.dark_field_2d = numpy.zeros(im_size)
+        self.dark_field_position_key = numpy.random.randint(0, 2, im_size)
+        self.flat_field_position_key = numpy.random.randint(0, 2, im_size)
 
         writer = NEXUSDataWriter()
         writer.set_up(file_name=os.path.join(self.data_dir, 'test_nexus_ad2d.nxs'),
-                      data=self.ad2d, flat_field=self.flat_field_2d, dark_field=self.dark_field_2d)
+                      data=self.ad2d, flat_field=self.flat_field_2d, flat_field_key = self.flat_field_position_key,
+                      dark_field=self.dark_field_2d, dark_field_key=self.dark_field_position_key)
         writer.write()
 
         self.flat_field_3d = numpy.ones((1, 10, 5))
         self.dark_field_3d = numpy.zeros((1, 10, 5))
 
-        print("write 3d")
+        self.dark_field_position_key = numpy.random.randint(0, 2, 1)
+        self.flat_field_position_key = numpy.random.randint(0, 2, 1)
+
         writer = NEXUSDataWriter()
         writer.set_up(file_name=os.path.join(self.data_dir, 'test_nexus_ad3d.nxs'),
-                      data=self.ad3d, flat_field=self.flat_field_3d, dark_field=self.dark_field_3d)
+                      data=self.ad3d, flat_field=self.flat_field_3d,
+                      flat_field_key=self.flat_field_position_key,
+                      dark_field=self.dark_field_3d,
+                      dark_field_key=self.dark_field_position_key)
         writer.write()
 
         self.readAcquisitionDataAndTest()

--- a/Wrappers/Python/test/test_NexusReaderWriter.py
+++ b/Wrappers/Python/test/test_NexusReaderWriter.py
@@ -36,7 +36,8 @@ class TestNexusReaderWriter(unittest.TestCase):
                                     .set_angles([0, 90, 180],-3.0, 'radian')\
                                     .set_panel(5, 0.2, origin='top-right')\
                                     .set_channels(6)\
-                                    .set_labels(['horizontal', 'angle'])
+                                    .set_labels(['angle', 'horizontal'])
+                                    #.set_labels(['horizontal', 'angle'])
 
         self.ad2d = self.ag2d.allocate('random_int')
 
@@ -114,14 +115,13 @@ class TestNexusReaderWriter(unittest.TestCase):
         
         if self.dark_field_2d is not None:
             dark_field_2d = reader2d.load_dark()
-            numpy.testing.assert_array_equal(dark_field_2d, self.dark_field_2d, 'Dark Field Data is not correct')
+            numpy.testing.assert_array_equal(dark_field_2d, self.dark_field_2d.reshape(1,5), 'Dark Field Data is not correct')
         
         if self.flat_field_2d is not None:
             flat_field_2d = reader2d.load_flat()
-            numpy.testing.assert_array_equal(flat_field_2d, self.flat_field_2d, 'Flat Field Data is not correct')
+            numpy.testing.assert_array_equal(flat_field_2d, self.flat_field_2d.reshape(1,5), 'Flat Field Data is not correct')
 
         assert ag2d == self.ag2d
-
         reader3d = NEXUSDataReader()
         reader3d.set_up(file_name = os.path.join(self.data_dir, 'test_nexus_ad3d.nxs'))
         ad3d = reader3d.read()
@@ -150,8 +150,9 @@ class TestNexusReaderWriter(unittest.TestCase):
         assert ag3d == self.ag3d
 
     def test_writeAcquisitionData_with_dark_and_flat_fields(self):
-        self.flat_field_2d = numpy.ones((5,1))
-        self.dark_field_2d = numpy.zeros((5,1))
+        print("write 2d")
+        self.flat_field_2d = numpy.ones(5)
+        self.dark_field_2d = numpy.zeros(5)
 
         writer = NEXUSDataWriter()
         writer.set_up(file_name=os.path.join(self.data_dir, 'test_nexus_ad2d.nxs'),
@@ -161,7 +162,7 @@ class TestNexusReaderWriter(unittest.TestCase):
         self.flat_field_3d = numpy.ones((1, 10, 5))
         self.dark_field_3d = numpy.zeros((1, 10, 5))
 
-
+        print("write 3d")
         writer = NEXUSDataWriter()
         writer.set_up(file_name=os.path.join(self.data_dir, 'test_nexus_ad3d.nxs'),
                       data=self.ad3d, flat_field=self.flat_field_3d, dark_field=self.dark_field_3d)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 sphinx_rtd_theme
 numpy
 scipy
-matplotlib
 olefile
 pywavelets

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx_rtd_theme
 numpy
 scipy
+matplotlib
 olefile
 pywavelets


### PR DESCRIPTION
Closes: https://github.com/TomographicImaging/CIL/issues/934
Writes dark and flat field data out to a CIL nexus file, and reads this in with the NEXUSReader.
The dark and flat fields must be arrays with the same dimensions and ordering as the data set.

Dark field data is saved to: `entry1/tomo_entry/data/dark_field/data`
A position key for this data is saved to: `entry1/tomo_entry/data/dark_field/position_key`
And similar for flat fields.
Any suggestions on renaming the location of these would be welcome.

The position key is an array of length [number of flat fields] which contains 0s and 1s. 0 indicates the field was taken before the projections, 1 indicates after.

I originally tried adding the flat and dark field data into the array that is saved in `entry1/tomo_entry/data/data`  and saving an image key to identify which are flat fields, dark fields and projections (as is done in the NXTomo format), but this quickly became complicated due to different orderings the data dimensions could have (see here https://github.com/TomographicImaging/CIL/pull/940/commits/86f2ae2137204ab62a26b2cef170bf45f676c4c8)
It seems better to save the dark and flat fields as separate arrays because that is how they will be read back and used in processing anyway.

More detailed information about the ordering of the dark and flat fields (i.e. if some were taken in between projections) could be added to the nexus file in the future if needed - this could be in another array entry within `entry1/tomo_entry/data/dark_field/`