### PR TITLE
NikonDataReader enhancement 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 * 22.0.0
+  - Update NikonDataReader to parse and set up geometry with: `ObjectTilt` `CentreOfRotationTop` and `CentreOfRotationBottom`
   - Merged CIL-ASTRA code in to CIL repository simplifying test, build and install procedures
     - Modules not moved should be considered deprecated
-    - CIL remains licenced as APACHE-2.0
+    - CIL remains licensed as APACHE-2.0
     - Minor bug fixes to the CPU 2D Parallel-beam FBP
   - Add ndim property for DataContainer class.
   - Fixes show_geometry compatibility issue with matplotlib 3.5

--- a/Wrappers/Python/cil/io/NikonDataReader.py
+++ b/Wrappers/Python/cil/io/NikonDataReader.py
@@ -123,7 +123,7 @@ class NikonDataReader(object):
             roi['vertical'] = -1
                 
         # parse xtekct file
-        with open(self.file_name, 'r') as f:
+        with open(self.file_name, 'r', errors='replace') as f:
             content = f.readlines()    
                 
         content = [x.strip() for x in content]

--- a/Wrappers/Python/cil/io/NikonDataReader.py
+++ b/Wrappers/Python/cil/io/NikonDataReader.py
@@ -17,7 +17,7 @@
 from cil.framework import AcquisitionData, AcquisitionGeometry
 from cil.io.TIFF import TIFFStackReader
 import warnings
-import numpy
+import numpy as np
 import os
     
         
@@ -31,7 +31,7 @@ class NikonDataReader(object):
         ----------
 
             
