### PR TITLE
show_geometry update for matplotlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 22.0.0
+ - Fixes show_geometry compatibility issue with matplotlib 3.5
+
 * 21.4.1
  - Removed prints from unittests and cleanup of unittest code.
  - CMake: 

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -402,6 +402,12 @@ class _Arrow3D(FancyArrowPatch):
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         FancyArrowPatch.draw(self, renderer)
 
+    def do_3d_projection(self, renderer=None):
+        xs3d, ys3d, zs3d = self._verts3d
+        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
+        self.set_positions((xs[0],ys[0]),(xs[1],ys[1]))
+        return np.min(zs)
+
 class _ShowGeometry(object):
 
     def __init__(self, acquisition_geometry, image_geometry=None):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     - python
     - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x.x') }}
     - scipy >=1.4.0
-    - matplotlib >=3.3.0,<3.5
+    - matplotlib >=3.3.0
     - h5py
     - pillow
     - libgcc-ng     # [linux]


### PR DESCRIPTION
## Describe your changes
Added `do_3d_projection` method to allow us to use matplotlib v3.5 and ease the recipe constraints.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*

Ran the geometry notebook with matplotlib v3.4.3 and v3.5

## Link relevant issues
closes #1111
Potentially helps with #1225

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
