### PR TITLE
add Gradient for SIRF

### DIFF
--- a/Wrappers/Python/cil/optimisation/operators/FiniteDifferenceOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/FiniteDifferenceOperator.py
@@ -226,7 +226,9 @@ class FiniteDifferenceOperator(LinearOperator):
 
         if outnone:                  
             ret.fill(outa)
-            return ret                
+            return ret
+        else:
+            out.fill(outa)                             
                  
         
     def adjoint(self, x, out=None):
@@ -371,7 +373,9 @@ class FiniteDifferenceOperator(LinearOperator):
             
         if outnone:                  
             ret.fill(outa)
-            return ret    
+            return ret
+        else:
+            out.fill(outa)        
               
         
     

--- a/Wrappers/Python/cil/optimisation/operators/GradientOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/GradientOperator.py
@@ -74,15 +74,23 @@ class GradientOperator(LinearOperator):
         """Constructor method
         """        
         
+        # Default backend = C
         backend = kwargs.get('backend',C)
 
+        # Default correlation for the gradient coupling
         correlation = kwargs.get('correlation',CORRELATION_SPACE)
-
+        
+        # Add attributes for pseudo CIL geometries, e.g., SIRF data
+        if not isinstance(domain_geometry, ImageGeometry):
+            domain_geometry.channels = 1
+            domain_geometry.dimension_labels = [None]*len(domain_geometry.shape)
+        
+        # Space correlation on multichannel data call numpy backend
         if correlation == CORRELATION_SPACE and domain_geometry.channels > 1:
             #numpy implementation only for now
             backend = NUMPY
             warnings.warn("Warning: correlation='Space' on multi-channel dataset will use `numpy` backend")
-           
+        
         if method != 'forward':
             backend = NUMPY
             warnings.warn("Warning: method = {} implemented on `numpy` backend. Other methods are backward/centered.".format(method))            
@@ -135,19 +143,28 @@ class Gradient_numpy(LinearOperator):
         :type bnd_cond: str, optional, default :code:`Neumann`
         :param correlation: optional, :code:`SpaceChannel` or :code:`Space`
         :type correlation: str, optional, default :code:`Space`
-        '''                
+        '''             
         
-        self.size_dom_gm = len(domain_geometry.shape)         
+        # Consider pseudo 3D geometries with one slice, e.g., (1,155,155)
+        tmp_dom_shape = list(domain_geometry.shape)               
+        self.ind = list(range(len(tmp_dom_shape)))
+
+        for i, size in enumerate(tmp_dom_shape):
+            if size==1:
+                tmp_dom_shape.remove(size)
+                self.ind.remove(i)
+                
+        # Dimension of domain geometry        
+        self.ndim = len(tmp_dom_shape) 
+        
+        # Default correlation for the gradient coupling
         self.correlation = kwargs.get('correlation',CORRELATION_SPACE)        
         self.bnd_cond = bnd_cond 
         
-        # Call FiniteDiff operator 
+        # Call FiniteDifference operator 
         self.method = method
         self.FD = FiniteDifferenceOperator(domain_geometry, direction = 0, method = self.method, bnd_cond = self.bnd_cond)
-        
-        self.ndim = len(domain_geometry.shape)
-        self.ind = list(range(self.ndim))
-
+    
         if self.correlation==CORRELATION_SPACE and 'channel' in domain_geometry.dimension_labels:
             self.ndim -= 1
             self.ind.remove(domain_geometry.dimension_labels.index('channel'))
@@ -165,7 +182,7 @@ class Gradient_numpy(LinearOperator):
         
         print("Initialised GradientOperator with numpy backend")               
         
-    def direct(self, x, out=None):              
+    def direct(self, x, out=None): 
          if out is not None:  
              for i, axis_index in enumerate(self.ind):
                  self.FD.direction = axis_index
@@ -197,7 +214,7 @@ class Gradient_numpy(LinearOperator):
                 self.FD.direction = axis_index
                 self.FD.voxel_size = self.voxel_size_order[axis_index]
                 tmp += self.FD.adjoint(x.get_item(i))
-            return tmp    
+            return tmp 
 
 import ctypes, platform
 from ctypes import util
@@ -263,12 +280,39 @@ class Gradient_C(LinearOperator):
 
     def __init__(self, gm_domain, gm_range=None, bnd_cond = NEUMANN, **kwargs):
 
+        # Number of threads
         self.num_threads = kwargs.get('num_threads',NUM_THREADS)
+        
+        # Split gradients, e.g., space and channels
         self.split = kwargs.get('split',False)
+        
         self.gm_domain = gm_domain
         self.gm_range = gm_range
