### PR TITLE
Changed SmoothMixedL21Norm parent class

### DIFF
--- a/Wrappers/Python/cil/optimisation/functions/MixedL21Norm.py
+++ b/Wrappers/Python/cil/optimisation/functions/MixedL21Norm.py
@@ -126,7 +126,7 @@ class MixedL21Norm(Function):
 
             out.fill(out)
 
-class SmoothMixedL21Norm(Function):
+class SmoothMixedL21Norm(MixedL21Norm):
     
     """ SmoothMixedL21Norm function: :math:`F(x) = ||x||_{2,1} = \sum |x|_{2} = \sum \sqrt{ (x^{1})^{2} + (x^{2})^{2} + \epsilon^2 + \dots}`                  
     


### PR DESCRIPTION
Changed SmoothMixedL21Norm parent class from Function to MixedL21Norm. Is this right? 

I was getting "NotImplementedErrors" originally