### PR TITLE
added sapyb and unittests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 2x.x.x
+  - added sapyb and deprecated axpby
+
 * 21.3.1
   - Added matplotlib version dependency to conda recipe
   - Fixed TIGRE wrappers for geometry with a virtual detector

--- a/Wrappers/Python/cil/framework/BlockDataContainer.py
+++ b/Wrappers/Python/cil/framework/BlockDataContainer.py
@@ -242,7 +242,7 @@ class BlockDataContainer(object):
 
     def axpby(self, a, b, y, out, dtype=numpy.float32, num_threads = NUM_THREADS):
         '''Deprecated method. Alias of sapyb'''
-        return self.sapyb(a,b,y,out,dtype,num_threads)
+        return self.sapyb(a,y,b,out,dtype,num_threads)
 
 
 

--- a/Wrappers/Python/cil/framework/BlockDataContainer.py
+++ b/Wrappers/Python/cil/framework/BlockDataContainer.py
@@ -212,7 +212,7 @@ class BlockDataContainer(object):
         else:
             return self.binary_operations(BlockDataContainer.MINIMUM, other, *args, **kwargs)
 
-    def axpby(self, a, b, y, out, dtype=numpy.float32, num_threads = NUM_THREADS):
+    def sapyb(self, a, y, b, out, dtype=numpy.float32, num_threads = NUM_THREADS):
         r'''performs axpby element-wise on the BlockDataContainer containers
         
         Does the operation .. math:: a*x+b*y and stores the result in out, where x is self
@@ -222,11 +222,28 @@ class BlockDataContainer(object):
         :param y: compatible (Block)DataContainer
         :param out: (Block)DataContainer to store the result
         :param dtype: optional, data type of the DataContainers
+
+
+        Example:
+        a = 2
+        b = 3
+        ig = ImageGeometry(10,11)
+        x = ig.allocate(1)
+        y = ig.allocate(2)
+        bdc1 = BlockDataContainer(2*x, y)
+        bdc2 = BlockDataContainer(x, 2*y)
+        out = bdc1.sapyb(a,bdc2,b)
         '''
         if out is None:
             raise ValueError("out container cannot be None")
         kwargs = {'a':a, 'b':b, 'out':out, 'dtype': dtype, 'num_threads': NUM_THREADS}
         self.binary_operations(BlockDataContainer.AXPBY, y, **kwargs)
+
+
+    def axpby(self, a, b, y, out, dtype=numpy.float32, num_threads = NUM_THREADS):
+        '''Deprecated method. Alias of sapyb'''
+        return self.sapyb(a,b,y,out,dtype,num_threads)
+
 
 
     def binary_operations(self, operation, other, *args, **kwargs):

--- a/Wrappers/Python/cil/framework/BlockDataContainer.py
+++ b/Wrappers/Python/cil/framework/BlockDataContainer.py
@@ -48,7 +48,7 @@ class BlockDataContainer(object):
     MULTIPLY  = 'multiply'
     DIVIDE    = 'divide'
     POWER     = 'power'
-    AXPBY     = 'axpby'
+    SAPYB     = 'sapyb'
     MAXIMUM   = 'maximum'
     MINIMUM   = 'minimum'
     ABS       = 'abs'
@@ -212,7 +212,7 @@ class BlockDataContainer(object):
         else:
             return self.binary_operations(BlockDataContainer.MINIMUM, other, *args, **kwargs)
 
-    def sapyb(self, a, y, b, out, dtype=numpy.float32, num_threads = NUM_THREADS):
+    def sapyb(self, a, y, b, out, num_threads = NUM_THREADS):
         r'''performs axpby element-wise on the BlockDataContainer containers
         
         Does the operation .. math:: a*x+b*y and stores the result in out, where x is self
@@ -221,10 +221,11 @@ class BlockDataContainer(object):
         :param b: scalar
         :param y: compatible (Block)DataContainer
         :param out: (Block)DataContainer to store the result
-        :param dtype: optional, data type of the DataContainers
-
+        
 
         Example:
+        --------
+
         a = 2
         b = 3
         ig = ImageGeometry(10,11)
@@ -236,13 +237,13 @@ class BlockDataContainer(object):
         '''
         if out is None:
             raise ValueError("out container cannot be None")
