### PR TITLE
DataProcessors use weak-references to input data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 * 22.0.0
+  - DataProcessors use weak-reference to input data
   - Merged CIL-ASTRA code in to CIL repository simplifying test, build and install procedures
     - Modules not moved should be considered deprecated
-    - CIL remains licenced as APACHE-2.0
+    - CIL remains licensed as APACHE-2.0
     - Minor bug fixes to the CPU 2D Parallel-beam FBP
   - Add ndim property for DataContainer class.
   - Fixes show_geometry compatibility issue with matplotlib 3.5

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -22,6 +22,8 @@ from numbers import Number
 import ctypes, platform
 from ctypes import util
 import math
+import weakref
+
 from cil.utilities.multiprocessing import NUM_THREADS
 # check for the extension
 
@@ -2963,6 +2965,7 @@ class Processor(object):
     `store_output` boolian defining whether a copy of the output is stored. Default is False.
     If no attributes are modified get_output will return this stored copy bypassing `process`
     '''
+
     def __init__(self, **attributes):
         if not 'store_output' in attributes.keys():
             attributes['store_output'] = False
@@ -3002,7 +3005,7 @@ class Processor(object):
 
         if issubclass(type(dataset), DataContainer):
             if self.check_input(dataset):
-                self.__dict__['input'] = dataset
+                self.__dict__['input'] = weakref.ref(dataset)
                 self.__dict__['shouldRun'] = True
             else:
                 raise ValueError('Input data not compatible')
@@ -3010,8 +3013,6 @@ class Processor(object):
             raise TypeError("Input type mismatch: got {0} expecting {1}"\
                             .format(type(dataset), DataContainer))
     
-    def clear_input(self):
-        self.__dict__['input']= None
 
     def check_input(self, dataset):
         '''Checks parameters of the input DataContainer
@@ -3052,7 +3053,7 @@ class Processor(object):
     
     def set_input_processor(self, processor):
         if issubclass(type(processor), DataProcessor):
-            self.__dict__['input'] = processor
+            self.__dict__['input'] =  weakref.ref(processor)
         else:
             raise TypeError("Input type mismatch: got {0} expecting {1}"\
                             .format(type(processor), DataProcessor))
@@ -3063,10 +3064,12 @@ class Processor(object):
         It is useful in the case the user has provided a DataProcessor as
         input
         '''
-        if issubclass(type(self.input), DataProcessor):
-            dsi = self.input.get_output()
+        if self.input() is None:
+            raise ValueError("Input has been deallocated externally")
+        elif issubclass(type(self.input()), DataProcessor):
+            dsi = self.input().get_output()
         else:
-            dsi = self.input
+            dsi = self.input()
         return dsi
         
     def process(self, out=None):
@@ -3081,8 +3084,6 @@ class Processor(object):
         else:
             self.get_output(out=out)
 
-        self.clear_input()
-        
         return out
 
 

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -738,19 +738,19 @@ class TestCentreOfRotation_parallel(unittest.TestCase):
     def test_CofR_xcorrelation(self):       
 
         corr = CofR_xcorrelation(slice_index='centre', projection_index=0, ang_tol=0.1)
-        corr.set_input(self.data_DLS.clone())
+        corr.set_input(self.data_DLS)
         ad_out = corr.get_output()
         self.assertAlmostEqual(6.33, ad_out.geometry.config.system.rotation_axis.position[0],places=2)     
         
         corr = CofR_xcorrelation(slice_index=67, projection_index=0, ang_tol=0.1)
-        corr.set_input(self.data_DLS.clone())
+        corr.set_input(self.data_DLS)
         ad_out = corr.get_output()
         self.assertAlmostEqual(6.33, ad_out.geometry.config.system.rotation_axis.position[0],places=2)              
 
     @unittest.skipUnless(has_astra, "ASTRA not installed")
     def test_CofR_image_sharpness_astra(self):
         corr = CofR_image_sharpness(search_range=20, FBP=AstraFBP)
-        corr.set_input(self.data_DLS.clone())
+        corr.set_input(self.data_DLS)
         ad_out = corr.get_output()
         self.assertAlmostEqual(6.33, ad_out.geometry.config.system.rotation_axis.position[0],places=1)     
 
@@ -758,18 +758,18 @@ class TestCentreOfRotation_parallel(unittest.TestCase):
     @unittest.skipUnless(False, "TIGRE not installed")
     def skiptest_test_CofR_image_sharpness_tigre(self): #currently not avaliable for parallel beam
         corr = CofR_image_sharpness(search_range=20, FBP=TigreFBP)
-        corr.set_input(self.data_DLS.clone())
+        corr.set_input(self.data_DLS)
         ad_out = corr.get_output()
         self.assertAlmostEqual(6.33, ad_out.geometry.config.system.rotation_axis.position[0],places=2)     
 
     def test_CenterOfRotationCorrector(self):       
         corr = CentreOfRotationCorrector.xcorrelation(slice_index='centre', projection_index=0, ang_tol=0.1)
-        corr.set_input(self.data_DLS.clone())
+        corr.set_input(self.data_DLS)
         ad_out = corr.get_output()
         self.assertAlmostEqual(6.33, ad_out.geometry.config.system.rotation_axis.position[0],places=2)     
         
         corr = CentreOfRotationCorrector.xcorrelation(slice_index=67, projection_index=0, ang_tol=0.1)
-        corr.set_input(self.data_DLS.clone())
+        corr.set_input(self.data_DLS)
         ad_out = corr.get_output()
         self.assertAlmostEqual(6.33, ad_out.geometry.config.system.rotation_axis.position[0],places=2)              
 
@@ -869,11 +869,18 @@ class TestDataProcessor(unittest.TestCase):
         ax.get_output(out=dc_out)
         numpy.testing.assert_array_equal(dc_out.as_array(), out_gold.as_array())
 
-        #check recalculation on input modified (won't pass)
+        #check auto recalculation if input modified (won't pass)
         dc_in2 *= 2
         out_gold = dc_in2*3
         ax.get_output(out=dc_out)
         #numpy.testing.assert_array_equal(dc_out.as_array(), out_gold.as_array())
+
+        #raise error if input is deleted
+        dc_in2 = dc_in.copy()
+        ax.set_input(dc_in2)
+        del dc_in2
+        with self.assertRaises(ValueError):
+            dc_out = ax.get_output()
 
 
     def test_DataProcessorChaining(self):


### PR DESCRIPTION
## Describe your changes
DataProcessors use weak-references to input data.

i.e. if all references to a dataset are deleted, a `DataProcessors` object will no longer keep a copy.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
Unit tests

## Link relevant issues
closes #1167

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
