### PR TITLE
Mask operator with domain parameter

### DIFF
--- a/Wrappers/Python/cil/optimisation/operators/DiagonalOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/DiagonalOperator.py
@@ -20,22 +20,32 @@ from cil.framework import ImageData
 from cil.optimisation.operators import LinearOperator
 
 class DiagonalOperator(LinearOperator):
-    
-    r'''DiagonalOperator:  D: X -> X,  takes in a DataContainer or subclass 
-    thereof, diag, representing elements on the diagonal of a diagonal 
-    operator. Maps an element of :math:`x\in X` onto the element 
+
+    r'''DiagonalOperator
+    D: X -> X
+    Maps an element of :math:`x\in X` onto the element 
     :math:`y \in X,  y = diag*x`, where * denotes elementwise multiplication.
-    In matrix-vector interpretation, if x is a vector of length N, then diag is 
-    also a vector of length N, and D will be an NxN diagonal matrix with diag 
+
+    In matrix-vector interpretation, if x is a vector of length N, then diagonal is 
+    also a vector of length N, and D  will be an NxN diagonal matrix with diag 
     on its diagonal and zeros everywhere else.
-                       
-        :param diagonal: DataContainer with diagonal elements
-                       
+
+    Parameters
+    ----------
+    diagonal : DataContainer
+        DataContainer with the same dimensions as the data to be operated on
+    domain_geometry : ImageGeometry
+        Specifies the geometry of the operator domain. If 'None' will use the diagonal geometry directly.
      '''
+
     
-    def __init__(self, diagonal):
-        super(DiagonalOperator, self).__init__(domain_geometry=diagonal.geometry, 
-                                           range_geometry=diagonal.geometry)
+    def __init__(self, diagonal, domain_geometry=None):
+
+        if domain_geometry is None:
+            domain_geometry = diagonal.geometry.copy()
+
+        super(DiagonalOperator, self).__init__(domain_geometry=domain_geometry, 
+                                    range_geometry=domain_geometry)
         self.diagonal = diagonal
 
         
@@ -48,12 +58,14 @@ class DiagonalOperator(LinearOperator):
         else:
             self.diagonal.multiply(x,out=out)
     
+
     def adjoint(self,x, out=None):
         
         '''Returns D^{*}(y), which is identical to direct, so use direct.'''        
         
         return self.direct(x, out=out)
-        
+
+  
     def calculate_norm(self, **kwargs):
         
         '''Evaluates operator norm of DiagonalOperator'''

--- a/Wrappers/Python/cil/optimisation/operators/DiagonalOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/DiagonalOperator.py
@@ -28,10 +28,10 @@ class DiagonalOperator(LinearOperator):
 
     .. math:: (D\circ x) = \sum_{i,j}^{M,N} D_{i,j} x_{i, j}
 
-    In matrix-vector interpretation, if `D` is a :math:`M\timesN` dense matrix and is flattened, we have a :math:`M*N\times M*N` vector.
-    A sparse diagonal matrix, i.e., :class:`DigaonalOperator can be created if we add the vector above to the main diagonal.
+    In matrix-vector interpretation, if `D` is a :math:`M\times N` dense matrix and is flattened, we have a :math:`M*N \times M*N` vector.
+    A sparse diagonal matrix, i.e., :class:`DigaonalOperator` can be created if we add the vector above to the main diagonal.
     If the :class:`DataContainer` `x` is also flattened, we have a :math:`M*N` vector.
-    Now, matrix-vector multiplcation is allowed and results to a :math:`(M*N,1)` vector. After reshaping we recover a :math:`M\timesxN` :class:`DataContainer`. 
+    Now, matrix-vector multiplcation is allowed and results to a :math:`(M*N,1)` vector. After reshaping we recover a :math:`M\times N` :class:`DataContainer`. 
 
     Parameters
     ----------
@@ -65,7 +65,7 @@ class DiagonalOperator(LinearOperator):
 
     def adjoint(self,x, out=None):
         
-        "Returns :math:`D^{T}\circ x` "
+        "Returns :math:`D\circ x` "
         
         return self.direct(x, out=out)
 

--- a/Wrappers/Python/cil/optimisation/operators/DiagonalOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/DiagonalOperator.py
@@ -21,22 +21,26 @@ from cil.optimisation.operators import LinearOperator
 
 class DiagonalOperator(LinearOperator):
 
-    r'''DiagonalOperator
-    D: X -> X
-    Maps an element of :math:`x\in X` onto the element 
-    :math:`y \in X,  y = diag*x`, where * denotes elementwise multiplication.
+    r"""DiagonalOperator 
 
-    In matrix-vector interpretation, if x is a vector of length N, then diagonal is 
-    also a vector of length N, and D  will be an NxN diagonal matrix with diag 
-    on its diagonal and zeros everywhere else.
+    Performs an element-wise multiplication, i.e., `Hadamard Product <https://en.wikipedia.org/wiki/Hadamard_product_(matrices)#:~:text=In%20mathematics%2C%20the%20Hadamard%20product,elements%20i%2C%20j%20of%20the>`_ 
+    of a :class:`DataContainer` `x` and :class:`DataContainer` `diagonal`, `d` .
+
+    .. math:: (D\circ x) = \sum_{i,j}^{M,N} D_{i,j} x_{i, j}
+
+    In matrix-vector interpretation, if `D` is a :math:`M\timesN` dense matrix and is flattened, we have a :math:`M*N\times M*N` vector.
+    A sparse diagonal matrix, i.e., :class:`DigaonalOperator can be created if we add the vector above to the main diagonal.
+    If the :class:`DataContainer` `x` is also flattened, we have a :math:`M*N` vector.
+    Now, matrix-vector multiplcation is allowed and results to a :math:`(M*N,1)` vector. After reshaping we recover a :math:`M\timesxN` :class:`DataContainer`. 
 
     Parameters
     ----------
     diagonal : DataContainer
-        DataContainer with the same dimensions as the data to be operated on
+        DataContainer with the same dimensions as the data to be operated on.
     domain_geometry : ImageGeometry
-        Specifies the geometry of the operator domain. If 'None' will use the diagonal geometry directly.
-     '''
+        Specifies the geometry of the operator domain. If 'None' will use the diagonal geometry directly. default=None
+        
+    """
 
     
     def __init__(self, diagonal, domain_geometry=None):
