### PR TITLE
Use v1.4.0 of conda action

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: publish-to-conda
-      uses: paskino/conda-package-publish-action@master
+      uses: paskino/conda-package-publish-action@v1.4.0
       env:
         CIL_VERSION: 21.0.0
       with:


### PR DESCRIPTION
Uses specific version of the conda build action so that if the master branch of the action repo is updated, this won't cause us problems.