### PR TITLE
Fix python build scripts

### DIFF
--- a/Wrappers/Python/CMake/setup.py.in
+++ b/Wrappers/Python/CMake/setup.py.in
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from distutils.core import setup
+from setuptools import setup
 import os
 import sys
 

--- a/Wrappers/Python/CMakeLists.txt
+++ b/Wrappers/Python/CMakeLists.txt
@@ -62,7 +62,7 @@ if (BUILD_PYTHON_WRAPPER)
       
       if (CONDA_BUILD)
         add_custom_target(pythonsetup ALL
-                        COMMAND ${CMAKE_COMMAND} -E env ${PYTHON_EXECUTABLE} ${SETUP_PY} -vv install
+                        COMMAND ${CMAKE_COMMAND} -E env ${PYTHON_EXECUTABLE} -m pip install .
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                         COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
                         DEPENDS cilacc)
@@ -78,8 +78,7 @@ if (BUILD_PYTHON_WRAPPER)
                         COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
                         DEPENDS cilacc)
 
-          install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/lib/cil
-                DESTINATION ${PYTHON_DEST} )
+          
                 
         else()
           add_custom_target(pythonsetup ALL  
@@ -93,20 +92,14 @@ if (BUILD_PYTHON_WRAPPER)
                         DEPENDS cilacc 
                         )
         endif()
-        #set (PYTHON_DEST ${CMAKE_INSTALL_PREFIX}/python/)
-
-        if (NOT WIN32)
-          install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/build/lib/cil
-                DESTINATION ${PYTHON_DEST} )
-
-        endif()
+        
+        # install step
+        install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/lib/cil
+              DESTINATION ${PYTHON_DEST} )
         install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data/ DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cil)
-        #file(TOUCH ${PYTHON_DEST}/edo/__init__.py)
         
       endif()
       
-      
-      #add_custom_target(PythonWrapper ALL DEPENDS ${OUTPUT})
       add_custom_target(PythonWrapper ALL DEPENDS pythonsetup)
        
   endif()

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,7 @@ mkdir "%SRC_DIR%\build_framework"
 
 cd "%SRC_DIR%\build_framework"
 cmake -G "NMake Makefiles" %RECIPE_DIR%\..\ -DCONDA_BUILD=ON -DCMAKE_BUILD_TYPE="Release" -DLIBRARY_LIB=%CONDA_PREFIX%\lib -DLIBRARY_INC=%CONDA_PREFIX% -DCMAKE_INSTALL_PREFIX=%PREFIX%
+if errorlevel 1 exit 1
 
-cmake --build . --target install
+cmake --build . --target install --config Release
 if errorlevel 1 exit 1


### PR DESCRIPTION
closes #1196 

* use `pip` to install with conda
* uses `setuptools` in `setup.py` script
* simplifies non conda install step