@@ -51,7 +55,7 @@ class DiagonalOperator(LinearOperator):
         
     def direct(self,x,out=None):
         
-        '''Returns D(x)'''
+        " Returns D(x)"
         
         if out is None:
             return self.diagonal * x

--- a/Wrappers/Python/cil/optimisation/operators/DiagonalOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/DiagonalOperator.py
@@ -38,8 +38,8 @@ class DiagonalOperator(LinearOperator):
     diagonal : DataContainer
         DataContainer with the same dimensions as the data to be operated on.
     domain_geometry : ImageGeometry
-        Specifies the geometry of the operator domain. If 'None' will use the diagonal geometry directly. default=None
-        
+        Specifies the geometry of the operator domain. If 'None' will use the diagonal geometry directly. default=None .
+
     """
 
     
@@ -55,7 +55,7 @@ class DiagonalOperator(LinearOperator):
         
     def direct(self,x,out=None):
         
-        " Returns D(x)"
+        "Returns :math:`D\circ x` "
         
         if out is None:
             return self.diagonal * x
@@ -65,13 +65,13 @@ class DiagonalOperator(LinearOperator):
 
     def adjoint(self,x, out=None):
         
-        '''Returns D^{*}(y), which is identical to direct, so use direct.'''        
+        "Returns :math:`D^{T}\circ x` "
         
         return self.direct(x, out=out)
 
   
     def calculate_norm(self, **kwargs):
         
-        '''Evaluates operator norm of DiagonalOperator'''
+        " Returns the operator norm of DiagonalOperator which is the maximum element in the `diagonal`."
         
         return self.diagonal.max()

--- a/Wrappers/Python/cil/optimisation/operators/MaskOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/MaskOperator.py
@@ -21,20 +21,28 @@ from cil.optimisation.operators import DiagonalOperator
 
 class MaskOperator(DiagonalOperator):
     
-    r'''MaskOperator:  D: X -> X,  takes in a DataContainer or subclass 
-    thereof, mask, with True or 1.0 representing a value to be
-    kept and False or 0.0 a value to be lost/set to zero. Maps an element of 
+    r'''MaskOperator
+    D: X -> X
+    Maps an element of 
     :math:`x\in X` onto the element :math:`y \in X,  y = mask*x`, 
     where * denotes elementwise multiplication.
-                       
-        :param mask: DataContainer of datatype bool or with 1/0 elements
-                       
+
+    Parameters
+    ----------
+    mask : DataContainer
+        Boolean array with the same dimensions as the data to be operated on
+    domain_geometry : ImageGeometry
+        Specifies the geometry of the operator domain. If 'None' will use the mask geometry size and spacing as float32
      '''
     
-    def __init__(self, mask):
-        # Special case of DiagonalOperator which is the superclass of
-        # MaskOperator, so simply instanciate a DiagonalOperator with mask.
-        super(MaskOperator, self).__init__(mask)
+    def __init__(self, mask, domain_geometry=None):
+
+        #if domain_geometry is not specified assume float32 for domain_geometry data type
+        if domain_geometry is None:
+            domain_geometry = mask.geometry.copy()
+            domain_geometry.dtype = np.float32
+
+        super(MaskOperator, self).__init__(mask, domain_geometry)
         self.mask = self.diagonal
         
         

--- a/Wrappers/Python/cil/optimisation/operators/MaskOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/MaskOperator.py
@@ -21,19 +21,15 @@ from cil.optimisation.operators import DiagonalOperator
 
 class MaskOperator(DiagonalOperator):
     
-    r'''MaskOperator
-    D: X -> X
-    Maps an element of 
-    :math:`x\in X` onto the element :math:`y \in X,  y = mask*x`, 
-    where * denotes elementwise multiplication.
-
+    r""" MaskOperator
+   
     Parameters
     ----------
     mask : DataContainer
-        Boolean array with the same dimensions as the data to be operated on
+        Boolean array with the same dimensions as the data to be operated on.
     domain_geometry : ImageGeometry
-        Specifies the geometry of the operator domain. If 'None' will use the mask geometry size and spacing as float32
-     '''
+        Specifies the geometry of the operator domain. If 'None' will use the mask geometry size and spacing as float32. default = None .
+    """
     
     def __init__(self, mask, domain_geometry=None):
 


### PR DESCRIPTION
## Describe your changes
Allows optional `domain_geometry` to be passed to Mask and DiagonalOperator, which doesn't break backward compatibility. If it is not passed mask will default to float32 for geometry allocation.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*

Inpainting demo works with boolean mask
https://github.com/TomographicImaging/CIL-Demos/pull/65

## Link relevant issues
closes #1208 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

All contributed code must be under [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)