-        kwargs = {'a':a, 'b':b, 'out':out, 'dtype': dtype, 'num_threads': NUM_THREADS}
-        self.binary_operations(BlockDataContainer.AXPBY, y, **kwargs)
+        kwargs = {'a':a, 'b':b, 'out':out, 'num_threads': NUM_THREADS}
+        self.binary_operations(BlockDataContainer.SAPYB, y, **kwargs)
 
 
     def axpby(self, a, b, y, out, dtype=numpy.float32, num_threads = NUM_THREADS):
         '''Deprecated method. Alias of sapyb'''
-        return self.sapyb(a,y,b,out,dtype,num_threads)
+        return self.sapyb(a,y,b,out,num_threads)
 
 
 
@@ -313,15 +314,15 @@ class BlockDataContainer(object):
                     op = el.maximum
                 elif operation == BlockDataContainer.MINIMUM:
                     op = el.minimum
-                elif operation == BlockDataContainer.AXPBY:
+                elif operation == BlockDataContainer.SAPYB:
                     if not isinstance(other, BlockDataContainer):
                         raise ValueError("{} cannot handle {}".format(operation, type(other)))
-                    op = el.axpby
+                    op = el.sapyb
                 else:
                     raise ValueError('Unsupported operation', operation)
 
                 if out is not None:
-                    if operation == BlockDataContainer.AXPBY:
+                    if operation == BlockDataContainer.SAPYB:
                         if isinstance(kw['a'], BlockDataContainer):
                             a = kw['a'].get_item(i)
                         else:
@@ -332,7 +333,7 @@ class BlockDataContainer(object):
                         else:
                             b = kw['b']
 
-                        el.axpby(a, b, ot,  out.get_item(i), dtype=kw['dtype'], num_threads=kw['num_threads'])
+                        el.sapyb(a, ot, b, out.get_item(i), num_threads=kw['num_threads'])
                     else:
                         kw['out'] = out.get_item(i)
                         op(ot, *args, **kw)
@@ -345,8 +346,8 @@ class BlockDataContainer(object):
         else:
             # try to do algebra with one DataContainer. Will raise error if not compatible
             kw = kwargs.copy()
-            if operation != BlockDataContainer.AXPBY:
-                # remove keyworded argument related to AXPBY
+            if operation != BlockDataContainer.SAPYB:
+                # remove keyworded argument related to SAPYB
                 for k in ['a','b','y', 'num_threads', 'dtype']:
                     if k in kw.keys():
                         kw.pop(k)
@@ -367,7 +368,7 @@ class BlockDataContainer(object):
                     op = el.maximum
                 elif operation == BlockDataContainer.MINIMUM:
                     op = el.minimum
-                elif operation == BlockDataContainer.AXPBY:
+                elif operation == BlockDataContainer.SAPYB:
 
                     if isinstance(kw['a'], BlockDataContainer):
                         a = kw['a'].get_item(i)
@@ -379,7 +380,7 @@ class BlockDataContainer(object):
                     else:
                         b = kw['b']
 
-                    el.axpby(a, b, other, out.get_item(i), kw['dtype'], kw['num_threads'])
+                    el.sapyb(a, other, b, out.get_item(i), kw['num_threads'])
 
                     # As axpyb cannot return anything we `continue` to skip the rest of the code block
                     continue

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2497,17 +2497,27 @@ class DataContainer(object):
         
         It will try to use the CIL C library and default to numpy operations, in case the C library does
         not handle the types.