-        self.ndim = self.gm_domain.length
-                
+        
+        # Consider pseudo 3D geometries with one slice, e.g., (1,155,155)
+        self.tmp_dom_shape = list(gm_domain.shape)               
+        self.ind = list(range(len(self.tmp_dom_shape)))
+        self.is2D = False
+        
+        # List of voxel sizes
+        tmp_gm_domain_spacing = list(self.gm_domain.spacing)
+
+        for i, size in enumerate(self.tmp_dom_shape):
+            if size==1:
+                self.tmp_dom_shape.remove(size)
+                self.ind.pop(i)
+                tmp_gm_domain_spacing.pop(i)
+                self.is2D = True
+        
+        # Dimension of domain geometry
+        self.ndim = len(self.tmp_dom_shape)
+        
+        #get voxel spacing, if not use 1s
+        try:
+            self.voxel_size_order = tmp_gm_domain_spacing
+        except:
+            self.voxel_size_order = [1]*self.ndim       
+                        
         #default is 'Neumann'
         self.bnd_cond = 0
         
@@ -278,25 +322,19 @@ class Gradient_C(LinearOperator):
         # Domain Geometry = Range Geometry if not stated
         if self.gm_range is None:
             if self.split is True and 'channel' in self.gm_domain.dimension_labels:
-                self.gm_range = BlockGeometry(gm_domain, BlockGeometry(*[gm_domain for _ in range(len(gm_domain.shape)-1)]))
+                self.gm_range = BlockGeometry(gm_domain, BlockGeometry(*[gm_domain for _ in range(self.ndim-1)]))
             else:
-                self.gm_range = BlockGeometry(*[gm_domain for _ in range(len(gm_domain.shape))])
+                self.gm_range = BlockGeometry(*[gm_domain for _ in range(self.ndim)])
                 self.split = False
 
-        if len(gm_domain.shape) == 4:
-            # Voxel size wrt to channel direction == 1.0
+        if self.ndim == 4:
             self.fd = cilacc.fdiff4D
-        elif len(gm_domain.shape) == 3:
+        elif self.ndim == 3:
             self.fd = cilacc.fdiff3D
-        elif len(gm_domain.shape) == 2:
+        elif self.ndim == 2:
             self.fd = cilacc.fdiff2D
         else:
             raise ValueError('Number of dimensions not supported, expected 2, 3 or 4, got {}'.format(len(gm_domain.shape)))
-        #get voxel spacing, if not use 1s
-        try:
-            self.voxel_size_order = list(self.gm_domain.spacing)
-        except:
-            self.voxel_size_order = [1]*len(self.gm_domain.shape)
         
         super(Gradient_C, self).__init__(domain_geometry=self.gm_domain, 
                                              range_geometry=self.gm_range) 
@@ -311,8 +349,13 @@ class Gradient_C(LinearOperator):
     def ndarray_as_c_pointer(ndx):
         return ndx.ctypes.data_as(c_float_p)
         
-    def direct(self, x, out=None):    
-        ndx = np.asarray(x.as_array(), dtype=np.float32, order='C')
+    def direct(self, x, out=None): 
+        
+        # Case for psedo 3D data with only one slice
+        if self.is2D:            
+            ndx = np.squeeze(np.asarray(x.as_array(), dtype=np.float32, order='C'))
+        else:
+            ndx = np.asarray(x.as_array(), dtype=np.float32, order='C')
         x_p = Gradient_C.ndarray_as_c_pointer(ndx)
         
         return_val = False
@@ -329,7 +372,7 @@ class Gradient_C(LinearOperator):
                 
         #pass list of all arguments
         arg1 = [Gradient_C.ndarray_as_c_pointer(ndout[i]) for i in range(len(ndout))]
-        arg2 = [el for el in x.shape]
+        arg2 = [el for el in ndx.shape]
         args = arg1 + arg2 + [self.bnd_cond, 1, self.num_threads]
         self.fd(x_p, *args)
 
@@ -364,8 +407,11 @@ class Gradient_C(LinearOperator):
         ndout = np.asarray(out.as_array(), dtype=np.float32, order='C')          
         out_p = Gradient_C.ndarray_as_c_pointer(ndout)
         
-        if self.split is False:
-            ndx = [el.as_array() for el in x.containers]
+        if self.split is False: 
+            if self.is2D:
+                ndx = [np.squeeze(el.as_array()) for el in x.containers]
+            else:
+                ndx = [el.as_array() for el in x.containers]
         else:
             ind = self.gm_domain.dimension_labels.index('channel')
             ndx = [el.as_array() for el in x.get_item(1).containers]
@@ -376,7 +422,7 @@ class Gradient_C(LinearOperator):
                 ndx[i]/=el
 
         arg1 = [Gradient_C.ndarray_as_c_pointer(ndx[i]) for i in range(self.ndim)]
-        arg2 = [el for el in out.shape]
+        arg2 = [el for el in ndx[0].shape]
         args = arg1 + arg2 + [self.bnd_cond, 0, self.num_threads]
 
         self.fd(out_p, *args)
@@ -388,4 +434,8 @@ class Gradient_C(LinearOperator):
                 ndx[i]*= el
                 
         if return_val is True:
-            return out
+            return out        
+
+
+
+   


### PR DESCRIPTION
Edit `FiniteDifferenceOperator` and `GradientOperator` classes to handle 
- SIRF data that have not `ImageGeometry` 
- and pseudo 3D data with e.g., (1, 10, 10) 