### PR TITLE
Cil new docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
 sphinx_rtd_theme
+sphinxcontrib-bibtex
+pydata_sphinx_theme
 numpy
 scipy
 matplotlib >=3.3.0,<=3.4.2 # temporary fix due to issue with installing matplotlib version 3.4.3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,10 +91,9 @@ html_theme = 'pydata_sphinx_theme'
 # documentation.
 #
 html_theme_options = {
-    "github_url": "https://github.com/TomographicImaging/CIL",
     "show_prev_next": False,
-    "navbar_end": ["search-field.html", "navbar-icon-links.html"],
-    "navbar_align": "left"
+    "navbar_end": ["navbar-icon-links.html","search-field.html"],
+    "navbar_align": "right"
 }
 html_sidebars = {
     "**": [],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,12 +41,14 @@ release = version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.napoleon',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
+    'sphinxcontrib.bibtex'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -82,7 +84,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -187,3 +189,9 @@ epub_exclude_files = ['search.html']
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# Add bibtex files and style
+bibtex_bibfiles = ['refs.bib']
+bibtex_encoding = 'latin'
+bibtex_reference_style = 'label'
+bibtex_default_style = 'plain'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,7 @@ html_theme_options = {
     "github_url": "https://github.com/TomographicImaging/CIL",
     "show_prev_next": False,
     "navbar_end": ["search-field.html", "navbar-icon-links.html"],
+    "navbar_align": "left"
 }
 html_sidebars = {
     "**": [],

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,7 +90,14 @@ html_theme = 'pydata_sphinx_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "github_url": "https://github.com/TomographicImaging/CIL",
+    "show_prev_next": False,
+    "navbar_end": ["search-field.html", "navbar-icon-links.html"],
+}
+html_sidebars = {
+    "**": [],
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,15 +90,10 @@ html_theme = 'pydata_sphinx_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {
-    "show_prev_next": False,
-    "navbar_end": ["navbar-icon-links.html","search-field.html"],
-    "navbar_align": "right"
-}
 html_sidebars = {
-    "**": [],
+   '**': ['globaltoc.html', 'sourcelink.html', 'searchbox.html'],
+   'using/windows': ['windowssidebar.html', 'searchbox.html'],
 }
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -2,7 +2,7 @@ Developer's guide
 #################
 
 The Core Imaging Library follows the `NumpyDoc <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
-style with `PyData Sphinx html theme <https://pydata-sphinx-theme.readthedocs.io/en/latest/>`_.
+style with the `PyData Sphinx html theme <https://pydata-sphinx-theme.readthedocs.io/en/latest/>`_.
 
 When contributing your code please refer to `this <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ link 
 for docstring formatting and this rendered `example <https://numpydoc.readthedocs.io/en/latest/example.html#example>`_ .

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -1,4 +1,12 @@
 Developer's guide
 #################
 
-When contributing your code please refer to `this <https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html#the-sphinx-docstring-format>`_ link for docstring formatting.
+The Core Imaging Library follows the `NumpyDoc <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
+style with `PyData Sphinx html theme <https://pydata-sphinx-theme.readthedocs.io/en/latest/>`_.
+
+When contributing your code please refer to `this <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ link 
+for docstring formatting and this rendered `example <https://numpydoc.readthedocs.io/en/latest/example.html#example>`_ .
+
+
+
+

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,0 +1,76 @@
+@Article{CP2011,
+author={Chambolle, Antonin
+and Pock, Thomas},
+title={A First-Order Primal-Dual Algorithm for Convex Problems with Applications to Imaging},
+journal={Journal of Mathematical Imaging and Vision},
+year={2011},
+month={May},
+day={01},
+volume={40},
+number={1},
+pages={120-145},
+abstract={In this paper we study a first-order primal-dual algorithm for non-smooth convex optimization problems with known saddle-point structure. We prove convergence to a saddle-point with rate O(1/N) in finite dimensions for the complete class of problems. We further show accelerations of the proposed algorithm to yield improved rates on problems with some degree of smoothness. In particular we show that we can achieve O(1/N2) convergence on problems, where the primal or the dual objective is uniformly convex, and we can show linear convergence, i.e. O($\omega$N) for some $\omega$∈(0,1), on smooth problems. The wide applicability of the proposed algorithm is demonstrated on several imaging problems such as image denoising, image deconvolution, image inpainting, motion estimation and multi-label image segmentation.},
+issn={1573-7683},
+doi={10.1007/s10851-010-0251-1},
+url={https://doi.org/10.1007/s10851-010-0251-1}
+}
+
+
+@article{EZXC2010,
+author = {Esser, Ernie and Zhang, Xiaoqun and Chan, Tony F.},
+title = {A General Framework for a Class of First Order Primal-Dual Algorithms for Convex Optimization in Imaging Science},
+journal = {SIAM Journal on Imaging Sciences},
+volume = {3},
+number = {4},
+pages = {1015-1046},
+year = {2010},
+doi = {10.1137/09076934X},
+
+URL = { 
+        https://doi.org/10.1137/09076934X
+    
+},
+eprint = { 
+        https://doi.org/10.1137/09076934X
+    
+}
+
+}
+
+
+
+@article{Papoutsellis_et_al_2021,
+author = {Papoutsellis, Evangelos  and Ametova, Evelina  and Delplancke, Claire  and Fardell, Gemma  and J\"{o}rgensen, Jakob S.  and Pasca, Edoardo  and Turner, Martin  and Warr, Ryan  and Lionheart, William R. B.  and Withers, Philip J. },
+title = {Core Imaging Library - Part II: multichannel reconstruction for dynamic and spectral tomography},
+journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
+volume = {379},
+number = {2204},
+pages = {20200193},
+year = {2021},
+doi = {10.1098/rsta.2020.0193},
+
+URL = {https://royalsocietypublishing.org/doi/abs/10.1098/rsta.2020.0193},
+eprint = {https://royalsocietypublishing.org/doi/pdf/10.1098/rsta.2020.0193}
+,
+    abstract = { The newly developed core imaging library (CIL) is a flexible plug and play library for tomographic imaging with a specific focus on iterative reconstruction. CIL provides building blocks for tailored regularized reconstruction algorithms and explicitly supports multichannel tomographic data. In the first part of this two-part publication, we introduced the fundamentals of CIL. This paper focuses on applications of CIL for multichannel data, e.g. dynamic and spectral. We formalize different optimization problems for colour processing, dynamic and hyperspectral tomography and demonstrate CILβs capabilities for designing state-of-the-art reconstruction methods through case studies and code snapshots. This article is part of the theme issue βSynergistic tomographic image reconstruction: part 2β. }
+}
+
+
+
+
+
+@article{Jorgensen_et_al_2021,
+author = {J\"{o}rgensen, J. S.  and Ametova, E.  and Burca, G.  and Fardell, G.  and Papoutsellis, E.  and Pasca, E.  and Thielemans, K.  and Turner, M.  and Warr, R.  and Lionheart, W. R. B.  and Withers, P. J. },
+title = {Core Imaging Library - Part I: a versatile Python framework for tomographic imaging},
+journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
+volume = {379},
+number = {2204},
+pages = {20200192},
+year = {2021},
+doi = {10.1098/rsta.2020.0192},
+
+URL = {https://royalsocietypublishing.org/doi/abs/10.1098/rsta.2020.0192},
+eprint = {https://royalsocietypublishing.org/doi/pdf/10.1098/rsta.2020.0192}
+,
+    abstract = { We present the Core Imaging Library (CIL), an open-source Python framework for tomographic imaging with particular emphasis on reconstruction of challenging datasets. Conventional filtered back-projection reconstruction tends to be insufficient for highly noisy, incomplete, non-standard or multi-channel data arising for example in dynamic, spectral and in situ tomography. CIL provides an extensive modular optimization framework for prototyping reconstruction methods including sparsity and total variation regularization, as well as tools for loading, preprocessing and visualizing tomographic data. The capabilities of CIL are demonstrated on a synchrotron example dataset and three challenging cases spanning golden-ratio neutron tomography, cone-beam X-ray laminography and positron emission tomography. This article is part of the theme issue βSynergistic tomographic image reconstruction: part 2β. }
+}


### PR DESCRIPTION
This PR adds the 

- `sphinx.ext.napoleon`
- `pydata_sphinx_theme`
- `sphinxcontrib-bibtex`

It allows to use both reST and numpy/google doc format and also use bibtex references.

Close #866 