+        
+        Example:
+        -------
+
+        a = 2
+        b = 3
+        ig = ImageGeometry(10,11)
+        x = ig.allocate(1)
+        y = ig.allocate(2)
+        out = x.sapyb(a,y,b)
         '''
-        do_numpy = False
+        use_c_lib = True
         ret_out = False
-        if self.dtype in [complex, numpy.complex, numpy.complex64]:
-            do_numpy = True
+        if self.dtype in numpy.sctypes['complex']:
+            use_c_lib = False
         
         if out is None:
             out = self * 0.
             ret_out = True
 
-        if do_numpy:
+        if not use_c_lib:
             ax = self * a
             y.multiply(b, out=out)
             out.add(ax, out=out)

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2482,7 +2482,7 @@ class DataContainer(object):
         return self.pixel_wise_binary(numpy.minimum, x2=x2, out=out, *args, **kwargs)
 
 
-    def sapyb(self, a, y, b, out=None, dtype=numpy.float32, num_threads=NUM_THREADS):
+    def sapyb(self, a, y, b, out=None, num_threads=NUM_THREADS):
         '''performs a*self + b * y. Can be done in-place
         
         Parameters
@@ -2492,7 +2492,6 @@ class DataContainer(object):
         b : multiplier for y, can be a number or a numpy array or a DataContainer
         out : return DataContainer, if None a new DataContainer is returned, default None. 
             out can be self or y.
-        dtype : forces the output to the type, default numpy float32
         num_threads : number of threads to use during the calculation, using the CIL C library
         
         It will try to use the CIL C library and default to numpy operations, in case the C library does
@@ -2517,7 +2516,7 @@ class DataContainer(object):
         if out.dtype in [ numpy.float32, numpy.float64 ]:
             # handle with C-lib _axpby
             try:
-                self._axpby(a, b, y, out, dtype, num_threads)
+                self._axpby(a, b, y, out, out.dtype, num_threads)
                 if ret_out:
                     return out
                 return

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2483,14 +2483,15 @@ class DataContainer(object):
 
 
     def sapyb(self, a, y, b, out=None, dtype=numpy.float32, num_threads=NUM_THREADS):
-        '''performs a*self + b * y
+        '''performs a*self + b * y. It is inline safe
         
         Parameters
         ----------
         a : multiplier for self, can be a number or a numpy array or a DataContainer
         y : DataContainer 
         b : multiplier for y, can be a number or a numpy array or a DataContainer
-        out : return DataContainer, if None a new DataContainer is returned, default None
+        out : return DataContainer, if None a new DataContainer is returned, default None. 
+            out can be self or y.
         dtype : forces the output to the type, default numpy float32
         num_threads : number of threads to use during the calculation, using the CIL C library
         
@@ -2508,9 +2509,8 @@ class DataContainer(object):
 
         if do_numpy:
             ax = self * a
-            tmp = numpy.multiply(y, b)
-            tmp.add(ax, out=tmp)
-            out.fill(tmp)
+            y.multiply(b, out=out)
+            out.add(ax, out=out)
         else:
             self._axpby(a,b,y,out, dtype, num_threads)
 

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2596,9 +2596,9 @@ class DataContainer(object):
         if ndy.dtype != dtype:
             ndy = ndy.astype(dtype, casting='safe')
         if nda.dtype != dtype:
-            nda = nda.astype(dtype, casting='safe')
+            nda = nda.astype(dtype, casting='same_kind')
         if ndb.dtype != dtype:
-            ndb = ndb.astype(dtype, casting='safe')
+            ndb = ndb.astype(dtype, casting='same_kind')
 
         if dtype == numpy.float32:
             x_p = ndx.ctypes.data_as(c_float_p)

--- a/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
@@ -169,12 +169,12 @@ class SPDHG(Algorithm):
         # Gradient ascent for the dual variable
         # y_k = y_old[i] + sigma[i] * K[i] x
         y_k = self.operator[i].direct(self.x)
-        # if self._use_axpby:
-        #     y_k.axpby(self.sigma[i], 1., self.y_old[i], out=y_k)
-        # else:
-        #     y_k.multiply(self.sigma[i], out=y_k)
-        #     y_k.add(self.y_old[i], out=y_k)
-        y_k.sapyb(self.sigma[i], self.y_old[i], 1., out=y_k)
+        if self._use_axpby:
+            y_k.axpby(self.sigma[i], 1., self.y_old[i], out=y_k)
+        else:
+            y_k.multiply(self.sigma[i], out=y_k)
+            y_k.add(self.y_old[i], out=y_k)
+        # y_k.sapyb(self.sigma[i], self.y_old[i], 1., out=y_k)
             
         y_k = self.f[i].proximal_conjugate(y_k, self.sigma[i])
         
