### PR TITLE
Power method fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * 21.3.1
+  - Fixed PowerMethod for square/non-square, complex/float matrices with stopping criterion.
   - Added matplotlib version dependency to conda recipe
   - Fixed TIGRE wrappers for geometry with a virtual detector
   - Fixed TIGRE wrappers for cone-beam geometry with tilted rotation axis

--- a/Wrappers/Python/cil/optimisation/operators/MatrixOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/MatrixOperator.py
@@ -34,8 +34,8 @@ class MatrixOperator(LinearOperator):
         '''
         self.A = A
         M_A, N_A = self.A.shape
-        domain_geometry = VectorGeometry(N_A)
-        range_geometry = VectorGeometry(M_A)
+        domain_geometry = VectorGeometry(N_A, dtype=A.dtype)
+        range_geometry = VectorGeometry(M_A, dtype=A.dtype)
         self.s1 = None   # Largest singular value, initially unknown
         super(MatrixOperator, self).__init__(domain_geometry=domain_geometry,
                                                    range_geometry=range_geometry)
@@ -62,8 +62,4 @@ class MatrixOperator(LinearOperator):
 
     def size(self):
         return self.A.shape
-    
-    def calculate_norm(self, **kwargs):
-        # If unknown, compute and store. If known, simply return it.
-        return svds(self.A,1,return_singular_vectors=False)[0]
     

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -52,8 +52,8 @@ class Operator(object):
         so in case you want to recalculate by setting a higher number of iterations or changing the
         starting point or both you need to set :code:`force=True`
 
-        :param iterations: number of iterations to run
-        :type iterations: int, optional, default = 25
+        :param max_iteration: number of iterations to run the Power method
+        :type max_iteration: int, optional, default = 25
         :param x_init: starting point for the iteration in the operator domain
         :type x_init: same type as domain, a subclass of :code:`DataContainer`, optional, default None
         :parameter force: forces the recalculation of the norm

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -178,10 +178,9 @@ class LinearOperator(Operator):
         # Default case: non-symmetric
         symmetric = False
 
-        # symmetric case   
-        if operator.domain_geometry().__class__.__name__ == operator.range_geometry().__class__.__name__:
-            if set(operator.domain_geometry().shape) == set(operator.range_geometry().shape):
-                symmetric = True
+        # symmetric case  
+        if operator.domain_geometry()==operator.range_geometry():
+            symmetric = True
         
         # Initialise random or by the user
         if initial is None:
@@ -222,7 +221,7 @@ class LinearOperator(Operator):
                 eig_new = numpy.sqrt(numpy.abs(x0_norm))
             
             # Stopping criterion of two consecutive eigenvalues
-            if numpy.abs(eig_new - eig_old) < tolerance :
+            if i>0 and numpy.abs(eig_new - eig_old) < tolerance :
                 break
             eig_old = eig_new
             

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -161,13 +161,13 @@ class LinearOperator(Operator):
         >>> Mop = MatrixOperator(M)
         >>> Mop_norm = Mop.PowerMethod(Mop)
         >>> Mop_norm
-        array([ 0,  2,  6, 12, 20])
+        2.0000654846240296
 
         `PowerMethod` is called when we compute the norm of a matrix or a `LinearOperator`.
 
         >>> Mop_norm = Mop.norm()
+        2.0005647295658866
         
-
 
         Note
         ----

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -18,6 +18,7 @@
 from numbers import Number
 import numpy
 import functools
+import warnings
 
 class Operator(object):
     '''Operator that maps from a space X -> Y'''
@@ -118,8 +119,7 @@ class LinearOperator(Operator):
         raise NotImplementedError
     
     @staticmethod
-    def PowerMethod(operator, iterations=10, tolerance = 1e-5, initial=None, verbose=False):
-        
+    def PowerMethod(operator, iterations=10, initial=None, tolerance = 1e-5, verbose=False, x_init=None):
 
         r"""Power method or Power iteration algorithm 
         
@@ -132,13 +132,15 @@ class LinearOperator(Operator):
 
         operator: LinearOperator
         iterations: positive:`int`, default=10
-            Number of iterations for the Power method
-        tolerance: positive:`float`, default = 1e-4
-            Stopping criterion for the Power method. Check if two consecutive eigenvalue evaluations are below this tolerance.
+            Number of iterations for the Power method.
         initial: DataContainer, default = None
-            Starting point for the Power method
+            Starting point for the Power method.
+        tolerance: positive:`float`, default = 1e-5
+            Stopping criterion for the Power method. Check if two consecutive eigenvalue evaluations are below this tolerance.                    
         verbose: boolean, default = False
-            Returns: dominant eigenvalue (False) or dominant eigenvalue, number of iterations, corresponding eigenvector, list of eigenvalue estimations
+            Returns: dominant eigenvalue (False) or dominant eigenvalue, number of iterations, corresponding eigenvector, list of eigenvalue estimations.
+        x_init: DataContainer, default = None
+            Starting point for the Power method (deprecated).        
 
         Notes
         -----
@@ -174,6 +176,10 @@ class LinearOperator(Operator):
 
 
         """
+
+        if x_init is not None:
+            warnings.warn('The x_init parameter is deprecated and will be removed in following version. Use initial instead.')
+            initial = x_init.copy()
 
         # Default case: non-symmetric
         symmetric = False

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -239,7 +239,7 @@ class LinearOperator(Operator):
             return eig_new
             
 
-    def calculate_norm(self, **kwargs):
+    def calculate_norm(self, iterations=10, initial=None, tolerance = 1e-5, verbose=False, x_init=None):
         '''Returns the norm of the LinearOperator as calculated by the PowerMethod
         
         :param iterations: number of iterations to run
