### PR TITLE
catch import error if wget is not installed

### DIFF
--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -34,8 +34,6 @@ from cil.io import NEXUSDataReader
 from cil.processors import CentreOfRotationCorrector, CofR_xcorrelation, CofR_image_sharpness
 from cil.processors import TransmissionAbsorptionConverter, AbsorptionTransmissionConverter
 from cil.processors import Slicer, Binner, MaskGenerator, Masker, Padder
-import wget
-import os
 
 from utils import has_gpu_tigre, has_gpu_astra
 

--- a/Wrappers/Python/test/test_io.py
+++ b/Wrappers/Python/test/test_io.py
@@ -48,7 +48,7 @@ except ImportError as ie:
     has_wget = False
 has_prerequisites = has_olefile and has_dxchange and has_astra and has_file \
     and has_wget
-import wget
+
 
 
 from cil.utilities.quality_measures import mae, mse, psnr


### PR DESCRIPTION
## Describe your changes

unit tests importing `wget` would fail if `wget` is not installed in the environment.
The `import wget` line is now in a `try/except` in `test_io` and removed from the `test_DataProcessor` where it wasn't even used.

## Describe any testing you have performed

I ran all unit tests locally in an environment without `wget` installed

## Link relevant issues

closes #881

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

All contributed code must be under [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)