@@ -189,12 +189,12 @@ class SPDHG(Algorithm):
         # z = z + x_tmp
         self.z.add(self.x_tmp, out =self.z)
         # zbar = z + (theta/p[i]) * x_tmp
-        # if self._use_axpby:
-        #     self.z.axpby(1., self.theta / self.prob[i], self.x_tmp, out = self.zbar)
-        # else:
-        #     self.x_tmp.multiply(self.theta / self.prob[i], out=self.x_tmp)
-        #     self.z.add(self.x_tmp, out=self.zbar)
-        self.z.sapyb(1., self.x_tmp, self.theta / self.prob[i], out = self.zbar)
+        if self._use_axpby:
+            self.z.axpby(1., self.theta / self.prob[i], self.x_tmp, out = self.zbar)
+        else:
+            self.x_tmp.multiply(self.theta / self.prob[i], out=self.x_tmp)
+            self.z.add(self.x_tmp, out=self.zbar)
+        # self.z.sapyb(1., self.x_tmp, self.theta / self.prob[i], out = self.zbar)
         
         # save previous iteration
         self.save_previous_iteration(i, y_k)

--- a/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
@@ -174,7 +174,7 @@ class SPDHG(Algorithm):
         # else:
         #     y_k.multiply(self.sigma[i], out=y_k)
         #     y_k.add(self.y_old[i], out=y_k)
-        y_k.sapyb(self.sigma[i], 1., self.y_old[i], out=y_k)
+        y_k.sapyb(self.sigma[i], self.y_old[i], 1., out=y_k)
             
         y_k = self.f[i].proximal_conjugate(y_k, self.sigma[i])
         
@@ -194,7 +194,7 @@ class SPDHG(Algorithm):
         # else:
         #     self.x_tmp.multiply(self.theta / self.prob[i], out=self.x_tmp)
         #     self.z.add(self.x_tmp, out=self.zbar)
-        self.z.sapyb(1., self.theta / self.prob[i], self.x_tmp, out = self.zbar)
+        self.z.sapyb(1., self.x_tmp, self.theta / self.prob[i], out = self.zbar)
         
         # save previous iteration
         self.save_previous_iteration(i, y_k)

--- a/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
@@ -174,7 +174,6 @@ class SPDHG(Algorithm):
         else:
             y_k.multiply(self.sigma[i], out=y_k)
             y_k.add(self.y_old[i], out=y_k)
-        # y_k.sapyb(self.sigma[i], self.y_old[i], 1., out=y_k)
             
         y_k = self.f[i].proximal_conjugate(y_k, self.sigma[i])
         
@@ -194,7 +193,6 @@ class SPDHG(Algorithm):
         else:
             self.x_tmp.multiply(self.theta / self.prob[i], out=self.x_tmp)
             self.z.add(self.x_tmp, out=self.zbar)
-        # self.z.sapyb(1., self.x_tmp, self.theta / self.prob[i], out = self.zbar)
         
         # save previous iteration
         self.save_previous_iteration(i, y_k)

--- a/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/SPDHG.py
@@ -169,11 +169,12 @@ class SPDHG(Algorithm):
         # Gradient ascent for the dual variable
         # y_k = y_old[i] + sigma[i] * K[i] x
         y_k = self.operator[i].direct(self.x)
-        if self._use_axpby:
-            y_k.axpby(self.sigma[i], 1., self.y_old[i], out=y_k)
-        else:
-            y_k.multiply(self.sigma[i], out=y_k)
-            y_k.add(self.y_old[i], out=y_k)
+        # if self._use_axpby:
+        #     y_k.axpby(self.sigma[i], 1., self.y_old[i], out=y_k)
+        # else:
+        #     y_k.multiply(self.sigma[i], out=y_k)
+        #     y_k.add(self.y_old[i], out=y_k)
+        y_k.sapyb(self.sigma[i], 1., self.y_old[i], out=y_k)
             
         y_k = self.f[i].proximal_conjugate(y_k, self.sigma[i])
         