@@ -249,12 +249,9 @@ class LinearOperator(Operator):
         :parameter force: forces the recalculation of the norm
         :type force: boolean, default :code:`False`
         '''
-        initial = kwargs.get('initial', None)
-        tolerance = kwargs.get('tolerance', 1e-5)
-        iterations = kwargs.get('iterations', 10)
-        verbose = kwargs.get('verbose', False)
-        s1 = LinearOperator.PowerMethod(self, iterations=iterations, tolerance=tolerance, initial=initial, verbose=verbose)
+        s1 = LinearOperator.PowerMethod(self, iterations=iterations, initial=initial, tolerance=tolerance, verbose=verbose, x_init = x_init)
         return s1
+
 
     @staticmethod
     def dot_test(operator, domain_init=None, range_init=None, tolerance=1e-6, **kwargs):

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -179,8 +179,9 @@ class LinearOperator(Operator):
         symmetric = False
 
         # symmetric case   
-        if set(operator.domain_geometry().shape)==set(operator.range_geometry().shape):
-            symmetric = True
+        if operator.domain_geometry().__class__.__name__ == operator.range_geometry().__class__.__name__:
+            if set(operator.domain_geometry().shape) == set(operator.range_geometry().shape):
+                symmetric = True
         
         # Initialise random or by the user
         if initial is None:

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -132,29 +132,26 @@ class LinearOperator(Operator):
 
         operator: LinearOperator
         iterations: positive:`int`, default=10
-            Number of iterations for the Power method.
+            Number of iterations for the Power method algorithm.
         initial: DataContainer, default = None
             Starting point for the Power method.
         tolerance: positive:`float`, default = 1e-5
-            Stopping criterion for the Power method. Check if two consecutive eigenvalue evaluations are below this tolerance.                    
+            Stopping criterion for the Power method. Check if two consecutive eigenvalue evaluations are below the tolerance.                    
         verbose: boolean, default = False
-            Returns: dominant eigenvalue (False) or dominant eigenvalue, number of iterations, corresponding eigenvector, list of eigenvalue estimations.
+            Returns: dominant eigenvalue, number of iterations, corresponding eigenvector, list of eigenvalue estimations.
         x_init: DataContainer, default = None
             Starting point for the Power method (deprecated).        
-
-        Notes
-        -----
 
         Returns
         -------
 
         dominant eigenvalue: positive:`float`
         number of iterations: positive:`int`
-            Number of iterations to reach tolerance, if verbose = True
+            Number of iterations for the Power method algorithm, if verbose = True
         eigenvector: DataContainer
             Corresponding eigenvector of the dominant eigenvalue, if verbose = True
         list of eigenvalues: :obj:`list`
-            List of eigenvalues
+            List of eigenvalues, if verbose = True
 
         Examples
         --------    
@@ -169,11 +166,6 @@ class LinearOperator(Operator):
 
         >>> Mop_norm = Mop.norm()
         2.0005647295658866
-        
-
-        Note
-        ----
-
 
         """
 
@@ -231,7 +223,7 @@ class LinearOperator(Operator):
             # Stopping criterion of two consecutive eigenvalues
             if i>0 and numpy.abs(eig_new - eig_old) < tolerance :
                 break
-            eig_old = eig_new            
+            eig_old = eig_new       
 
         if verbose:
             return eig_new, i, x0, eig_list

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -225,13 +225,13 @@ class LinearOperator(Operator):
                 eig_new =  numpy.abs(x0_norm)
             else:
                 eig_new = numpy.sqrt(numpy.abs(x0_norm))
+
+            eig_list.append(eig_new)                
             
             # Stopping criterion of two consecutive eigenvalues
             if i>0 and numpy.abs(eig_new - eig_old) < tolerance :
                 break
-            eig_old = eig_new
-            
-            eig_list.append(eig_new)
+            eig_old = eig_new            
 
         if verbose:
             return eig_new, i, x0, eig_list

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -239,7 +239,7 @@ class LinearOperator(Operator):
             return eig_new
             
 
-    def calculate_norm(self, iterations=10, initial=None, tolerance = 1e-5, verbose=False, x_init=None, force=False):
+    def calculate_norm(self, iterations=10, initial=None, tolerance = 1e-5, verbose=False, x_init=None, **kwargs):
         
         r""" Returns the norm of the LinearOperator calculated by the PowerMethod.
         

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -122,7 +122,7 @@ class LinearOperator(Operator):
         raise NotImplementedError
     
     @staticmethod
-    def PowerMethod(operator, max_iteration=10, initial=None, tolerance = 1e-5,  verbose=False,  **deprecated_args):
+    def PowerMethod(operator, max_iteration=10, initial=None, tolerance = 1e-5,  return_all=False,  **deprecated_args):
 
         r"""Power method or Power iteration algorithm 
         
@@ -140,7 +140,7 @@ class LinearOperator(Operator):
             Starting point for the Power method.
         tolerance: positive:`float`, default = 1e-5
             Stopping criterion for the Power method. Check if two consecutive eigenvalue evaluations are below the tolerance.                    
-        verbose: boolean, default = False
+        return_all: boolean, default = False
             Toggles the verbosity of the return
     
 
@@ -148,11 +148,11 @@ class LinearOperator(Operator):
         -------
         dominant eigenvalue: positive:`float`
         number of iterations: positive:`int`
-            Number of iterations run. Only returned if verbose = True.
+            Number of iterations run. Only returned if return_all is True.
         eigenvector: DataContainer
-            Corresponding eigenvector of the dominant eigenvalue. Only returned if verbose = True.
+            Corresponding eigenvector of the dominant eigenvalue. Only returned if return_all is True.
         list of eigenvalues: :obj:`list`
-            List of eigenvalues. Only returned if verbose = True.
+            List of eigenvalues. Only returned if return_all is True.
 
         Examples
         --------    
@@ -232,7 +232,7 @@ class LinearOperator(Operator):
             eig_list.append(eig_new)   
             eig_old = eig_new       
 
-        if verbose:
+        if return_all:
             return eig_new, i, x0, eig_list
         else:
             return eig_new

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -239,16 +239,25 @@ class LinearOperator(Operator):
             return eig_new
             
 
-    def calculate_norm(self, iterations=10, initial=None, tolerance = 1e-5, verbose=False, x_init=None):
-        '''Returns the norm of the LinearOperator as calculated by the PowerMethod
+    def calculate_norm(self, iterations=10, initial=None, tolerance = 1e-5, verbose=False, x_init=None, force=False):
         
