### PR TITLE
Dc properties

### DIFF
--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1839,21 +1839,10 @@ class DataContainer(object):
 
     def __getitem__(self, ind):
 
-        '''Allows python indexing for CIL DataContainer/ImageData/AcquisitionData'''
+        '''Allows python indexing for CIL DataContainer/ImageData/AcquisitionData with no metadata'''
 
         tmp = self.array[ind]
-
-        if len(tmp.shape) > 1:
-            if isinstance(self, ImageData):
-                return ImageData(tmp, geometry=ImageGeometry(*tmp.shape[::-1]))
-            elif isinstance(self, AcquisitionData):
-                return AcquisitionData(tmp, geometry=AcquisitionGeometry(*tmp.shape[::-1]))
-
-        else:
-            if isinstance(tmp, numpy.float32):
-                return tmp
-            else:
-                return VectorData(tmp, geometry=VectorGeometry(*tmp.shape))           
+        return DataContainer(tmp)         
 
     @shape.setter
     def shape(self, val):
@@ -2526,12 +2515,7 @@ class ImageData(DataContainer):
     @property
     def dimension_labels(self):
         return self.geometry.dimension_labels
-
-    
-    # def __getitem__(self, val):
-    #     tmp = self.array[val]
-    #     return ImageData(tmp)       
-  
+   
           
     @dimension_labels.setter
     def dimension_labels(self, val):
@@ -3098,6 +3082,3 @@ class DataOrder():
         else:
             raise ValueError("Expected dimension_label order {0}, got {1}.\nTry using `data.reorder('{2}')` to permute for {2}"
                  .format(order_requested, list(geometry.dimension_labels), engine))
-
-
-

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1832,6 +1832,29 @@ class DataContainer(object):
         '''Returns the shape of the  of the DataContainer'''
         return self.array.shape
 
+    @property
+    def ndim(self):
+        '''Returns the ndim of the  of the DataContainer'''
+        return self.array.ndim
+
+    def __getitem__(self, ind):
+
+        '''Allows python indexing for CIL DataContainer/ImageData/AcquisitionData'''
+
+        tmp = self.array[ind]
+
+        if len(tmp.shape) > 1:
+            if isinstance(self, ImageData):
+                return ImageData(tmp, geometry=ImageGeometry(*tmp.shape[::-1]))
+            elif isinstance(self, AcquisitionData):
+                return AcquisitionData(tmp, geometry=AcquisitionGeometry(*tmp.shape[::-1]))
+
+        else:
+            if isinstance(tmp, numpy.float32):
+                return tmp
+            else:
+                return VectorData(tmp, geometry=VectorGeometry(*tmp.shape))           
+
     @shape.setter
     def shape(self, val):
         print("Deprecated - shape will be set automatically")
@@ -2116,8 +2139,8 @@ class DataContainer(object):
         repres += "Number of dimensions: {0}\n".format(self.number_of_dimensions)
         repres += "Shape: {0}\n".format(self.shape)
         repres += "Axis labels: {0}\n".format(self.dimension_labels)
-        if representation:
-            repres += "Representation: \n{0}\n".format(self.array)
+        repres += "Representation: \n{0}\n".format(self.array[:5])
+
         return repres
         
     def get_data_axes_order(self,new_order=None):
@@ -2503,7 +2526,13 @@ class ImageData(DataContainer):
     @property
     def dimension_labels(self):
         return self.geometry.dimension_labels
-      
+
+    
+    # def __getitem__(self, val):
+    #     tmp = self.array[val]
+    #     return ImageData(tmp)       
+  
+          
     @dimension_labels.setter
     def dimension_labels(self, val):
         if val is not None:
@@ -2656,7 +2685,6 @@ class AcquisitionData(DataContainer):
             if force:
                 geometry_new = None
             else:
-                print(ve)
                 raise ValueError ("Unable to return slice of requested AcquisitionData. Use 'force=True' to return DataContainer instead.")
 
         #get new data
@@ -3070,3 +3098,6 @@ class DataOrder():
         else:
             raise ValueError("Expected dimension_label order {0}, got {1}.\nTry using `data.reorder('{2}')` to permute for {2}"
                  .format(order_requested, list(geometry.dimension_labels), engine))
+
+
+

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1832,11 +1832,6 @@ class DataContainer(object):
         '''Returns the shape of the  of the DataContainer'''
         return self.array.shape
 
-    @property
-    def ndim(self):
-        '''Returns the ndim of the  of the DataContainer'''
-        return self.array.ndim
-
     def __getitem__(self, ind):
 
         '''Allows python indexing for CIL DataContainer/ImageData/AcquisitionData with no metadata'''
@@ -1884,6 +1879,9 @@ class DataContainer(object):
         # finally copy the geometry
         if 'geometry' in kwargs.keys():
             self.geometry = kwargs['geometry']
+
+        # ndim for DataContainer
+        self.ndim = self.array.ndim    
         
     def get_dimension_size(self, dimension_label):
 
@@ -3082,3 +3080,8 @@ class DataOrder():
         else:
             raise ValueError("Expected dimension_label order {0}, got {1}.\nTry using `data.reorder('{2}')` to permute for {2}"
                  .format(order_requested, list(geometry.dimension_labels), engine))
+
+
+
+
+    

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -3080,8 +3080,3 @@ class DataOrder():
         else:
             raise ValueError("Expected dimension_label order {0}, got {1}.\nTry using `data.reorder('{2}')` to permute for {2}"
                  .format(order_requested, list(geometry.dimension_labels), engine))