@@ -188,11 +189,12 @@ class SPDHG(Algorithm):
         # z = z + x_tmp
         self.z.add(self.x_tmp, out =self.z)
         # zbar = z + (theta/p[i]) * x_tmp
-        if self._use_axpby:
-            self.z.axpby(1., self.theta / self.prob[i], self.x_tmp, out = self.zbar)
-        else:
-            self.x_tmp.multiply(self.theta / self.prob[i], out=self.x_tmp)
-            self.z.add(self.x_tmp, out=self.zbar)
+        # if self._use_axpby:
+        #     self.z.axpby(1., self.theta / self.prob[i], self.x_tmp, out = self.zbar)
+        # else:
+        #     self.x_tmp.multiply(self.theta / self.prob[i], out=self.x_tmp)
+        #     self.z.add(self.x_tmp, out=self.zbar)
+        self.z.sapyb(1., self.theta / self.prob[i], self.x_tmp, out = self.zbar)
         
         # save previous iteration
         self.save_previous_iteration(i, y_k)

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -931,6 +931,105 @@ class TestDataContainer(unittest.TestCase):
         res = numpy.zeros_like(d1.as_array())
         numpy.testing.assert_array_equal(res, out.as_array())
 
+
+    def test_sapyb_datacontainer_f(self):
+        print ("test sapyb")
+        #a vec, b vec
+        #daxpby
+        ig = ImageGeometry(10,10)                                               
+        d1 = ig.allocate(dtype=numpy.float32)                                                     
+        d2 = ig.allocate(dtype=numpy.float32)   
+        a = ig.allocate(dtype=numpy.float32)                                                  
+        b = ig.allocate(dtype=numpy.float32)         
+
+        d1.fill(numpy.asarray(numpy.arange(1,101).reshape(10,10), dtype=numpy.float32))
+        d2.fill(numpy.asarray(numpy.arange(1,101).reshape(10,10), dtype=numpy.float32))
+        a.fill(1.0/d1.as_array())                                                  
+        b.fill(-1.0/d2.as_array())   
+
+        out = ig.allocate(-1,dtype=numpy.float32)                                                 
+        # equals to 1 + -1 = 0
+        out = d1.sapyb(a,d2,b)
+        res = numpy.zeros_like(d1.as_array())
+        numpy.testing.assert_array_equal(res, out.as_array())
+
+        out.fill(0)
+        d1.sapyb(a,d2,b, out)
+        res = numpy.zeros_like(d1.as_array())
+        numpy.testing.assert_array_equal(res, out.as_array())
+
+    def test_sapyb_scalar_f(self):
+        print ("test sapyb")
+        #a vec, b vec
+        #daxpby
+        ig = ImageGeometry(10,10)                                               
+        d1 = ig.allocate(1, dtype=numpy.float32)                                                     
+        d2 = ig.allocate(2, dtype=numpy.float32)   
+        a = 2.
+        b = -1.
+
+        out = ig.allocate(-1,dtype=numpy.float32)                                                 
+        # equals to 2*[1] + -1*[2] = 0
+        out = d1.sapyb(a,d2,b)
+        res = numpy.zeros_like(d1.as_array())
+        numpy.testing.assert_array_equal(res, out.as_array())
+
+        out.fill(0)
+        d1.sapyb(a,d2,b, out)
+        numpy.testing.assert_array_equal(res, out.as_array())
+
+    def test_sapyb_scalar_c(self):
+        print ("test sapyb")
+        #a vec, b vec
+        #daxpby
+        ig = ImageGeometry(10,10)                                               
+        d1 = ig.allocate(1, dtype=numpy.complex64)                                                     
+        d2 = ig.allocate(2, dtype=numpy.complex64)   
+        a = 2.+2j
+        b = -1.-1j
+
+        out = ig.allocate(-1,dtype=numpy.complex64)                                                 
+        # equals to (2+2j)*[1] + -(1+j)*[2] = 0
+        out = d1.sapyb(a,d2,b)
+        res = numpy.zeros_like(d1.as_array())
+        numpy.testing.assert_array_equal(res, out.as_array())
+
+        out.fill(0)
+        d1.sapyb(a,d2,b, out)
+        numpy.testing.assert_array_equal(res, out.as_array())
+
+    def test_sapyb_datacontainer_c(self):
+        print ("test sapyb")
+        #a vec, b vec
+        #daxpby
+        ig = ImageGeometry(10,10)                                               
+        d1 = ig.allocate(dtype=numpy.complex64)                                                     
+        d2 = ig.allocate(dtype=numpy.complex64)   
+        a = ig.allocate(dtype=numpy.complex64)                                                  
+        b = ig.allocate(dtype=numpy.complex64)         
+
+        arr = numpy.empty(ig.shape, dtype=numpy.complex64)
+        arr.real = numpy.asarray(numpy.arange(1,101).reshape(10,10), dtype=numpy.float32)
+        arr.imag = numpy.asarray(numpy.arange(1,101).reshape(10,10), dtype=numpy.float32)
+
+        d1.fill(arr)
+
+        arr.imag = -1* arr.imag
+        d2.fill(arr)
+
+        a.fill(d2.as_array())                                                  
+        b.fill(d1.as_array())   
+
+        out = ig.allocate(-1,dtype=numpy.complex64)
+        # equals to d1^ * d1 + d2^*d2 = d1**2 + d2**2 = 2* arr.norm = 2 * (arr.real **2 + arr.imag **2)
+        out = d1.sapyb(a,d2,b)
+        res = 2* (arr.real * arr.real + arr.imag * arr.imag)
+        numpy.testing.assert_array_equal(res, out.as_array())
+
+        out.fill(0)
+        d1.sapyb(a,d2,b, out)
+        numpy.testing.assert_array_equal(res, out.as_array())
+
     def test_min(self):
         print ("test min")
         ig = ImageGeometry(10,10)     

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -933,9 +933,8 @@ class TestDataContainer(unittest.TestCase):
 
 
     def test_sapyb_datacontainer_f(self):
