### PR TITLE
Remove CIL_VERSION environment variable and update to v1.4.1 of conda build action

### DIFF
--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -20,8 +20,6 @@ jobs:
     - uses: actions/checkout@v1
     - name: publish-to-conda
       uses: paskino/conda-package-publish-action@v1.4.0
-      env:
-        CIL_VERSION: 21.0.0
       with:
         subDir: 'recipe'
         channels: 'conda-forge -c astra-toolbox/label/dev -c cvxgrp -c ccpi'

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: publish-to-conda
-      uses: paskino/conda-package-publish-action@fix-apt-update
+      uses: paskino/conda-package-publish-action@v1.4.0
       with:
         subDir: 'recipe'
         channels: 'conda-forge -c astra-toolbox/label/dev -c cvxgrp -c ccpi'

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: publish-to-conda
-      uses: paskino/conda-package-publish-action@v1.4.0
+      uses: paskino/conda-package-publish-action@fix-apt-update
       with:
         subDir: 'recipe'
         channels: 'conda-forge -c astra-toolbox/label/dev -c cvxgrp -c ccpi'

--- a/.github/workflows/conda_build.yml
+++ b/.github/workflows/conda_build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: publish-to-conda
-      uses: paskino/conda-package-publish-action@v1.4.0
+      uses: paskino/conda-package-publish-action@v1.4.1
       with:
         subDir: 'recipe'
         channels: 'conda-forge -c astra-toolbox/label/dev -c cvxgrp -c ccpi'


### PR DESCRIPTION
Closes #923 

Also updates to using version 1.4.1 of the conda build action.