### PR TITLE
add minimum version of CMake for mac build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 3.4)
+if(APPLE)
+  cmake_minimum_required(VERSION 3.16)
+else()
+  cmake_minimum_required(VERSION 3.4)
+endif()
 
 project (cil LANGUAGES CXX)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,8 @@ requirements:
     - python
     - numpy {{ numpy }}
     - setuptools
-    - cmake
+    - cmake         # [not osx]
+    - cmake >=3.16 # [osx]
     - libgcc-ng     # [linux]
     - libstdcxx-ng  # [linux]
     - _openmp_mutex # [linux]


### PR DESCRIPTION
sets correctly the minimum required version for Mac in `CMakeLists.txt` and in the `meta.yaml`

Tested on a system with AppleClang 10.0.1.10010046