### PR TITLE
PDHG current solution bugfix

### DIFF
--- a/Wrappers/Python/cil/optimisation/algorithms/PDHG.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/PDHG.py
@@ -129,6 +129,11 @@ class PDHG(Algorithm):
         tmp = self.x_old
         self.x_old = self.x
         self.x = tmp
+
+    def get_output(self):
+        # returns the current solution
+        return self.x_old
+
     def update(self):
 
         #calculate x-bar and store in self.x_tmp
@@ -160,12 +165,15 @@ class PDHG(Algorithm):
             self.x_tmp += self.x_old
 
         self.g.proximal(self.x_tmp, self.tau, out=self.x)
+
+        #update_previous_solution() called after update by base class
+        #i.e current solution is now in x_old, previous solution is now in x
         
     def update_objective(self):
 
-        self.operator.direct(self.x, out=self.y_tmp)
+        self.operator.direct(self.x_old, out=self.y_tmp)
         f_eval_p = self.f(self.y_tmp)
-        g_eval_p = self.g(self.x)
+        g_eval_p = self.g(self.x_old)
         p1 = f_eval_p + g_eval_p
 
         self.operator.adjoint(self.y, out=self.x_tmp)

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -1115,8 +1115,7 @@ class TestADMM(unittest.TestCase):
         from cil.utilities.quality_measures import psnr
         if debug_print:
             print ("PSNR" , psnr(admm.solution, pdhg.solution))
-        np.testing.assert_almost_equal(psnr(admm.solution, pdhg.solution), 84.46678222768597, decimal=4)
-        # 84.46678222768597
+        np.testing.assert_almost_equal(psnr(admm.solution, pdhg.solution), 84.55162459062069, decimal=4)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
The base algorithm class calls `update()` followed by `update_previous_solution()`

With PDHG this sets `self.x_old` to the current solution and `self.x` to the previous solution.

This PR changes `self.get_output` and `update_objective` to return the current solution, previously they were referring to the previous solution.
