### PR TITLE
Fix condition for publishing docs

### DIFF
--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -57,7 +57,7 @@ jobs:
   docs_publish:
     needs: docs_build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     steps:
     - name: Download artifact of the html output.
       uses: actions/download-artifact@v2


### PR DESCRIPTION
Previously was publishing on push to `main`, corrected this to be `master`.