### PR TITLE
Agnostic dc

### DIFF
--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1856,14 +1856,13 @@ class DataContainer(object):
                   **kwargs):
         '''Holds the data'''
         
-        if type(array) == numpy.ndarray:
+        try:
             if deep_copy:
                 self.array = array.copy()
             else:
                 self.array = array    
-        else:
-            raise TypeError('Array must be NumpyArray, passed {0}'\
-                            .format(type(array)))
+        except:
+            raise AttributeError("ImageData requires an Array type with shape, ndim and dtype, {} is passed".format(type(array)))  
 
         #Don't set for derived classes
         if type(self) is DataContainer:
@@ -2521,7 +2520,7 @@ class ImageData(DataContainer):
         dtype = kwargs.get('dtype', numpy.float32)
 
         if geometry is None:
-            raise AttributeError("ImageGeometry requires a geometry")
+            raise AttributeError("ImageData requires a geometry, {} is passed ".format(type(geometry)))
 
         labels = kwargs.get('dimension_labels', None)
         if labels is not None and labels != geometry.dimension_labels:
@@ -2530,11 +2529,9 @@ class ImageData(DataContainer):
         if array is None:                                   
             array = numpy.empty(geometry.shape, dtype=dtype)
         elif issubclass(type(array) , DataContainer):
-            array = array.as_array()
-        elif issubclass(type(array) , numpy.ndarray):
-            pass
-        else:
-            raise TypeError('array must be a CIL type DataContainer or numpy.ndarray got {}'.format(type(array)))
+            array = array.as_array()        
+        elif not all(getattr(array, attrib) for attrib in ["shape", "ndim","dtype"]):
+            raise AttributeError("ImageData requires an Array type with shape, ndim and dtype, {} is passed".format(type(array)))  
             
         if array.shape != geometry.shape:
             raise ValueError('Shape mismatch {} {}'.format(array.shape, geometry.shape))
@@ -2618,12 +2615,10 @@ class AcquisitionData(DataContainer):
         if array is None:                                   
             array = numpy.empty(geometry.shape, dtype=dtype)
         elif issubclass(type(array) , DataContainer):
-            array = array.as_array()
-        elif issubclass(type(array) , numpy.ndarray):
-            pass
-        else:
-            raise TypeError('array must be a CIL type DataContainer or numpy.ndarray got {}'.format(type(array)))
-            
+            array = array.as_array()        
+        elif not all(getattr(array, attrib) for attrib in ["shape", "ndim","dtype"]):
+            raise AttributeError("ImageData requires an Array type with shape, ndim and dtype, {} is passed".format(type(array)))  
+                       
         if array.shape != geometry.shape:
             raise ValueError('Shape mismatch got {} expected {}'.format(array.shape, geometry.shape))
 
@@ -3070,3 +3065,5 @@ class DataOrder():
         else:
             raise ValueError("Expected dimension_label order {0}, got {1}.\nTry using `data.reorder('{2}')` to permute for {2}"
                  .format(order_requested, list(geometry.dimension_labels), engine))
+
+

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1871,6 +1871,9 @@ class DataContainer(object):
         # finally copy the geometry
         if 'geometry' in kwargs.keys():
             self.geometry = kwargs['geometry']
+
+        # ndim for DataContainer
+        self.ndim = self.array.ndim    
         
     def get_dimension_size(self, dimension_label):
 
@@ -3065,5 +3068,32 @@ class DataOrder():
         else:
             raise ValueError("Expected dimension_label order {0}, got {1}.\nTry using `data.reorder('{2}')` to permute for {2}"
                  .format(order_requested, list(geometry.dimension_labels), engine))
+
+
+if __name__ == "__main__":
+
+    from cil.framework import ImageData, ImageGeometry
+    import cupy
+    import numpy
+
+    x_np = numpy.random.rand(3,3)
+    x_cp = cupy.random.rand(3,3)
+
+    x_np_DC = DataContainer(x_np)
+    x_cp_DC = DataContainer(x_cp)
+
+    print(type(x_np_DC), type(x_np_DC.array))
+    print(type(x_cp_DC), type(x_cp_DC.array))
+
+    ig = ImageGeometry(3,3)
+    x_np_ID = ImageData(x_np, geometry = ig)
+    x_cp_ID = ImageData(x_cp, geometry = ig)
+
+    print(type(x_np_ID), type(x_np_ID.array))
+    print(type(x_cp_ID), type(x_cp_ID.array))    
+
+
+
+
 
 


### PR DESCRIPTION
- Make `DataContainer`>=`ImageData`, `AcquisitionData` **Array** agnostic. 
- `shape`, `dtype`, `ndim` are required
-  `ndim` is an `DataContainer` attribute

* Following code is a `numpy`, `cupy` example. Adding `__getitem__` will allow `Dask.array` to be used.


``` python
    from cil.framework import ImageData, AcquisitionData, ImageGeometry
    import cupy
    import numpy

    x_np = numpy.random.rand(3,3)
    x_cp = cupy.random.rand(3,3)

    x_np_DC = DataContainer(x_np)
    x_cp_DC = DataContainer(x_cp)

    print(type(x_np_DC), type(x_np_DC.array))
    print(type(x_cp_DC), type(x_cp_DC.array))

    ig = ImageGeometry(3,3)
    x_np_ID = ImageData(x_np, geometry = ig)
    x_cp_ID = ImageData(x_cp, geometry = ig)

    print(type(x_np_ID), type(x_np_ID.array))
    print(type(x_cp_ID), type(x_cp_ID.array))    

    x_np_AD = AcquisitionData(x_np, geometry = ig)
    x_cp_AD = AcquisitionData(x_cp, geometry = ig)

    print(type(x_np_AD), type(x_np_AD.array))
    print(type(x_cp_AD), type(x_cp_AD.array))   

```

```bash
<class '__main__.DataContainer'> <class 'numpy.ndarray'>
<class '__main__.DataContainer'> <class 'cupy.core.core.ndarray'>
<class 'cil.framework.framework.ImageData'> <class 'numpy.ndarray'>
<class 'cil.framework.framework.ImageData'> <class 'cupy.core.core.ndarray'>
/media/newhd/vaggelis/CCPi/tmp_CIL_devel/Wrappers/Python/cil/framework/framework.py:2608: DeprecationWarning: Direct invocation is deprecated and will be removed in following version. Use allocate from AcquisitionGeometry instead
  DeprecationWarning)
<class '__main__.AcquisitionData'> <class 'numpy.ndarray'>
<class '__main__.AcquisitionData'> <class 'cupy.core.core.ndarray'>
```