### PR TITLE
add dTV test

### DIFF
--- a/Wrappers/Python/test/test_CIL_CVXPy.py
+++ b/Wrappers/Python/test/test_CIL_CVXPy.py
@@ -15,8 +15,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from cil.optimisation.functions import L2NormSquared
-from cil.optimisation.functions import TotalVariation
+from cil.optimisation.functions import L2NormSquared, TotalVariation, MixedL21Norm
+from cil.optimisation.operators import BlockOperator, FiniteDifferenceOperator, CompositionOperator, DiagonalOperator
+from cil.optimisation.algorithms import PDHG
 
 from cil.utilities import dataexample
 import cvxpy as cp
@@ -158,6 +159,147 @@ class Test_CIL_vs_CVXPy(unittest.TestCase):
             f = 0.5*L2NormSquared(b=self.data)
             cil_objective = TV(tv_cil) + f(tv_cil)
             np.testing.assert_allclose(cil_objective, obj.value, atol=1e-3)              
+
+    def dtv(self,u, reference, eta, isotropic=True, direction = "forward", boundaries = "Neumann"):
+            
+        G = self.sparse_gradient_matrix(u.shape, direction = direction, order = 1, boundaries = boundaries)         
+        DX, DY = G[1], G[0]
+        
+        # gradient for reference image
+        tmp_xi_x = DX@cp.vec(reference.array)
+        tmp_xi_y = DY@cp.vec(reference.array)    
+        denom = cp.sqrt(tmp_xi_x**2 + tmp_xi_y**2 + eta**2)
+
+        # compute field xi
+        xi_x = tmp_xi_x/denom
+        xi_y = tmp_xi_y/denom
+        
+        # gradient for u
+        u_x = DX@cp.vec(u)
+        u_y = DY@cp.vec(u) 
+        
+        inner_prod = cp.multiply(u_x,xi_x) + cp.multiply(u_y,xi_y)
+        z1 = u_x - cp.multiply(inner_prod,xi_x)
+        z2 = u_y - cp.multiply(inner_prod,xi_y)
+        z = cp.vstack([z1, z2])
+        
+        if isotropic:
+            return cp.sum(cp.norm( z, 2, axis = 0))
+        else:
+            return cp.sum(cp.norm( z, 1, axis = 0)) 
+
+
+    def test_cil_vs_cvxpy_direction_totalvariation_isotropic(self):      
+
+        # Reference image
+        reference = self.data * 0.01     
+
+        # Construct problem    
+        u_cvx = cp.Variable(self.data.shape)
+
+        # fidelity
+        fidelity = cp.sum_squares(u_cvx - self.data.array)   
+
+        # regulariser
+        eta = 0.1
+        alpha = 0.5
+        regulariser = alpha * self.dtv(u_cvx, reference, eta) 
+        constraints = []
+
+        obj =  cp.Minimize( regulariser +  fidelity)
+        prob = cp.Problem(obj, constraints)
+
+        # Choose solver (SCS is fast but less accurate than MOSEK)
+        res = prob.solve(verbose = True, solver = cp.SCS, eps=1e-5)        
+
+        # set up and run PDHG algorithm for 2D direction TotalVariation
+        ig = self.data.geometry
+
+        # fidelity term
+        g = L2NormSquared(b=self.data)
+
+        # setup operator for directional TV
+        DY = FiniteDifferenceOperator(ig, direction=1)
+        DX = FiniteDifferenceOperator(ig, direction=0)
+
+        Grad = BlockOperator(DY, DX)
+        grad_ref = Grad.direct(reference)
+        denom = (eta**2 + grad_ref.pnorm(2)**2).sqrt()
+        xi = grad_ref/denom
+
+        A1 = DY - CompositionOperator(DiagonalOperator(xi[0]**2),DY) - CompositionOperator(DiagonalOperator(xi[0]*xi[1]),DX)
+        A2 = DX - CompositionOperator(DiagonalOperator(xi[0]*xi[1]),DY) - CompositionOperator(DiagonalOperator(xi[1]**2),DX)
+
+        operator = BlockOperator(A1, A2)
+
+        f = alpha * MixedL21Norm()
+
+        # use primal acceleration, g being strongly convex
+        pdhg = PDHG(f = f, g = g, operator = operator, 
+                    max_iteration=500, update_objective_interval = 100, gamma_g = 1.)
+        pdhg.run(verbose=0)        
+
+        # compare solution
+        np.testing.assert_allclose(pdhg.solution.array, u_cvx.value, atol=1e-3)   
+
+        # compare objectives
+        np.testing.assert_allclose(pdhg.objective[-1], obj.value, atol=1e-3)             
+
+    def test_cil_vs_cvxpy_direction_totalvariation(self):      
+
+        # Reference image
+        reference = self.data * 0.01     
+
+        # Construct problem    
+        u_cvx = cp.Variable(self.data.shape)
+
+        # fidelity
+        fidelity = cp.sum_squares(u_cvx - self.data.array)   
+
+        # regulariser
+        eta = 0.1
+        alpha = 0.5
+        regulariser = alpha * self.dtv(u_cvx, reference, eta, isotropic=False) 
+        constraints = []
+
+        obj =  cp.Minimize( regulariser +  fidelity)
+        prob = cp.Problem(obj, constraints)
+
+        # Choose solver (SCS is fast but less accurate than MOSEK)
+        res = prob.solve(verbose = True, solver = cp.SCS, eps=1e-5)        
+
+        # set up and run PDHG algorithm for 2D direction TotalVariation
+        ig = self.data.geometry
+
+        # fidelity term
+        g = L2NormSquared(b=self.data)
+
+        # setup operator for directional TV
+        DY = FiniteDifferenceOperator(ig, direction=1)
+        DX = FiniteDifferenceOperator(ig, direction=0)
+
+        Grad = BlockOperator(DY, DX)
+        grad_ref = Grad.direct(reference)
+        denom = (eta**2 + grad_ref.pnorm(2)**2).sqrt()
+        xi = grad_ref/denom
+
+        A1 = DY - CompositionOperator(DiagonalOperator(xi[0]**2),DY) - CompositionOperator(DiagonalOperator(xi[0]*xi[1]),DX)
+        A2 = DX - CompositionOperator(DiagonalOperator(xi[0]*xi[1]),DY) - CompositionOperator(DiagonalOperator(xi[1]**2),DX)
+
+        operator = BlockOperator(A1, A2)
+
+        f = alpha * MixedL21Norm()
+
+        # use primal acceleration, g being strongly convex
+        pdhg = PDHG(f = f, g = g, operator = operator, 
+                    max_iteration=500, update_objective_interval = 100, gamma_g = 1.)
+        pdhg.run(verbose=0)        
+
+        # compare solution
+        np.testing.assert_allclose(pdhg.solution.array, u_cvx.value, atol=1e-3)   
+
+        # compare objectives
+        np.testing.assert_allclose(pdhg.objective[-1], obj.value, atol=1e-3)           
 
 
 


### PR DESCRIPTION
Unittest for dTV denoising: CIL vs CVXPy

Note: Until, we agree on the algorithm class, this test contains all the ingredients needed to set up the dTV regulariser for the PDHG algorithm. The test will remain the same in the future but instead of using PDHG for dTV, we will use the proximal method of dTV, i.e., dTV.proximal