### PR TITLE
memory optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* 21.2.1
+  - PDHG memory optimisation
+  - ScaledFunction memory Optimisation
+
 * 21.2.0
   - add version string from git describe
   - add CCPi-Regularisation toolkit in unittests

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2778,10 +2778,19 @@ class Processor(object):
     def process(self, out=None):
         raise NotImplementedError('process must be implemented')
     
-    def __call__(self, x):
+    def __call__(self, x, out=None):
         
-        self.set_input(x)
-        return self.get_output()        
+        self.set_input(x)    
+
+        if out is None:
+            out = self.get_output()      
+        else:
+            self.get_output(out=out)
+
+        self.clear_input()
+        
+        return out
+
 
 class DataProcessor(Processor):
     '''Basically an alias of Processor Class'''

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2728,6 +2728,9 @@ class Processor(object):
             raise TypeError("Input type mismatch: got {0} expecting {1}"\
                             .format(type(dataset), DataContainer))
     
+    def clear_input(self):
+        self.__dict__['input']= None
+
     def check_input(self, dataset):
         '''Checks parameters of the input DataContainer
         

--- a/Wrappers/Python/cil/optimisation/algorithms/PDHG.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/PDHG.py
@@ -32,9 +32,9 @@ class PDHG(Algorithm):
     :param operator: Linear Operator = K
     :param f: Convex function with "simple" proximal of its conjugate. 
     :param g: Convex function with "simple" proximal 
-    :param sigma: Step size parameter for Primal problem
-    :param tau: Step size parameter for Dual problem
-        
+    :param tau: Step size parameter for Primal problem
+    :param sigma: Step size parameter for Dual problem
+ 
     Remark: Convergence is guaranted provided that
         
     .. math:: 
@@ -62,8 +62,8 @@ class PDHG(Algorithm):
         :param operator: a Linear Operator
         :param f: Convex function with "simple" proximal of its conjugate. 
         :param g: Convex function with "simple" proximal 
-        :param sigma: Step size parameter for Primal problem
-        :param tau: Step size parameter for Dual problem
+        :param tau: Step size parameter for Primal problem
+        :param sigma: Step size parameter for Dual problem
         :param initial: Initial guess ( Default initial = 0)
         '''
         super(PDHG, self).__init__(**kwargs)
@@ -86,8 +86,8 @@ class PDHG(Algorithm):
         :param operator: a Linear Operator
         :param f: Convex function with "simple" proximal of its conjugate. 
         :param g: Convex function with "simple" proximal 
