### PR TITLE
adds line_plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * 2x.x.x
+  - Add line_plot to plot lines from 2D/3D/4D data
   - Fixed PowerMethod for square/non-square, complex/float matrices with stopping criterion.
   - CofR image_sharpness improved for large datasets
   - Geometry alignmentment fix for 2D datasets

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -786,8 +786,8 @@ def _extract_single_line(data, **kwargs):
 def line_plot(data, line_coords=None, label=None, title=None, color=None, size=(15,15)):
     '''Creates a 1D plot of data given some coordinates
 
-    Parameters
-    ----------
+    Parameters:
+    -----------
     data : ImageData, AcquisitionData, generic DataContainer or a list of such
            data from which to extract the line plot. 
     line_coords : tuple, list of tuples
@@ -803,10 +803,8 @@ def line_plot(data, line_coords=None, label=None, title=None, color=None, size=(
     size : tuple or list of ints, optional
         Specifies the size of the plot
 
-
     Example Usage:
     --------------
-
     line_plot( [gt, fbp_recon, algo1.solution * A1.norm()], 
                 label=['Ground Truth', 'FBP', 'PDHG + TV + nn'],
                 line_coords=(('horizontal_x',64), ('vertical',64)), 
@@ -814,7 +812,6 @@ def line_plot(data, line_coords=None, label=None, title=None, color=None, size=(
                 color=('cyan', 'purple', 'orange'), 
                 size=(15,9)
            )
-
     '''
     kwargs = {}
     for i, el in enumerate(line_coords):

--- a/Wrappers/Python/test/test_version.py
+++ b/Wrappers/Python/test/test_version.py
@@ -8,3 +8,10 @@ class TestModuleBase(unittest.TestCase):
             self.assertTrue(isinstance(a, str))
         except ImportError as ie:
             self.assertFalse(True, str(ie))
+    
+    def test_line_plot(self):
+        try:
+            from cil.utilities.display import line_plot
+            self.assertTrue(True)
+        except ImportError as ie:
+            self.assertFalse(True, str(ie))

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -62,6 +62,12 @@ show_geometry - Display system geometry
    :members:
    :inherited-members:
 
+line_plot - Display a line plot from 2D/3D/4D data
+--------------------------------------------------
+
+.. autoclass:: cil.utilities.display.line_plot
+   :members:
+   :inherited-members:
 
 islicer - interactive display of 2D slices
 ------------------------------------------


### PR DESCRIPTION
Adds the function `line_plot` to the `utilities.display` to easily plot line profiles. 

The API is similar to `show2D`. A line like the following produces the plot:

```python

line_plot( [gt, fbp_recon, algo1.solution * A1.norm()], 
           label=['Ground Truth', 'FBP', 'PDHG + TV + nn'],
           line_coords=(('horizontal_x',64), ('vertical',64)), 
           title=f'Comparison alpha {alpha}',
           color=('cyan', 'purple', 'orange'), 
           size=(15,9))
```
`data`  and `line_coords` are required parameters, the others are optional and described in the docstring.

![image](https://user-images.githubusercontent.com/14138589/154076724-09e4683b-fa04-4cba-ba6d-b013be9af16c.png)


In the future I would like to merge this functionality in `show2D` but the interface needs to be discussed.