-        print ("test sapyb")
         #a vec, b vec
-        #daxpby
+        
         ig = ImageGeometry(10,10)                                               
         d1 = ig.allocate(dtype=numpy.float32)                                                     
         d2 = ig.allocate(dtype=numpy.float32)   
@@ -959,9 +958,7 @@ class TestDataContainer(unittest.TestCase):
         numpy.testing.assert_array_equal(res, out.as_array())
 
     def test_sapyb_scalar_f(self):
-        print ("test sapyb")
-        #a vec, b vec
-        #daxpby
+        # a,b scalar
         ig = ImageGeometry(10,10)                                               
         d1 = ig.allocate(1, dtype=numpy.float32)                                                     
         d2 = ig.allocate(2, dtype=numpy.float32)   
@@ -978,10 +975,43 @@ class TestDataContainer(unittest.TestCase):
         d1.sapyb(a,d2,b, out)
         numpy.testing.assert_array_equal(res, out.as_array())
 
+        d1.sapyb(a,d2,b, out=d1)
+        numpy.testing.assert_array_equal(res, d1.as_array())
+
+        d1.fill(1)
+        d1.sapyb(a,d2,b, out=d2)
+        numpy.testing.assert_array_equal(res, d2.as_array())
+    
+    def test_sapyb_datacontainer_scalar_f(self):
+        #mix: a scalar and b DataContainer and a DataContainer and b scalar
+        ig = ImageGeometry(10,10)                                               
+        d1 = ig.allocate(1., dtype=numpy.complex64)                                                     
+        d2 = ig.allocate(2.,dtype=numpy.complex64)   
+        a = 2.+2j                                                
+        b = ig.allocate(-1.-1j, dtype=numpy.complex64)         
+
+
+        out = ig.allocate(-1,dtype=numpy.complex64)
+        # equals to (2+2j)*[1] + -(1+j)*[2] = 0
+        
+        out = d1.sapyb(a,d2,b)
+        res = ig.allocate(0, dtype=numpy.complex64)
+        numpy.testing.assert_array_equal(res.as_array(), out.as_array())
+
+        out.fill(-1)
+        d1.sapyb(a,d2,b, out)
+        numpy.testing.assert_array_equal(res.as_array(), out.as_array())
+
+        out = d2.sapyb(b,d1,a)
+        res = ig.allocate(0, dtype=numpy.complex64)
+        numpy.testing.assert_array_equal(res.as_array(), out.as_array())
+
+        out.fill(-1)
+        d2.sapyb(b,d1,a, out)
+        numpy.testing.assert_array_equal(res.as_array(), out.as_array())
+
     def test_sapyb_scalar_c(self):
