### PR TITLE
update gradient operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * 22.0.0
+  - TotalVariation: updates gradient operator at each __call__ or proximal call.
   - Deprecated: `x_init` removed from the initialisation of the Algorithms and `initial` will be used.
   - DataProcessors use weak-reference to input data
   - Merged CIL-ASTRA code in to CIL repository simplifying test, build and install procedures

--- a/Wrappers/Python/cil/optimisation/functions/TotalVariation.py
+++ b/Wrappers/Python/cil/optimisation/functions/TotalVariation.py
@@ -108,7 +108,6 @@ class TotalVariation(Function):
                         
         # Setup GradientOperator as None. This is to avoid domain argument in the __init__     
 
-        self._gradient = None
         self._domain = None
 
         self.pptmp = None
@@ -300,10 +299,11 @@ class TotalVariation(Function):
         '''creates a gradient operator if not instantiated yet
 
         There is no check that the variable _domain is changed after instantiation (should not be the case)'''
-        if self._gradient is None:
-            if self._domain is not None:
-                self._gradient = GradientOperator(self._domain, correlation = self.correlation, backend = self.backend)
-        return self._gradient
+        
+        if self._domain is not None:
+            return GradientOperator(self._domain, correlation = self.correlation, backend = self.backend)
+        raise ValueError('')
+        
     def __rmul__(self, scalar):
         if not isinstance (scalar, Number):
             raise TypeError("scalar: Expectec a number, got {}".format(type(scalar)))

--- a/Wrappers/Python/cil/optimisation/functions/TotalVariation.py
+++ b/Wrappers/Python/cil/optimisation/functions/TotalVariation.py
@@ -296,13 +296,13 @@ class TotalVariation(Function):
     
     @property
     def gradient(self):
-        '''creates a gradient operator if not instantiated yet
+        '''Returns a gradient operator compatible with the internal variable _domain if available
 
         There is no check that the variable _domain is changed after instantiation (should not be the case)'''
         
         if self._domain is not None:
             return GradientOperator(self._domain, correlation = self.correlation, backend = self.backend)
-        raise ValueError('')
+        raise ValueError('Cannot return a valid GradientOperator. Please call __call__ or proximal first.')
         
     def __rmul__(self, scalar):
         if not isinstance (scalar, Number):

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -878,6 +878,11 @@ class TestTotalVariation(unittest.TestCase):
         res2 = self.grad.direct(x_real).pnorm(1).sum()
         np.testing.assert_equal(res1, res2)                
     
+    def test_gradient_not_initialised(self):
+        with self.assertRaises(ValueError):
+            tv = TotalVariation()
+            x_real = self.ig_real.allocate('random', seed=4)  
+            grad = tv.gradient.direct(x_real)
 
     @unittest.skipUnless(has_reg_toolkit, "Regularisation Toolkit not present")
     def test_compare_regularisation_toolkit(self):


### PR DESCRIPTION
## Describe your changes

Enables to use a `TotalVariation` class on data with different geometries, because `Function`s do not have domain.

This way the property `gradient` will always be in sync with the data it is applied to.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues

closes #1170
## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