-
-
-
-
-    

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1832,12 +1832,13 @@ class DataContainer(object):
         '''Returns the shape of the  of the DataContainer'''
         return self.array.shape
 
-    def __getitem__(self, ind):
+    def __getitem__(self, ind):    
 
         '''Allows python indexing for CIL DataContainer/ImageData/AcquisitionData with no metadata'''
 
-        tmp = self.array[ind]
-        return DataContainer(tmp)         
+        return DataContainer(self.array[ind], False)
+
+
 
     @shape.setter
     def shape(self, val):
@@ -1863,13 +1864,13 @@ class DataContainer(object):
                   **kwargs):
         '''Holds the data'''
         
-        if type(array) == numpy.ndarray:
+        try:
             if deep_copy:
                 self.array = array.copy()
             else:
                 self.array = array    
-        else:
-            raise TypeError('Array must be NumpyArray, passed {0}'\
+        except:
+            raise TypeError('Array like must be passed {0}'\
                             .format(type(array)))
 
         #Don't set for derived classes

--- a/Wrappers/Python/cil/optimisation/operators/FiniteDifferenceOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/FiniteDifferenceOperator.py
@@ -93,47 +93,51 @@ class FiniteDifferenceOperator(LinearOperator):
 
     def direct(self, x, out = None):
         
-        x_asarr = x.as_array()
-        
-        outnone = False
         if out is None:
-            outnone = True
-            ret = self.domain_geometry().allocate()
-            outa = ret.as_array()
-        else:
-            outa = out.as_array()
-            outa[:]=0     
+            out = self.domain_geometry().allocate()
+
+        # outnone = False
+        # if out is None:
+            # outnone = True
+            # ret = self.domain_geometry().allocate()
+        # else:
+            # pass
+            # outa = out.as_array()
+            # outa[:]=0     
 
         #######################################################################
         ##################### Forward differences #############################
         #######################################################################
                 
         if self.method == 'forward':  
-            
-            # interior nodes
-            np.subtract( x_asarr[tuple(self.get_slice(2, None))], \
-                             x_asarr[tuple(self.get_slice(1,-1))], \
-                             out = outa[tuple(self.get_slice(1, -1))])               
+
+            x[tuple(self.get_slice(2, None))].\
+                subtract(x[tuple(self.get_slice(1,-1))], \
+                    out = out[tuple(self.get_slice(1, -1))])             
 
             if self.boundary_condition == 'Neumann':
                 
                 # left boundary
-                np.subtract(x_asarr[tuple(self.get_slice(1,2))],\
-                            x_asarr[tuple(self.get_slice(0,1))],
-                            out = outa[tuple(self.get_slice(0,1))]) 
+
+                x[tuple(self.get_slice(1,2))].\
+                    subtract(x[tuple(self.get_slice(0,1))], \
+                        out = out[tuple(self.get_slice(0,1))]) 
                 
                 
             elif self.boundary_condition == 'Periodic':
                 
                 # left boundary
-                np.subtract(x_asarr[tuple(self.get_slice(1,2))],\
-                            x_asarr[tuple(self.get_slice(0,1))],
-                            out = outa[tuple(self.get_slice(0,1))])  
+
+                x[tuple(self.get_slice(1,2))].\
+                    subtract([tuple(self.get_slice(0,1))], \
+                        out = out[tuple(self.get_slice(0,1))]) 
                 
                 # right boundary
-                np.subtract(x_asarr[tuple(self.get_slice(0,1))],\
-                            x_asarr[tuple(self.get_slice(-1,None))],
-                            out = outa[tuple(self.get_slice(-1,None))])  
+
+                x[tuple(self.get_slice(0,1))].\
+                    subtract([tuple(self.get_slice(-1,None))], \
+                        out = out[tuple(self.get_slice(-1,None))])   
+
                 
             else:
                 raise ValueError('Not implemented')                
@@ -222,11 +226,12 @@ class FiniteDifferenceOperator(LinearOperator):
                 raise ValueError('Not implemented')                
         
         if self.voxel_size != 1.0:
-            outa /= self.voxel_size  
+            out /= self.voxel_size  
 
-        if outnone:                  
-            ret.fill(outa)
-            return ret                
+        # if outnone:                  
+        #     # ret.fill(outa)
+        #     return ret       
+        return out         
                  
         
     def adjoint(self, x, out=None):


### PR DESCRIPTION
Adds missing properties from DataContainers:

1) ndim
2) Python slicing with no metadata. This is different from `subset` method, since no geometry information is used. However, we can use easily to wrap dask arrays.
3) Representation is allowed when printing a `DataContainer`

-- I can understand what is `labels` [here](https://github.com/TomographicImaging/CIL/blob/master/Wrappers/Python/cil/framework/framework.py#L1828)

**Example**

```python
    import dask.array as da
    from cil.framework import ImageGeometry

    ig = ImageGeometry(voxel_num_y=3, voxel_num_x=2) 
    x = ig.allocate('random')
    x_dask = da.from_array(x)

    print(x[0])
    print(x[0:1,1:2])
    print(x_dask)
```

```bash
Number of dimensions: 1
Shape: (2,)
Axis labels: ('dimension_00',)
Representation: 
[0.8609546 0.9744223]

Number of dimensions: 2
Shape: (1, 1)
Axis labels: ('dimension_00', 'dimension_01')
Representation: 
[[0.9744223]]

dask.array<array, shape=(3, 2), dtype=float32, chunksize=(3, 2), chunktype=__main__.DataContainer>
```