-        print ("test sapyb")
-        #a vec, b vec
-        #daxpby
+        # a, b scalar
         ig = ImageGeometry(10,10)                                               
         d1 = ig.allocate(1, dtype=numpy.complex64)                                                     
         d2 = ig.allocate(2, dtype=numpy.complex64)   
@@ -998,10 +1028,16 @@ class TestDataContainer(unittest.TestCase):
         d1.sapyb(a,d2,b, out)
         numpy.testing.assert_array_equal(res, out.as_array())
 
+        d1.sapyb(a,d2,b, out=d1)
+        numpy.testing.assert_array_equal(res, d1.as_array())
+
+        d1.fill(1)
+        d1.sapyb(a,d2,b, out=d2)
+        numpy.testing.assert_array_equal(res, d2.as_array())
+
+
     def test_sapyb_datacontainer_c(self):
-        print ("test sapyb")
         #a vec, b vec
-        #daxpby
         ig = ImageGeometry(10,10)                                               
         d1 = ig.allocate(dtype=numpy.complex64)                                                     
         d2 = ig.allocate(dtype=numpy.complex64)   
@@ -1029,6 +1065,35 @@ class TestDataContainer(unittest.TestCase):
         out.fill(0)
         d1.sapyb(a,d2,b, out)
         numpy.testing.assert_array_equal(res, out.as_array())
+
+
+    def test_sapyb_datacontainer_scalar_c(self):
+        #mix: a scalar and b DataContainer and a DataContainer and b scalar
+        ig = ImageGeometry(10,10)                                               
+        d1 = ig.allocate(1., dtype=numpy.complex64)                                                     
+        d2 = ig.allocate(2.,dtype=numpy.complex64)   
+        a = 2.+2j                                                
+        b = ig.allocate(-1.-1j, dtype=numpy.complex64)         
+
+
+        out = ig.allocate(-1,dtype=numpy.complex64)
+        # equals to (2+2j)*[1] + -(1+j)*[2] = 0
+        
+        out = d1.sapyb(a,d2,b)
+        res = ig.allocate(0, dtype=numpy.complex64)
+        numpy.testing.assert_array_equal(res.as_array(), out.as_array())
+
+        out.fill(-1)
+        d1.sapyb(a,d2,b, out)
+        numpy.testing.assert_array_equal(res.as_array(), out.as_array())
+
+        out = d2.sapyb(b,d1,a)
+        res = ig.allocate(0, dtype=numpy.complex64)
+        numpy.testing.assert_array_equal(res.as_array(), out.as_array())
+
+        out.fill(-1)
+        d2.sapyb(b,d1,a, out)
+        numpy.testing.assert_array_equal(res.as_array(), out.as_array())
 
     def test_min(self):
         print ("test min")

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -1116,8 +1116,13 @@ class TestDataContainer(unittest.TestCase):
         numpy.testing.assert_array_equal(res, d1.as_array())
 
         d1.fill(1)
-        with self.assertRaises(numpy.core._exceptions.UFuncTypeError) as context:
-            d1.sapyb(a,d2,b, out=d2)
+        try:
+
+            with self.assertRaises(numpy.core._exceptions.UFuncTypeError) as context:
+                d1.sapyb(a,d2,b, out=d2)
+        except AttributeError as ae:
+            print ("Probably numpy version too low:", ae)
+
         # print ("Exception thrown:", str(context.exception))
         
         # out is complex

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -1095,6 +1095,38 @@ class TestDataContainer(unittest.TestCase):
         d2.sapyb(b,d1,a, out)
         numpy.testing.assert_array_equal(res.as_array(), out.as_array())
 