-        :param sigma: Step size parameter for Primal problem
-        :param tau: Step size parameter for Dual problem
+        :param tau: Step size parameter for Primal problem
+        :param sigma: Step size parameter for Dual problem
         :param initial: Initial guess ( Default initial = 0)'''
 
         print("{} setting up".format(self.__class__.__name__, ))

--- a/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
@@ -175,8 +175,8 @@ class SPDHG(Algorithm):
             y_k.multiply(self.sigma[i], out=y_k)
             y_k.add(self.y_old[i], out=y_k)
             
-        tmp = self.f[i].proximal_conjugate(y_k, self.sigma[i])
-        y_k = tmp
+        y_k = self.f[i].proximal_conjugate(y_k, self.sigma[i])
+        
         # Back-project
         # x_tmp = K[i]^*(y_k - y_old[i])
         y_k.subtract(self.y_old[i], out=self.y_old[i])

--- a/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
@@ -175,8 +175,8 @@ class SPDHG(Algorithm):
             y_k.multiply(self.sigma[i], out=y_k)
             y_k.add(self.y_old[i], out=y_k)
             
-        self.f[i].proximal_conjugate(y_k, self.sigma[i], out=y_k)
-        
+        tmp = self.f[i].proximal_conjugate(y_k, self.sigma[i])
+        y_k = tmp
         # Back-project
         # x_tmp = K[i]^*(y_k - y_old[i])
         y_k.subtract(self.y_old[i], out=self.y_old[i])

--- a/Wrappers/Python/cil/optimisation/functions/Function.py
+++ b/Wrappers/Python/cil/optimisation/functions/Function.py
@@ -318,6 +318,8 @@ class ScaledFunction(Function):
         r"""This returns the proximal operator for the function at x, tau
         """
 
+
+
         try:
             x.divide(self.scalar, out = x)
             tmp = x
@@ -500,8 +502,6 @@ class TranslateFunction(Function):
         self.function = function
         self.center = center
         
-        
-                
     def __call__(self, x):
         
         r"""Returns the value of the translated function.
@@ -509,8 +509,19 @@ class TranslateFunction(Function):
         .. math:: G(x) = F(x - b)
         
         """        
-        
-        return self.function(x - self.center)
+        try:
+            x.subtract(self.center, out = x)
+            tmp = x
+        except TypeError:
+            tmp = x.subtract(self.center, dtype=np.float32)
+
+        val = self.function(tmp)
+
+        if id(tmp) == id(x):
+            x.add(self.center, out = x)
+
+        return val
+
     
     def gradient(self, x, out = None):
         
@@ -519,12 +530,23 @@ class TranslateFunction(Function):
         .. math:: G'(x) =  F'(x - b)
         
         """        
-        
+        try:
+            x.subtract(self.center, out = x)
+            tmp = x
+        except TypeError:
+            tmp = x.subtract(self.center, dtype=np.float32)
+
         if out is None:
-            return self.function.gradient(x - self.center)
+            val = self.function.gradient(tmp)
         else:                       
-            x.subtract(self.center, out = out)
-            self.function.gradient(out, out = out)           
+            self.function.gradient(tmp, out = out)   
+
+        if id(tmp) == id(x):
+            x.add(self.center, out = x)
+
+        if out is None:
+            return val
+
     
     def proximal(self, x, tau, out = None):
         
@@ -533,14 +555,25 @@ class TranslateFunction(Function):
         .. math:: \mathrm{prox}_{\tau G}(x) = \mathrm{prox}_{\tau F}(x-b) + b
         
         """        
-        
+        try:
+            x.subtract(self.center, out = x)
+            tmp = x
+        except TypeError:
+            tmp = x.subtract(self.center, dtype=np.float32)
+
         if out is None:
-            return self.function.proximal(x - self.center, tau) + self.center
+            val = self.function.proximal(tmp, tau)
+            val.add(self.center, out = val)
         else:                    
-            x.subtract(self.center, out = out)
-            self.function.proximal(out, tau, out = out)
+            self.function.proximal(tmp, tau, out = out)   
             out.add(self.center, out = out)
-                    
+
+        if id(tmp) == id(x):
+            x.add(self.center, out = x)
+
+        if out is None:
+            return val
+
     def convex_conjugate(self, x):
         
         r"""Returns the convex conjugate of the translated function.

--- a/Wrappers/Python/cil/optimisation/functions/Function.py
+++ b/Wrappers/Python/cil/optimisation/functions/Function.py
@@ -84,7 +84,7 @@ class Function(object):
             tmp = x
             x.divide(tau, out = tmp)
         except TypeError:
-            tmp = x.divide(tau)
+            tmp = x.divide(tau, dtype=np.float32)
 
         if out is None:
             val = self.proximal(tmp, 1.0/tau)
@@ -281,7 +281,7 @@ class ScaledFunction(Function):
             x.divide(self.scalar, out = x)
             tmp = x
         except TypeError:
-            tmp = x.divide(self.scalar)
+            tmp = x.divide(self.scalar, dtype=np.float32)
 
         val = self.function.convex_conjugate(tmp)
 
@@ -317,29 +317,25 @@ class ScaledFunction(Function):
     def proximal_conjugate(self, x, tau, out = None):
         r"""This returns the proximal operator for the function at x, tau
         """
-
-
-
         try:
-            x.divide(self.scalar, out = x)
             tmp = x
+            x.divide(tau, out = tmp)
         except TypeError:
-            tmp = x.divide(self.scalar, dtype=np.float32)
+            tmp = x.divide(tau, dtype=np.float32)
 
         if out is None:
-            val = self.function.proximal_conjugate(tmp, tau/self.scalar)
-            val *= self.scalar
-
-            if id(tmp) == id(x):
-                x.multiply(self.scalar, out = x)
-            return val
-
+            val = self.function.proximal(tmp, self.scalar/tau )
         else:
-            self.function.proximal_conjugate(tmp, tau/self.scalar, out=out)
-            out *= self.scalar
-        
-            if id(tmp) == id(x):
-                x.multiply(self.scalar, out = x)       
+            self.function.proximal(tmp, self.scalar/tau, out = out)
+            val = out     
+
+        if id(tmp) == id(x):
+            x.multiply(tau, out = x)
+
+        val.axpby(-tau, 1.0, x, out=val)
+
+        if out is None:
+            return val
 
 class SumScalarFunction(SumFunction):
           

--- a/Wrappers/Python/cil/optimisation/functions/MixedL21Norm.py
+++ b/Wrappers/Python/cil/optimisation/functions/MixedL21Norm.py
@@ -105,7 +105,14 @@ class MixedL21Norm(Function):
             
         else:
             
-            tmp = (x/tau).pnorm(2)
+            try:
+                x.divide(tau,out=x)
+                tmp = x.pnorm(2)
+                x.multiply(tau,out=x)
+            except TypeError:
+                x_scaled = x.divide(tau)
+                tmp = x_scaled.pnorm(2)
+ 
             tmp_ig = 0.0 * tmp
             (tmp - 1).maximum(0.0, out = tmp_ig)
             tmp_ig.multiply(x, out = out)

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -856,6 +856,7 @@ class TestDataProcessor(unittest.TestCase):
         self.assertTrue(ax.store_output)
 
         #check storing a copy and not a reference
+        ax.set_input(dc_in)
         dc_out = ax.get_output()
         numpy.testing.assert_array_equal(ax.output.as_array(), out_gold.as_array())
         self.assertFalse(id(ax.output.as_array()) == id(dc_out.as_array()))
@@ -900,17 +901,12 @@ class TestDataProcessor(unittest.TestCase):
     
         ax = AX()
         ax.scalar = 2
-        ax.set_input(c)
-        #ax.apply()
-        #print ("ax  in {0} out {1}".format(c.as_array().flatten(),
-        #       ax.get_output().as_array().flatten()))
-        
-        numpy.testing.assert_array_equal(ax.get_output().as_array(), arr*2)
-                
-        
-        #print("check call method of DataProcessor")
+
         numpy.testing.assert_array_equal(ax(c).as_array(), arr*2)
-        
+
+        ax.set_input(c)
+        numpy.testing.assert_array_equal(ax.get_output().as_array(), arr*2)
+
         cast = CastDataContainer(dtype=numpy.float32)
         cast.set_input(c)
         out = cast.get_output()


### PR DESCRIPTION
Changes (predominantly) to PDHG and scaled functions to reduce memory use.

The changed to PDHG are just to make better use of existing allocated memory.

Scaled operators were duplicating the data to temporarily divide by a scalar. I've switched this to an in place division and post-operation multiplication as this was generating multiply trivial copies of data, which with TV ends up as a large `BlockDatacontainer`

Maybe we could still avoid this computation if we added a 'scalar multiplier' to our data container that gets updated independently, and only applied when necessary.

The plots show memory use of a 512^3 data set, with PDHG and TV.

20-90s is calculating the operator norms, PDHG is initialised at ~90s, followed by 'update objective' to ~110s, then 5 iterations of PDHG, with peak memory usage at nearly 14GB (28x the dataset size)

![image](https://user-images.githubusercontent.com/47746591/128525446-23676553-89ad-42c0-970a-6de6f406303d.png)

With my changes the peak is now 9.5GB (19x dataset size).
![image](https://user-images.githubusercontent.com/47746591/128525801-25e4818a-e999-4246-b64d-37121d1fcaf5.png)

There's still plenty of scope for more improvements, but this was some low hanging fruit.
