### PR TITLE
Allow use of square brackets in file paths to Nikon and TIFF datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Geometry alignmentment fix for 2D datasets
   - CGLS update for sapyb to enable complex data
   - added sapyb and deprecated axpby
+  - Allow use of square brackets in file paths to TIFF and Nikon datasets
 
 * 21.3.1
   - Added matplotlib version dependency to conda recipe

--- a/Wrappers/Python/cil/io/NikonDataReader.py
+++ b/Wrappers/Python/cil/io/NikonDataReader.py
@@ -31,7 +31,7 @@ class NikonDataReader(object):
         ----------
 
             
-        xtek_file: str with full path to .xtexct file
+        file_name: str with full path to .xtexct file
             
         roi: dictionary with roi to load 
                 {'angle': (start, end, step), 

--- a/Wrappers/Python/cil/io/TIFF.py
+++ b/Wrappers/Python/cil/io/TIFF.py
@@ -271,10 +271,10 @@ class TIFFStackReader(object):
         elif os.path.isfile(file_name):
             self._tiff_files = [file_name]
         elif os.path.isdir(file_name): 
-            self._tiff_files = glob.glob(os.path.join(file_name,"*.tif"))
+            self._tiff_files = glob.glob(os.path.join(glob.escape(file_name),"*.tif"))
             
             if not self._tiff_files:
-                self._tiff_files = glob.glob(os.path.join(file_name,"*.tiff"))
+                self._tiff_files = glob.glob(os.path.join(glob.escape(file_name),"*.tiff"))
 
             if not self._tiff_files:
                 raise Exception("No tiff files were found in the directory \n{}".format(file_name))

--- a/Wrappers/Python/test/test_tiff_readerwriter.py
+++ b/Wrappers/Python/test/test_tiff_readerwriter.py
@@ -37,7 +37,9 @@ class TIFFReadWriter(unittest.TestCase):
                 k += 1
         data.fill(arr)
         self.cwd = os.getcwd()
-        fname = os.path.join(self.cwd, 'test_tiff','myfile.tif')
+        # filename contains brackets to test if previous problems 
+        # with use of glob in the tiff reader have been resolved:
+        fname = os.path.join(self.cwd, 'test_tiff [0]','myfile.tif')
         self.data_dir = os.path.dirname(fname)
         writer = TIFFWriter(data=data, file_name=fname, counter_offset=0)
         writer.write()
@@ -52,7 +54,7 @@ class TIFFReadWriter(unittest.TestCase):
         data = self.data
         print (data.shape)
         print ("expecting {} files".format(data.shape[0]*data.shape[1]))
-        files = glob.glob(os.path.join(self.data_dir, '*'))
+        files = glob.glob(os.path.join(glob.escape(self.data_dir), '*'))
         assert len(files) == data.shape[0]*data.shape[1]
     
     def test_read1(self):


### PR DESCRIPTION
## Describe your changes
Fixed an issue with not being able to read Nikon files if their path contains square brackets. This was actually an issue in the TIFF reader (which the Nikon reader uses). The issue arose with the use of glob.glob. I checked and this is the only place in CIL where we use glob.glob so I don't think there should be the same problem elsewhere.

Also updated the Nikon reader docstring so it has the correct name for the file name input argument.

## Describe any testing you have performed
Changed the TIFF reader unit test so the path where the TIFF files are written to contains [ ] . This means it tests reading files with this path.

## Link relevant issues
Closes #1217 
Closes #1207 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

All contributed code must be under [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)