+    def test_sapyb_scalar_f_c(self):
+        # a,b scalar
+        ig = ImageGeometry(10,10)                                               
+        d1 = ig.allocate(1, dtype=numpy.complex64)                                                     
+        d2 = ig.allocate(2, dtype=numpy.float32)   
+        a = 2.+1j
+        b = -1.
+
+        # equals to 2*[1] + -1*[2] = 0
+        out = d1.sapyb(a,d2,b)
+        res = numpy.zeros_like(d1.as_array()) + 1j
+        numpy.testing.assert_array_equal(res, out.as_array())
+
+        out.fill(0)
+        d1.sapyb(a,d2,b, out)
+        numpy.testing.assert_array_equal(res, out.as_array())
+
+        d1.sapyb(a,d2,b, out=d1)
+        numpy.testing.assert_array_equal(res, d1.as_array())
+
+        d1.fill(1)
+        with self.assertRaises(numpy.core._exceptions.UFuncTypeError) as context:
+            d1.sapyb(a,d2,b, out=d2)
+        # print ("Exception thrown:", str(context.exception))
+        
+        # out is complex
+        # d1.fill(1+0j)
+        d2.fill(2)
+        d1.sapyb(a,d2,b,out=d1)
+        # 2+1j * [1+0j] -1 * [2]
+        numpy.testing.assert_array_equal(1j * numpy.ones_like(d1.as_array()), d1.as_array())
+            
     def test_min(self):
         print ("test min")
         ig = ImageGeometry(10,10)     

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -980,7 +980,10 @@ class TestSPDHG(unittest.TestCase):
             np.random.seed(10)
             scale = 5
             eta = 0
-            noisy_data = AcquisitionData(np.random.poisson( scale * (eta + sin.as_array()))/scale, geometry=ag)
+            noisy_data = AcquisitionData(np.asarray(
+                np.random.poisson( scale * (eta + sin.as_array()))/scale, geometry=ag),
+                dtype=np.float32
+            )
         elif noise == 'gaussian':
             np.random.seed(10)
             n1 = np.asarray(np.random.normal(0, 0.1, size = ag.shape), dtype=np.float32)

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -983,7 +983,7 @@ class TestSPDHG(unittest.TestCase):
             noisy_data = AcquisitionData(np.random.poisson( scale * (eta + sin.as_array()))/scale, geometry=ag)
         elif noise == 'gaussian':
             np.random.seed(10)
-            n1 = np.random.normal(0, 0.1, size = ag.shape)
+            n1 = np.asarray(np.random.normal(0, 0.1, size = ag.shape), dtype=np.float32)
             noisy_data = AcquisitionData(n1 + sin.as_array(), geometry=ag)
             
         else:

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -952,7 +952,7 @@ class TestSPDHG(unittest.TestCase):
     
     @unittest.skipUnless(has_astra, "ccpi-astra not available")
     def test_SPDHG_vs_SPDHG_explicit_axpby(self):
-        data = dataexample.SIMPLE_PHANTOM_2D.get(size=(128,128))
+        data = dataexample.SIMPLE_PHANTOM_2D.get(size=(128,128), dtype=numpy.float32)
         if debug_print:
             print ("test_SPDHG_vs_SPDHG_explicit_axpby here")
         ig = data.geometry
@@ -981,8 +981,10 @@ class TestSPDHG(unittest.TestCase):
             scale = 5
             eta = 0
             noisy_data = AcquisitionData(np.asarray(
-                np.random.poisson( scale * (eta + sin.as_array()))/scale, geometry=ag),
-                dtype=np.float32
+                                            np.random.poisson( scale * (eta + sin.as_array()))/scale, 
+                                            dtype=np.float32
+                                            ), 
+                                         geometry=ag
             )
         elif noise == 'gaussian':
             np.random.seed(10)


### PR DESCRIPTION
Adds `sapyb` method of `DataContainer` and some unit tests.

I think we should remove all `axpby` references in the code as `sapyb` is able to switch from the c-library to pure numpy implementation, which should fix a few problems that have arisen.

Besides, SIRF has already [developed `sapyb` and deprecated `axpby`](https://github.com/SyneRBI/SIRF/blob/0c22d1dcdf5bb7a5135d50e99ec3eca3e9f4d18f/src/common/SIRF.py#L227-L251).