### PR TITLE
conversion of all algorithms to use sapyb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-* 2x.x.x
+* 21.4.0
   - Recon.FBP allows 'astra' backend 
   - Fixed PowerMethod for square/non-square, complex/float matrices with stopping criterion.
   - CofR image_sharpness improved for large datasets
   - Geometry alignmentment fix for 2D datasets
   - CGLS update for sapyb to enable complex data
-  - added sapyb and deprecated axpby
+  - added sapyb and deprecated axpby. All algorithm updated to use sapyb.
 
 * 21.3.1
   - Added matplotlib version dependency to conda recipe

--- a/Wrappers/Python/cil/optimisation/algorithms/ADMM.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/ADMM.py
@@ -64,7 +64,6 @@ class LADMM(Algorithm):
             else:
                 raise ValueError('{} received both initial and the deprecated x_init parameter. It is not clear which one we should use.'\
                     .format(self.__class__.__name__))
-        self._use_axpby = kwargs.get('use_axpby', True)
 
         self.set_up(f = f, g = g, operator = operator, tau = tau,\
              sigma = sigma, initial=initial)        
@@ -110,11 +109,8 @@ class LADMM(Algorithm):
         self.tmp_dir -= self.z
         self.operator.adjoint(self.tmp_dir, out = self.tmp_adj)
         
-        if self._use_axpby:
-            self.x.axpby(1,-(self.tau/self.sigma), self.tmp_adj, out=self.x)
-        else:
-            self.tmp_adj *= -(self.tau/self.sigma)
-            self.x += self.tmp_adj
+        self.x.sapyb(1, self.tmp_adj, -(self.tau/self.sigma), out=self.x)
+
         # apply proximal of f
         tmp = self.f.proximal(self.x, self.tau)
         self.operator.direct(tmp, out=self.tmp_dir)

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -100,20 +100,27 @@ class FISTA(Algorithm):
     def update(self):
         self.t_old = self.t
         self.f.gradient(self.y, out=self.u)
-        self.u.__imul__( -self.invL )
-        self.u.__iadd__( self.y )
+
+        self.u.sapyb(-self.invL, self.y, 1.0)
 
         self.g.proximal(self.u, self.invL, out=self.x)
         
         self.t = 0.5*(1 + numpy.sqrt(1 + 4*(self.t_old**2)))
         
         self.x.subtract(self.x_old, out=self.y)
-        self.y.axpby(((self.t_old-1)/self.t), 1, self.x, out=self.y)
-        
-        self.x_old.fill(self.x)
+        self.y.sapyb(((self.t_old-1)/self.t), self.x, 1, out=self.y)
 
-        
+        # update_previous_solution() called after update by base class
+        #i.e current solution is now in x_old, previous solution is now in x       
+
+    def update_previous_solution(self):
+        # swap the pointers to current and previous solution
+        tmp = self.x_old
+        self.x_old = self.x
+        self.x = tmp
+
+
     def update_objective(self):
-        self.loss.append( self.f(self.x) + self.g(self.x) )    
+        self.loss.append( self.f(self.x_old) + self.g(self.x_old) )    
     
 

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -101,7 +101,7 @@ class FISTA(Algorithm):
         self.t_old = self.t
         self.f.gradient(self.y, out=self.u)
 
-        self.u.sapyb(-self.invL, self.y, 1.0)
+        self.u.sapyb(-self.invL, self.y, 1.0, out=self.u)
 
         self.g.proximal(self.u, self.invL, out=self.x)
         

--- a/Wrappers/Python/cil/optimisation/algorithms/GD.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/GD.py
@@ -100,10 +100,8 @@ class GD(Algorithm):
             # the next update and solution are calculated within the armijo_rule
             self.step_size = self.armijo_rule()
         else:
-            self.x_update *= -self.step_size
-            self.x += self.x_update
+            self.x.sapyb(1.0, self.x_update, -self.step_size, out=self.x)
         
-    
 
     def update_objective(self):
         self.loss.append(self.objective_function(self.x))


### PR DESCRIPTION
## Describe your changes
Removed `use_axpby` where it appeared in algorithms and raised a warning if this was an optional parameter.
Replaced all code blocks that have `use_axpby` and `axpby` with `sapyb` . Used `sapyb` elsewhere where applicable.

In SPDHG converted `norms` to kwargs to maintain backward compatibility with the signature change. Updated docstring to reflect this following new style.

In FISTA switch datacontainer references at the end of the iteration rather than copying the data.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*

Ran CIL unit tests. Would benefit from a sirf example being run. But I don't envisage any problem as they have `sapyb` implemented.

## Link relevant issues
closes #1013
closes #622 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

All contributed code must be under [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)