-        :param iterations: number of iterations to run
-        :type iterations: int, optional, default = 25
-        :param x_init: starting point for the iteration in the operator domain
-        :type x_init: same type as domain, a subclass of :code:`DataContainer`, optional, None
-        :parameter force: forces the recalculation of the norm
-        :type force: boolean, default :code:`False`
-        '''
+        r""" Returns the norm of the LinearOperator calculated by the PowerMethod.
+        
+        Parameters
+        ----------
+        iterations: positive:`int`, default=10
+            Number of iterations for the Power method.
+        initial: DataContainer, default = None
+            Starting point for the Power method.
+        tolerance: positive:`float`, default = 1e-5
+            Stopping criterion for the Power method. Check if two consecutive eigenvalue evaluations are below this tolerance.                    
+        verbose: boolean, default = False
+            Returns: dominant eigenvalue (False) or dominant eigenvalue, number of iterations, corresponding eigenvector, list of eigenvalue estimations.
+        x_init: DataContainer, default = None
+            Starting point for the Power method (deprecated).   
+
+
+        """
         s1 = LinearOperator.PowerMethod(self, iterations=iterations, initial=initial, tolerance=tolerance, verbose=verbose, x_init = x_init)
         return s1
 

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -548,10 +548,8 @@ class TestGradients(CCPiTestClass):
         
         E3 = SymmetrisedGradientOperator(Grad3.range_geometry())
 
-        norm1 = E3.norm()
-        norm2 = E3.calculate_norm(iterations=100)
-        print (norm1,norm2)
-        numpy.testing.assert_almost_equal(norm2, numpy.sqrt(12), decimal = self.decimal)
+        norm = LinearOperator.PowerMethod(E3,max_iteration=100, tolerance = 0)
+        numpy.testing.assert_almost_equal(norm, numpy.sqrt(12), decimal = self.decimal)
         
     def test_SymmetrisedGradientOperator3b(self):
         ###########################################################################

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -340,12 +340,18 @@ class TestOperator(CCPiTestClass):
         res1 = M1op.PowerMethod(M1op,100)
         numpy.testing.assert_almost_equal(res1,3.1624439599276974, decimal=4)                
 
-        # Gradient Operator
+        # Gradient Operator (float)
         ig = ImageGeometry(30,30)
         Grad = GradientOperator(ig)
         res1 = Grad.PowerMethod(Grad,500, tolerance=1e-6)
-        numpy.testing.assert_almost_equal(res1, numpy.sqrt(8), decimal=2)                
+        numpy.testing.assert_almost_equal(res1, numpy.sqrt(8), decimal=2) 
 
+        # Gradient Operator (complex)
+        ig = ImageGeometry(30,30, dtype=numpy.complex)
+        Grad = GradientOperator(ig)
+        res1 = Grad.PowerMethod(Grad,500, tolerance=1e-6)
+        numpy.testing.assert_almost_equal(res1, numpy.sqrt(8), decimal=2)         
+                    
         # Identity Operator
         Id = IdentityOperator(ig)
         res1 = Id.PowerMethod(Id,100)

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -310,35 +310,49 @@ class TestOperator(CCPiTestClass):
             print("Check for 2D chan for FiniteDiff label {}".format(labels[i]))        
         
     def test_PowerMethod(self):
-        print ("test_BlockOperator")
+
+        # 2x2 real matrix, dominant eigenvalue = 2
+        M1 = numpy.array([[1,0],[1,2]], dtype=float)
+        M1op = MatrixOperator(M1)
+        res1 = M1op.PowerMethod(M1op,100)
+        numpy.testing.assert_almost_equal(res1,2., decimal=4)
+
+        # Test with the norm       
+        res2 = M1op.norm()
+        numpy.testing.assert_almost_equal(res1,res2, decimal=4)
+
+
+        # 2x3 real matrix, dominant eigenvalue = 4.711479432297657
+        M1 = numpy.array([[1.,0.,3],[1,2.,3]])
+        M1op = MatrixOperator(M1)
+        res1 = M1op.PowerMethod(M1op,100)
+        numpy.testing.assert_almost_equal(res1,4.711479432297657, decimal=4)        
         
-        N, M = 200, 300
-        niter = 10
-        ig = ImageGeometry(N, M)
+        # 2x3 complex matrix, (real eigenvalues), dominant eigenvalue = 5.417602365823937
+        M1 = numpy.array([[2,1j,0],[2j,5j,0]])
+        M1op = MatrixOperator(M1)
+        res1 = M1op.PowerMethod(M1op,100)
+        numpy.testing.assert_almost_equal(res1,5.417602365823937, decimal=4) 
+
+        # 3x3 complex matrix, (real+complex eigenvalue), dominant eigenvalue = 3.1624439599276974
+        M1 = numpy.array([[2,0,0],[1,2j,1j],[3, 3-1j,3]])
+        M1op = MatrixOperator(M1)
+        res1 = M1op.PowerMethod(M1op,100)
+        numpy.testing.assert_almost_equal(res1,3.1624439599276974, decimal=4)                
+
+        # Gradient Operator
+        ig = ImageGeometry(30,30)
+        Grad = GradientOperator(ig)
+        res1 = Grad.PowerMethod(Grad,500, tolerance=1e-6)
+        numpy.testing.assert_almost_equal(res1, numpy.sqrt(8), decimal=2)                
+
+        # Identity Operator
         Id = IdentityOperator(ig)
-        
-        G = GradientOperator(ig)
-        
-        uid = Id.domain_geometry().allocate(ImageGeometry.RANDOM, seed=1)
-        
-        a = LinearOperator.PowerMethod(Id, niter, uid)
-        #b = LinearOperator.PowerMethodNonsquare(Id, niter, uid)
-        b = LinearOperator.PowerMethod(Id, niter)
-        print ("Edo impl", a[0])
-        print ("None impl", b[0])
-        
-        #self.assertAlmostEqual(a[0], b[0])
-        self.assertNumpyArrayAlmostEqual(a[0],b[0],decimal=6)
-        
-        a = LinearOperator.PowerMethod(G, niter, uid)
-        b = LinearOperator.PowerMethod(G, niter)
-        #b = LinearOperator.PowerMethodNonsquare(G, niter, uid)
-        
-        print ("Edo impl", a[0])
-        #print ("old impl", b[0])
-        self.assertNumpyArrayAlmostEqual(a[0],b[0],decimal=2)
-        #self.assertAlmostEqual(a[0], b[0])
-        
+        res1 = Id.PowerMethod(Id,100)
+        numpy.testing.assert_almost_equal(res1,1.0, decimal=4)                
+
+
+             
     def test_Norm(self):
         print ("test_BlockOperator")
         ##

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -360,37 +360,28 @@ class TestOperator(CCPiTestClass):
 
              
     def test_Norm(self):
-        print ("test_BlockOperator")
-        ##
         numpy.random.seed(1)
         N, M = 200, 300
 
         ig = ImageGeometry(N, M)
         G = GradientOperator(ig)
-        t0 = timer()
-        norm = G.norm()
-        t1 = timer()
-        norm2 = G.norm()
-        t2 = timer()
-        norm3 = G.norm(force=True)
-        t3 = timer()
-        print ("Norm dT1 {} dT2 {} dT3 {}".format(t1-t0,t2-t1, t3-t2))
-        self.assertLess(t2-t1, t1-t0)
-        self.assertLess(t2-t1, t3-t2)
 
-        numpy.random.seed(1)
-        t4 = timer()
-        norm4 = G.norm(iterations=50, force=True)
-        t5 = timer()
-        self.assertLess(t2-t1, t5-t4)
+        self.assertIsNone(G._norm)
+        
+        #calculates norm
+        self.assertAlmostEqual(G.norm(), 2.825, 3)
 
-        numpy.random.seed(1)
-        t4 = timer()
-        norm5 = G.norm(x_init=ig.allocate('random'), iterations=50, force=True)
-        t5 = timer()
-        self.assertLess(t2-t1, t5-t4)
-        for n in [norm, norm2, norm3, norm4, norm5]:
-            print ("norm {}", format(n))
+        #sets_norm
+        G.set_norm(4)
+        self.assertEqual(G._norm, 4)
+
+        #gets chached norm
+        self.assertEqual(G.norm(), 4)
+
+        #sets cache to None
+        G.set_norm(None)
+        #recalculates norm
+        self.assertAlmostEqual(G.norm(), 2.825, 3)
 
     def test_ProjectionMap(self):
 
@@ -490,7 +481,8 @@ class TestGradients(CCPiTestClass):
         Grad = GradientOperator(self.ig)
         
         E1 = SymmetrisedGradientOperator(Grad.range_geometry())
-        numpy.testing.assert_almost_equal(E1.norm(iterations=self.iterations), numpy.sqrt(8), decimal = self.decimal)
+        norm = LinearOperator.PowerMethod(E1, max_iteration=self.iterations)
+        numpy.testing.assert_almost_equal(norm, numpy.sqrt(8), decimal = self.decimal)
         
     def test_SymmetrisedGradientOperator1b(self):
         ###########################################################################  
@@ -536,7 +528,8 @@ class TestGradients(CCPiTestClass):
         Grad2 = GradientOperator(self.ig2, correlation = 'Space')
         
         E2 = SymmetrisedGradientOperator(Grad2.range_geometry())
-        numpy.testing.assert_almost_equal(E2.norm(iterations=self.iterations), 
+        norm = LinearOperator.PowerMethod(E2, max_iterations=self.iterations)
+        numpy.testing.assert_almost_equal(norm, 
            numpy.sqrt(8), decimal = self.decimal)
         
     

--- a/Wrappers/Python/test/test_PluginsRegularisation.py
+++ b/Wrappers/Python/test/test_PluginsRegularisation.py
@@ -38,7 +38,7 @@ class TestPlugin(unittest.TestCase):
         #Default test image
         self.data = dataexample.SIMPLE_PHANTOM_2D.get(size=(64,64))
         self.alpha = 2.0
-        self.iterations = 500     
+        self.iterations = 1000     
     def tearDown(self):
         pass
     @unittest.skipUnless(has_regularisation_toolkit, "Skipping as CCPi Regularisation Toolkit is not installed")

--- a/Wrappers/Python/test/test_PluginsTigre.py
+++ b/Wrappers/Python/test/test_PluginsTigre.py
@@ -368,7 +368,7 @@ class TestCommon(object):
     def compare_norm(self,direct_method,norm):
         ig = self.ag_small.get_ImageGeometry()
         Op = ProjectionOperator(ig, self.ag_small, direct_method=direct_method)
-        n = Op.norm(seed=0.52, iterations=25)
+        n = Op.norm()
         self.assertAlmostEqual(n, norm, places=1)
 
 

--- a/Wrappers/Python/test/test_PluginsTigre.py
+++ b/Wrappers/Python/test/test_PluginsTigre.py
@@ -368,7 +368,7 @@ class TestCommon(object):
     def compare_norm(self,direct_method,norm):
         ig = self.ag_small.get_ImageGeometry()
         Op = ProjectionOperator(ig, self.ag_small, direct_method=direct_method)
-        n = Op.norm(seed=0.52)
+        n = Op.norm(seed=0.52, iterations=25)
         self.assertAlmostEqual(n, norm, places=1)
 
 

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -1236,13 +1236,13 @@ class TestADMM(unittest.TestCase):
 
     def test_compare_with_PDHG(self):
         # Load an image from the CIL gallery. 
-        data = dataexample.SHAPES.get()
+        data = dataexample.SHAPES.get(size=(64,64))
         ig = data.geometry    
         # Add gaussian noise
-        noisy_data = applynoise.gaussian(data, seed = 10, var = 0.005)
+        noisy_data = applynoise.gaussian(data, seed = 10, var = 0.0005)
 
         # TV regularisation parameter
-        alpha = 1
+        alpha = 0.1
 
         # fidelity = 0.5 * L2NormSquared(b=noisy_data)
         # fidelity = L1Norm(b=noisy_data)
@@ -1261,20 +1261,16 @@ class TestADMM(unittest.TestCase):
         tau = 1./normK
 
         pdhg = PDHG(f=F, g=G, operator=K, tau=tau, sigma=sigma,
-                    max_iteration = 100, update_objective_interval = 10)
+                    max_iteration = 500, update_objective_interval = 10)
         pdhg.run(verbose=0)
 
         sigma = 1
         tau = sigma/normK**2
 
         admm = LADMM(f=G, g=F, operator=K, tau=tau, sigma=sigma,
-                    max_iteration = 100, update_objective_interval = 10)
+                    max_iteration = 500, update_objective_interval = 10)
         admm.run(verbose=0)
-
-        from cil.utilities.quality_measures import psnr
-        if debug_print:
-            print ("PSNR" , psnr(admm.solution, pdhg.solution))
-        np.testing.assert_almost_equal(psnr(admm.solution, pdhg.solution), 84.55162459062069, decimal=4)
+        np.testing.assert_almost_equal(admm.solution.array, pdhg.solution.array,  decimal=3)
 
     def tearDown(self):
         pass

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -1012,7 +1012,6 @@ class TestTotalVariation(unittest.TestCase):
         
         
         np.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal = 4)
-        # np.testing.assert_allclose(res1.as_array(), res2.as_array(), atol=2.5e-3)
 
         ###################################################################
         ###################################################################

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -977,18 +977,18 @@ class TestTotalVariation(unittest.TestCase):
     
         # print("Compare CIL_FGP_TV vs CCPiReg_FGP_TV no tolerance (2D)")
 
-        data = dataexample.SHAPES.get()
+        data = dataexample.SHAPES.get(size=(64,64))
         ig = data.geometry
         ag = ig
 
         np.random.seed(0)
         # Create noisy data. 
-        n1 = np.random.normal(0, 0.1, size = ig.shape)
+        n1 = np.random.normal(0, 0.0005, size = ig.shape)
         noisy_data = ig.allocate()
         noisy_data.fill(n1+data.as_array())
         
         alpha = 0.1
-        iters = 100
+        iters = 500
             
         # CIL_FGP_TV no tolerance
         g_CIL = alpha * TotalVariation(iters, tolerance=None, lower = 0, info = True)
@@ -1011,8 +1011,8 @@ class TestTotalVariation(unittest.TestCase):
         # print(t3-t1)
         
         
-        # np.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal = 4)
-        np.testing.assert_allclose(res1.as_array(), res2.as_array(), atol=2.5e-3)
+        np.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal = 4)
+        # np.testing.assert_allclose(res1.as_array(), res2.as_array(), atol=2.5e-3)
 
         ###################################################################
         ###################################################################

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 test:
   requires:
     - python-wget
-    - cvxpy               # [ linux and py==37 and np==118 ]
+    - cvxpy               # [ linux ]
     - scikit-image
     - tomophantom =1.4.10 # [ linux ]
     - cil-astra =21.3.0   # [ linux ] 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 test:
   requires:
     - python-wget
-    - cvxpy               # [ linux ]
+    - cvxpy               # [ linux and py==37 and np==118 ]
     - scikit-image
     - tomophantom =1.4.10 # [ linux ]
     - cil-astra =21.3.0   # [ linux ] 


### PR DESCRIPTION
**Fix Power method**

- Works for square & non-square matrices
- Works with real/complex matrices
- Stopping criterion is used, based on the difference of two consecutive eigenvalues.
- Add unittests: Using `MatrixOperator` and `LinearOperator` e.g., `IdentityOperator`, `GradientOperator`

Close #451 , #616