### PR TITLE
TIGRE fp geometry

### DIFF
--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1244,7 +1244,7 @@ class Panel(object):
             if pixel_size_temp[0] <= 0 or pixel_size_temp[1] <= 0:
                 raise ValueError('pixel_size (x,y) at must be > (0.,0.). Got {}'.format(pixel_size_temp)) 
 
-        self.__pixel_size = numpy.array(pixel_size_temp, dtype=numpy.float32)
+        self.__pixel_size = numpy.array(pixel_size_temp)
 
     @property
     def origin(self):
@@ -1270,7 +1270,7 @@ class Panel(object):
         if not isinstance(other, self.__class__):
             return False
         
-        if numpy.all(self.pixel_size == other.pixel_size) \
+        if numpy.array_equal(self.num_pixels, other.num_pixels) \
             and numpy.allclose(self.pixel_size, other.pixel_size) \
             and self.origin == other.origin:   
             return True

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1209,7 +1209,7 @@ class Panel(object):
         if num_pixels_temp[0] < 1 or num_pixels_temp[1] < 1:
             raise ValueError('num_pixels (x,y) must be >= (1,1). Got {}'.format(num_pixels_temp))
         else:
-            self.__num_pixels = num_pixels_temp
+            self.__num_pixels = numpy.array(num_pixels_temp, dtype=numpy.int16)
 
     @property
     def pixel_size(self):
@@ -1244,7 +1244,7 @@ class Panel(object):
             if pixel_size_temp[0] <= 0 or pixel_size_temp[1] <= 0:
                 raise ValueError('pixel_size (x,y) at must be > (0.,0.). Got {}'.format(pixel_size_temp)) 
 
-        self.__pixel_size = pixel_size_temp
+        self.__pixel_size = numpy.array(pixel_size_temp, dtype=numpy.float32)
 
     @property
     def origin(self):

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1270,7 +1270,7 @@ class Panel(object):
         if not isinstance(other, self.__class__):
             return False
         
-        if self.num_pixels == other.num_pixels \
+        if numpy.equal(self.pixel_size, other.pixel_size) \
             and numpy.allclose(self.pixel_size, other.pixel_size) \
             and self.origin == other.origin:   
             return True

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1270,7 +1270,7 @@ class Panel(object):
         if not isinstance(other, self.__class__):
             return False
         
-        if numpy.equal(self.pixel_size, other.pixel_size) \
+        if numpy.all(self.pixel_size == other.pixel_size) \
             and numpy.allclose(self.pixel_size, other.pixel_size) \
             and self.origin == other.origin:   
             return True

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -186,13 +186,13 @@ class Test_AcquisitionGeometry(unittest.TestCase):
 
         #default
         AG.set_panel([1000,2000])
-        self.assertEqual(AG.config.panel.num_pixels, [1000,2000])
-        self.assertEqual(AG.config.panel.pixel_size, [1.,1.])
+        numpy.testing.assert_array_equal(AG.config.panel.num_pixels, [1000,2000])
+        numpy.testing.assert_array_almost_equal(AG.config.panel.pixel_size, [1,1])
 
         #values
         AG.set_panel([1000,2000],[0.1,0.2])
-        self.assertEqual(AG.config.panel.num_pixels, [1000,2000])
-        self.assertEqual(AG.config.panel.pixel_size, [0.1,0.2])
+        numpy.testing.assert_array_equal(AG.config.panel.num_pixels, [1000,2000])
+        numpy.testing.assert_array_almost_equal(AG.config.panel.pixel_size, [0.1,0.2])
 
         #set 2D panel with 3D geometry
         with self.assertRaises(ValueError):


### PR DESCRIPTION
A TIGRE issue with the linear interpolation forward projector means the detector must be defined outside the reconstruction volume, or the ray is clipped.

This fixes it in our wrappers for cone-beam if the detector is set up at the origin then it is moved (along the source -> detector vector) and pixel sizes are scaled to correspond.

See TIGRE issue:
https://github.com/CERN/TIGRE/issues/353