-        file_name: str with full path to .xtexct file
+        file_name: str with full path to .xtekct file
             
         roi: dictionary with roi to load 
                 {'angle': (start, end, step), 
@@ -64,7 +64,7 @@ class NikonDataReader(object):
         Output
         ------
         
-        Acquisition data with corresponding geomrtry, arranged as ['angle', horizontal'] 
+        Acquisition data with corresponding geometry, arranged as ['angle', horizontal'] 
         if a single slice is loaded and ['vertical, 'angle', horizontal'] 
         if more than 1 slices are loaded.
                     
@@ -106,9 +106,9 @@ class NikonDataReader(object):
             warnings.warn("'normalize' has now been deprecated. Please use 'normalise' instead.")
 
         if self.file_name == None:
-            raise Exception('Path to xtek file is required.')
+            raise Exception('Path to xtekct file is required.')
         
-        # check if xtek file exists
+        # check if xtekct file exists
         if not(os.path.isfile(self.file_name)):
             raise Exception('File\n {}\n does not exist.'.format(self.file_name))
         
@@ -118,7 +118,7 @@ class NikonDataReader(object):
         # check labels     
         for key in self.roi.keys():
             if key not in ['angle', 'horizontal', 'vertical']:
-                raise Exception("Wrong label. One of ollowing is expected: angle, horizontal, vertical")
+                raise Exception("Wrong label. One of the following is expected: angle, horizontal, vertical")
         
         roi = self.roi.copy()
         
@@ -131,7 +131,7 @@ class NikonDataReader(object):
         if 'vertical' not in roi.keys():
             roi['vertical'] = -1
                 
-        # parse xtek file
+        # parse xtekct file
         with open(self.file_name, 'r') as f:
             content = f.readlines()    
                 
@@ -142,6 +142,7 @@ class NikonDataReader(object):
         detector_offset_v = 0
         object_offset_x = 0
         object_roll_deg = 0
+        object_tilt_deg = 0
 
         for line in content:
             # filename of TIFF files
@@ -189,6 +190,8 @@ class NikonDataReader(object):
             # object roll in degrees  
             elif line.startswith("ObjectRoll"):
                 object_roll_deg = float(line.split('=')[1])
+            elif line.startswith("ObjectTilt"):
+                object_tilt_deg = float(line.split('=')[1])
             # directory where data is stored
             elif line.startswith("InputFolderName"):
                 input_folder_name = line.split('=')[1]
@@ -230,8 +233,8 @@ class NikonDataReader(object):
             pixel_size_v = pixel_size_v_0 * self._roi_par[1][2]
             pixel_size_h = pixel_size_h_0 * self._roi_par[2][2]
         else: # slice
-            pixel_num_v = numpy.int(numpy.ceil((self._roi_par[1][1] - self._roi_par[1][0]) / self._roi_par[1][2]))
-            pixel_num_h = numpy.int(numpy.ceil((self._roi_par[2][1] - self._roi_par[2][0]) / self._roi_par[2][2]))
+            pixel_num_v = np.int(np.ceil((self._roi_par[1][1] - self._roi_par[1][0]) / self._roi_par[1][2]))
+            pixel_num_h = np.int(np.ceil((self._roi_par[2][1] - self._roi_par[2][0]) / self._roi_par[2][2]))
             pixel_size_v = pixel_size_v_0
             pixel_size_h = pixel_size_h_0
         
@@ -245,8 +248,8 @@ class NikonDataReader(object):
         det_end = det_start + pixel_num_v * self._roi_par[1][2]
         det_pos_v = (det_start + det_end) * 0.5 * pixel_size_v_0 + detector_offset_v         
 
-        #angles from xtek.ct ignore *.ang and _ctdata.txt as not correct
-        angles = numpy.asarray( [ angular_step * proj for proj in range(num_projections) ] , dtype=numpy.float32)
+        #angles from xtekct ignore *.ang and _ctdata.txt as not correct
+        angles = np.asarray( [ angular_step * proj for proj in range(num_projections) ] , dtype=np.float32)
         
         if self.mode == 'bin':
             n_elem = (self._roi_par[0][1] - self._roi_par[0][0]) // self._roi_par[0][2]
@@ -258,8 +261,23 @@ class NikonDataReader(object):
         #convert NikonGeometry to CIL geometry
         angles = -angles - initial_angle + 180
 
-        object_roll_deg * numpy.pi /180.
-        rotate_axis_x = numpy.tan(object_roll_deg * numpy.pi /180.)
+        object_roll = object_roll_deg * np.pi /180.
+        object_tilt = -object_tilt_deg * np.pi /180.
+
+        tilt_matrix = np.eye(3)
+        tilt_matrix[1][1] = tilt_matrix[2][2] = np.cos(object_tilt)
+        tilt_matrix[1][2] = -np.sin(object_tilt)
+        tilt_matrix[2][1] = np.sin(object_tilt)
+
+        roll_matrix = np.eye(3)
+        roll_matrix[0][0] = roll_matrix[2][2] = np.cos(object_roll)
+        roll_matrix[0][2] = np.sin(object_roll)
+        roll_matrix[2][0] = -np.sin(object_roll)
+
+        #order of construction may be reversed, but unlikely to have both in a dataset
+        rot_matrix = np.matmul(tilt_matrix,roll_matrix)
+        rotation_axis_direction = rot_matrix.dot([0,0,1])
+
 
         if self.fliplr:
             origin = 'top-left'
@@ -279,7 +297,7 @@ class NikonDataReader(object):
         else:
             self._ag = AcquisitionGeometry.create_Cone3D(source_position=[0, -source_to_origin, 0],
                                                          rotation_axis_position=[-object_offset_x, 0, 0],
-                                                         rotation_axis_direction=[rotate_axis_x,0,1],
+                                                         rotation_axis_direction=rotation_axis_direction,
                                                          detector_position=[-det_pos_h, source_to_det-source_to_origin, det_pos_v])
             self._ag.set_angles(angles, 
                                 angle_unit='degree')
@@ -327,12 +345,12 @@ class NikonDataReader(object):
         if (self.normalise):
             ad.array[ad.array < 1] = 1
             # cast the data read to float32
-            ad = ad / numpy.float32(self._white_level)
+            ad = ad / np.float32(self._white_level)
             
         
         if self.fliplr:
             dim = ad.get_dimension_axis('horizontal')
-            ad.array = numpy.flip(ad.array, dim)
+            ad.array = np.flip(ad.array, dim)
         
         return ad
 

--- a/Wrappers/Python/cil/plugins/tigre/Geometry.py
+++ b/Wrappers/Python/cil/plugins/tigre/Geometry.py
@@ -149,6 +149,7 @@ class TIGREGeometry(Geometry):
             #this is in CIL reference frames as the TIGRE geometry rotates the reconstruction volume to match our definitions
             self.offOrigin[0] += ig.center_z
 
+
             #convert roll, pitch, yaw
             U = system.detector.direction_x[ind] * flip
             V = system.detector.direction_y[ind] * flip
@@ -163,9 +164,11 @@ class TIGREGeometry(Geometry):
 
         self.theta = yaw
         panel_origin = ag_in.config.panel.origin
-        if 'right' in panel_origin:
+        if 'right' in panel_origin and 'top' in panel_origin:
+            roll += np.pi
+        elif 'right' in panel_origin:
             yaw += np.pi
-        if 'top' in panel_origin:
+        elif 'top' in panel_origin:
             pitch += np.pi
 
         self.rotDetector = np.array((roll, pitch, yaw)) 


### PR DESCRIPTION
## Describe your changes
Update the Nikon reader to read in `ObjectTilt` and configure the geometry.
Update the Nikon reader to read in `CentreOfRotationTop` and `CentreOfRotationBottom` (old version of parameters) and configure the geometry.
Bug fix to Tigre geometry for tilted Nikon data

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
Tigre unit tests pass
Read in old version of `xtekct` (from DTU) with  `CentreOfRotationTop` and `CentreOfRotationBottom` parameters and confirmed reconstruction looked correct. 
Read in new versions of `xtekct` with `ObjectTilt` and `ObjectOffsetX` and confirmed reconstruction of extreme slices is centred as expected.
Read in laminography dataset and confirmed geometry was set up correctly.
Ran LegoLaminography demo

read in dataset without rolled rotation axis:
![output_orig](https://user-images.githubusercontent.com/47746591/180007973-f89b186e-7b92-4492-8f98-ec5f4ae7ca7c.png)

read in dataset including rolled rotation axis:
![output_cor](https://user-images.githubusercontent.com/47746591/180007995-47bc7d45-4a85-4bd2-aed3-59e9ffbb4212.png)


## Link relevant issues
closes #1277 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
