### PR TITLE
fix for paths with spaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(Git REQUIRED)
 find_package(Python COMPONENTS Interpreter REQUIRED)
 
 if (Python_FOUND)
-  execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Wrappers/Python/CMake/parse_git_describe.py ${GIT_EXECUTABLE}
+  execute_process(COMMAND "${Python_EXECUTABLE}" ${CMAKE_CURRENT_SOURCE_DIR}/Wrappers/Python/CMake/parse_git_describe.py "${GIT_EXECUTABLE}"
                 RESULT_VARIABLE worked 
                 OUTPUT_VARIABLE CIL_VERSION
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/Wrappers/Python/CMake/parse_git_describe.py
+++ b/Wrappers/Python/CMake/parse_git_describe.py
@@ -3,8 +3,7 @@ import re, subprocess, sys, os
 git_executable = os.path.abspath(sys.argv[1])
 
 pattern = re.compile('v([0-9]*)\.([0-9]*)(\.*)([0-9]*)')
-git_describe_string = subprocess.check_output(f'{git_executable} describe', shell=True).decode("utf-8").rstrip()
-
+git_describe_string = subprocess.check_output(f'"{git_executable}" describe', shell=True).decode("utf-8").rstrip()
 v = git_describe_string.split('-')
 if len(v) == 3:
     git_version_string, git_commit_number, git_hash = git_describe_string.split('-')


### PR DESCRIPTION
## Describe your changes
on windows the normal path to "program files" has a space that was breaking cmake.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
Built with updates

## Link relevant issues


## Checklist when you are ready to request a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

All contributed code must be under [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)