### PR TITLE
Limit pydata-sphinx-theme version

### DIFF
--- a/docs/docs_environment.yml
+++ b/docs/docs_environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - tigre
   - sphinx_rtd_theme
   - sphinxcontrib-bibtex
-  - pydata-sphinx-theme
+  - pydata-sphinx-theme<0.9
   - sphinx=3.5.*
   - recommonmark=0.6.*
   - sphinx-panels=0.5


### PR DESCRIPTION
## Describe your changes
Limit pydata-sphinx-theme version to prevent error with docs build.
I saw that a new (0.9) version of pydata-sphinx-theme was released 12 days ago, which seems to be causing the problems with running the docs build action.

## Describe any testing you have performed
testing requires opening a PR - as you can see the docs_build ran successfully.


## Link relevant issues
Example of action that was previously failing: https://github.com/TomographicImaging/CIL/runs/6975506254?check_suite_focus=true

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
