### PR TITLE
update deprecated numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 * 22.0.0
-  - Deprecated: `x_init` removed from the initialisation of the Algorithms and `initial` will be used.
+  - Removal of deprecated code
+    - AcquisitionGeometry `__init__` no longer sets up a working geometry, use factory `create` methods instead
+    - `subset` method removed, use `get_slice` or `reorder` methods
+    - NikonDataReader `normalize` kwarg removed, use `normalise`
+    - Algorithms initialisation `x_init` kwarg removed, use `initial`
+    - Removed deprecated numpy calls
   - DataProcessors use weak-reference to input data
   - Merged CIL-ASTRA code in to CIL repository simplifying test, build and install procedures
     - Modules not moved should be considered deprecated

--- a/Wrappers/Python/cil/framework/BlockDataContainer.py
+++ b/Wrappers/Python/cil/framework/BlockDataContainer.py
@@ -104,10 +104,7 @@ class BlockDataContainer(object):
             return True   
         elif isinstance(other, (list, tuple, numpy.ndarray)) :
             for ot in other:
-                if not isinstance(ot, (Number,\
-                                 numpy.int, numpy.int8, numpy.int16, numpy.int32, numpy.int64,\
-                                 numpy.float, numpy.float16, numpy.float32, numpy.float64, \
-                                 numpy.complex)):
+                if not isinstance(ot, Number):
                     raise ValueError('List/ numpy array can only contain numbers {}'\
                                      .format(type(ot)))
             return len(self.containers) == len(other)

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -316,7 +316,7 @@ class ImageGeometry(object):
                 seed = kwargs.get('seed', None)
                 if seed is not None:
                     numpy.random.seed(seed)
-                if dtype in [ numpy.complex , numpy.complex64 , numpy.complex128 ] :
+                if numpy.iscomplexobj(out.array):
                     r = numpy.random.random_sample(self.shape) + 1j * numpy.random.random_sample(self.shape)
                     out.fill(r)
                 else: 
@@ -532,7 +532,7 @@ class SystemConfiguration(object):
             axis_rotation[0][1] = -math.sin(theta)
             axis_rotation[1][0] = math.sin(theta)
 
-        return numpy.matrix(axis_rotation)
+        return axis_rotation
 
     @staticmethod
     def rotation_vec_to_z(vec):
@@ -559,7 +559,7 @@ class SystemConfiguration(object):
         else:
             raise ValueError("Vec must have length 3, got {}".format(len(vec)))
     
-        return numpy.matrix(axis_rotation)
+        return axis_rotation
 
     def update_reference_frame(self):
         r'''Transforms the system origin to the rotation_axis position
@@ -1966,7 +1966,7 @@ class AcquisitionGeometry(object):
                 seed = kwargs.get('seed', None)
                 if seed is not None:
                     numpy.random.seed(seed)
-                if dtype in [ numpy.complex , numpy.complex64 , numpy.complex128 ] :
+                if numpy.iscomplexobj(out.array):
                     r = numpy.random.random_sample(self.shape) + 1j * numpy.random.random_sample(self.shape)
                     out.fill(r)
                 else:
@@ -2361,10 +2361,7 @@ class DataContainer(object):
         out = kwargs.get('out', None)
         
         if out is None:
-            if isinstance(x2, (int, float, complex, \
-                                 numpy.int, numpy.int8, numpy.int16, numpy.int32, numpy.int64,\
-                                 numpy.float, numpy.float16, numpy.float32, numpy.float64, \
-                                 numpy.complex)):
+            if isinstance(x2, Number):
                 out = pwop(self.as_array() , x2 , *args, **kwargs )
             elif issubclass(x2.__class__ , DataContainer):
                 out = pwop(self.as_array() , x2.as_array() , *args, **kwargs )
@@ -2394,10 +2391,7 @@ class DataContainer(object):
             else:
                 raise ValueError(message(type(self),"Wrong size for data memory: out {} x2 {} expected {}".format( out.shape,x2.shape ,self.shape)))
         elif issubclass(type(out), DataContainer) and \
-             isinstance(x2, (int,float,complex, numpy.int, numpy.int8, \
-                             numpy.int16, numpy.int32, numpy.int64,\
-                             numpy.float, numpy.float16, numpy.float32,\
-                             numpy.float64, numpy.complex)):
+             isinstance(x2, Number):
             if self.check_dimensions(out):
                 kwargs['out']=out.as_array()
                 pwop(self.as_array(), x2, *args, **kwargs )

--- a/Wrappers/Python/cil/io/NikonDataReader.py
+++ b/Wrappers/Python/cil/io/NikonDataReader.py
@@ -230,8 +230,8 @@ class NikonDataReader(object):
             pixel_size_v = pixel_size_v_0 * self._roi_par[1][2]
             pixel_size_h = pixel_size_h_0 * self._roi_par[2][2]
         else: # slice
-            pixel_num_v = numpy.int(numpy.ceil((self._roi_par[1][1] - self._roi_par[1][0]) / self._roi_par[1][2]))
-            pixel_num_h = numpy.int(numpy.ceil((self._roi_par[2][1] - self._roi_par[2][0]) / self._roi_par[2][2]))
+            pixel_num_v = int(numpy.ceil((self._roi_par[1][1] - self._roi_par[1][0]) / self._roi_par[1][2]))
+            pixel_num_h = int(numpy.ceil((self._roi_par[2][1] - self._roi_par[2][0]) / self._roi_par[2][2]))
             pixel_size_v = pixel_size_v_0
             pixel_size_h = pixel_size_h_0
         

--- a/Wrappers/Python/cil/io/TIFF.py
+++ b/Wrappers/Python/cil/io/TIFF.py
@@ -300,7 +300,7 @@ class TIFFStackReader(object):
     def _get_file_type(self, img): 
         mode = img.mode
         if mode == '1':
-            dtype = np.bool
+            dtype = np.bool_
         elif mode == 'L':
             dtype = np.uint8
         elif mode == 'F':
@@ -384,9 +384,9 @@ class TIFFStackReader(object):
                     
         else: # slice mode
             # calculate number of pixels
-            n_rows = np.int(np.ceil((roi_par[1][1] - roi_par[1][0]) / roi_par[1][2]))
-            n_cols = np.int(np.ceil((roi_par[2][1] - roi_par[2][0]) / roi_par[2][2]))
-            num_to_read = np.int(np.ceil((roi_par[0][1] - roi_par[0][0]) / roi_par[0][2]))
+            n_rows = int(np.ceil((roi_par[1][1] - roi_par[1][0]) / roi_par[1][2]))
+            n_cols = int(np.ceil((roi_par[2][1] - roi_par[2][0]) / roi_par[2][2]))
+            num_to_read = int(np.ceil((roi_par[0][1] - roi_par[0][0]) / roi_par[0][2]))
             
             if not self.transpose:
                 im = np.zeros((num_to_read, n_rows, n_cols), dtype=self.dtype)

--- a/Wrappers/Python/cil/optimisation/operators/GradientOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/GradientOperator.py
@@ -81,26 +81,24 @@ class GradientOperator(LinearOperator):
         # Default correlation for the gradient coupling
         correlation = kwargs.get('correlation',CORRELATION_SPACE)
 
-        # Add attributes for SIRF data where there is no CIL geometry
-        if not isinstance(domain_geometry, ImageGeometry):
+        # Add assumed attributes if there is no CIL geometry (i.e. SIRF objects)
+        if not hasattr(domain_geometry, 'channels'):
             domain_geometry.channels = 1
-            domain_geometry.dimension_labels = [None]*len(domain_geometry.shape)        
-                       
-        # Space correlation on multichannel data call numpy backend
-        if correlation == CORRELATION_SPACE and domain_geometry.channels > 1:
-            #numpy implementation only for now
-            backend = NUMPY
-            logging.info("correlation='Space' on multi-channel dataset will use `numpy` backend")
 
-        # Complex data will use numpy backend
-        if domain_geometry.dtype in [np.complex, np.complex64]:
-            backend = NUMPY
-            logging.info("Complex geometries will use `numpy` backend")
-        
-        if method != 'forward':
-            backend = NUMPY
-            logging.info("Method = {} implemented on `numpy` backend. Other methods are backward/centered.".format(method))            
-            
+        if not hasattr(domain_geometry, 'dimension_labels'):
+            domain_geometry.dimension_labels = [None]*len(domain_geometry.shape)       
+
+        if backend == C:
+            if correlation == CORRELATION_SPACE and domain_geometry.channels > 1:
+                backend = NUMPY
+                logging.warning("C backend cannot use correlation='Space' on multi-channel dataset - defaulting to `numpy` backend")
+            elif domain_geometry.dtype != np.float32:
+                backend = NUMPY
+                logging.warning("C backend is only for arrays of datatype float32 - defaulting to `numpy` backend")
+            elif method != 'forward':
+                backend = NUMPY
+                logging.warning("C backend is only implemented for forward differences - defaulting to `numpy` backend")
+   
         if backend == NUMPY:
             self.operator = Gradient_numpy(domain_geometry, bnd_cond=bnd_cond, **kwargs)
         else:

--- a/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
+++ b/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
@@ -48,7 +48,7 @@ class RegulariserFunction(Function):
 
         self.check_input(x)
         arr = x.as_array()
-        if arr.dtype in [np.complex, np.complex64]:
+        if np.iscomplexobj(arr):
             # do real and imag part indep
             in_arr = np.asarray(arr.real, dtype=np.float32, order='C')
             res, info = self.proximal_numpy(in_arr, tau)

--- a/Wrappers/Python/cil/processors/MaskGenerator.py
+++ b/Wrappers/Python/cil/processors/MaskGenerator.py
@@ -218,7 +218,7 @@ class MaskGenerator(DataProcessor):
                 axis_index = None
 
         # intialise mask with all ones
-        mask = numpy.ones(arr.shape, dtype=numpy.bool)
+        mask = numpy.ones(arr.shape, dtype=bool)
         
         # if NaN or +/-Inf
         if self.mode == 'special_values':
@@ -363,7 +363,7 @@ class MaskGenerator(DataProcessor):
         
 
         if out is None:
-            mask = numpy.asarray(mask, dtype=numpy.bool)
+            mask = numpy.asarray(mask, dtype=bool)
             out = type(data)(mask, deep_copy=False, dtype=mask.dtype, geometry=data.geometry, suppress_warning=True, dimension_labels=data.dimension_labels)
             return out
         else:

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -562,9 +562,14 @@ class TestDataContainer(CCPiTestClass):
         self.assertEqual(geometry.dtype, numpy.float32)
 
         #print("Change it to complex")
-        geometry.dtype = numpy.complex
-        #print("The {} dtype is now {} ".format(classname , geometry.dtype))         
-        self.assertEqual(geometry.dtype, numpy.complex)
+        geometry.dtype = numpy.complex64
+        self.assertEqual(geometry.dtype, numpy.complex64)
+
+        geometry.dtype = numpy.complex128
+        self.assertEqual(geometry.dtype, numpy.complex128)
+
+        geometry.dtype = complex
+        self.assertEqual(geometry.dtype, complex)
 
         #print("Test {} allocate".format(classname ))
         data = geometry.allocate()
@@ -583,7 +588,7 @@ class TestDataContainer(CCPiTestClass):
         self.assertEqual(data.dtype, numpy.int64)
 
         #print("The dtype of the {} remain unchanged ig.dtype =  {}".format(classname, geometry.dtype))
-        self.assertEqual(geometry.dtype, numpy.complex)
+        self.assertEqual(geometry.dtype, complex)
 
         self.assertNotEqual(id(geometry), id(data.geometry))
 
@@ -617,7 +622,7 @@ class TestDataContainer(CCPiTestClass):
 
 
     def complex_allocate_geometry_test(self, geometry):
-        data = geometry.allocate(dtype=numpy.complex)
+        data = geometry.allocate(dtype=numpy.complex64)
         r = (1 + 1j*1)* numpy.ones(data.shape, dtype=data.dtype)
         data.fill(r)
         self.assertAlmostEqual(data.squared_norm(), data.size * 2)  

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -972,7 +972,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((10,10), dtype=numpy.bool)
+        mask_manual = numpy.ones((10,10), dtype=bool)
         mask_manual[2,3] = 0
         mask_manual[4,5] = 0
         
@@ -983,7 +983,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((10,10), dtype=numpy.bool)
+        mask_manual = numpy.ones((10,10), dtype=bool)
         mask_manual[4,5] = 0
         
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
@@ -993,7 +993,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((10,10), dtype=numpy.bool)
+        mask_manual = numpy.ones((10,10), dtype=bool)
         mask_manual[2,3] = 0
         
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
@@ -1007,7 +1007,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((10,10), dtype=numpy.bool)
+        mask_manual = numpy.ones((10,10), dtype=bool)
         mask_manual[6,8] = 0
         mask_manual[1,3] = 0
         
@@ -1017,7 +1017,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((10,10), dtype=numpy.bool)
+        mask_manual = numpy.ones((10,10), dtype=bool)
         mask_manual[6,8] = 0
         
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
@@ -1031,7 +1031,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((10,10), dtype=numpy.bool)
+        mask_manual = numpy.ones((10,10), dtype=bool)
         mask_manual[6,8] = 0
         mask_manual[1,3] = 0
         
@@ -1041,7 +1041,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((10,10), dtype=numpy.bool)
+        mask_manual = numpy.ones((10,10), dtype=bool)
         mask_manual[6,8] = 0
         
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
@@ -1059,7 +1059,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((200,200), dtype=numpy.bool)
+        mask_manual = numpy.ones((200,200), dtype=bool)
         mask_manual[7,4] = 0
         
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
@@ -1068,7 +1068,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((200,200), dtype=numpy.bool)
+        mask_manual = numpy.ones((200,200), dtype=bool)
         mask_manual[7,4] = 0
         
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
@@ -1078,7 +1078,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((200,200), dtype=numpy.bool)
+        mask_manual = numpy.ones((200,200), dtype=bool)
         mask_manual[7,4] = 0
         
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
@@ -1087,7 +1087,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((200,200), dtype=numpy.bool)
+        mask_manual = numpy.ones((200,200), dtype=bool)
         mask_manual[7,4] = 0
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
         
@@ -1096,7 +1096,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((200,200), dtype=numpy.bool)
+        mask_manual = numpy.ones((200,200), dtype=bool)
         mask_manual[7,4] = 0
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
         
@@ -1105,7 +1105,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((200,200), dtype=numpy.bool)
+        mask_manual = numpy.ones((200,200), dtype=bool)
         mask_manual[7,4] = 0
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
         
@@ -1113,7 +1113,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((200,200), dtype=numpy.bool)
+        mask_manual = numpy.ones((200,200), dtype=bool)
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
         
         # check movmedian
@@ -1121,7 +1121,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((200,200), dtype=numpy.bool)
+        mask_manual = numpy.ones((200,200), dtype=bool)
         mask_manual[7,4] = 0
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
         
@@ -1130,7 +1130,7 @@ class TestMaskGenerator(unittest.TestCase):
         m.set_input(data)
         mask = m.process()
         
-        mask_manual = numpy.ones((200,200), dtype=numpy.bool)
+        mask_manual = numpy.ones((200,200), dtype=bool)
         mask_manual[7,4] = 0
         numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
@@ -1239,7 +1239,7 @@ class TestMasker(unittest.TestCase):
         self.data.as_array()[2,3] = float('inf')
         self.data.as_array()[4,5] = float('nan')
         
-        mask_manual = numpy.ones((10,10), dtype=numpy.bool)
+        mask_manual = numpy.ones((10,10), dtype=bool)
         mask_manual[2,3] = 0
         mask_manual[4,5] = 0
         

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -100,7 +100,7 @@ class TestOperator(CCPiTestClass):
         ig = ImageGeometry(M, M)
         x = ig.allocate('random',seed=100)
         
-        mask = ig.allocate(True,dtype=numpy.bool)
+        mask = ig.allocate(True,dtype=bool)
         amask = mask.as_array()
         amask[2,1:3] = False
         amask[0,0] = False
@@ -296,8 +296,8 @@ class TestOperator(CCPiTestClass):
         numpy.testing.assert_almost_equal(res1, numpy.sqrt(8), decimal=2) 
 
         # Gradient Operator (complex)
-        ig = ImageGeometry(30,30, dtype=numpy.complex)
-        Grad = GradientOperator(ig)
+        ig = ImageGeometry(30,30, dtype=complex)
+        Grad = GradientOperator(ig, backend='numpy')
         res1 = Grad.PowerMethod(Grad,500, tolerance=1e-6)
         numpy.testing.assert_almost_equal(res1, numpy.sqrt(8), decimal=2)         
                     
@@ -447,7 +447,7 @@ class TestGradients(CCPiTestClass):
         ###########################################################################
         # 2D geometry with channels
         # ig2 = ImageGeometry(N, M, channels = C)
-        Grad2 = GradientOperator(self.ig2, correlation = 'Space')
+        Grad2 = GradientOperator(self.ig2, correlation = 'Space', backend='numpy')
         
         E2 = SymmetrisedGradientOperator(Grad2.range_geometry())
         numpy.random.seed(1)
@@ -464,7 +464,7 @@ class TestGradients(CCPiTestClass):
         ###########################################################################
         # 2D geometry with channels
         # ig2 = ImageGeometry(N, M, channels = C)
-        Grad2 = GradientOperator(self.ig2, correlation = 'Space')
+        Grad2 = GradientOperator(self.ig2, correlation = 'Space', backend='numpy')
         
         E2 = SymmetrisedGradientOperator(Grad2.range_geometry())
         norm = LinearOperator.PowerMethod(E2, max_iterations=self.iterations)

--- a/Wrappers/Python/test/test_PluginsRegularisation.py
+++ b/Wrappers/Python/test/test_PluginsRegularisation.py
@@ -89,7 +89,7 @@ class TestPlugin(unittest.TestCase):
     def test_FGP_TV_complex(self):
         data = dataexample.CAMERA.get(size=(256,256))
         datarr = data.as_array()
-        cmpx = np.zeros(data.shape, dtype=np.complex)
+        cmpx = np.zeros(data.shape, dtype=np.complex64)
         cmpx.real = datarr[:]
         cmpx.imag = datarr[:]
         data.array = cmpx

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -300,7 +300,7 @@ class TestAlgorithms(CCPiTestClass):
             return noisy_data, alpha, g
 
         noisy_data, alpha, g = setup(data, dnoise)
-        operator = GradientOperator(ig, correlation=GradientOperator.CORRELATION_SPACE)
+        operator = GradientOperator(ig, correlation=GradientOperator.CORRELATION_SPACE, backend='numpy')
 
         f1 =  alpha * MixedL21Norm()
          
@@ -324,7 +324,7 @@ class TestAlgorithms(CCPiTestClass):
         which_noise = 1
         noise = noises[which_noise]
         noisy_data, alpha, g = setup(data, noise)
-        operator = GradientOperator(ig, correlation=GradientOperator.CORRELATION_SPACE)
+        operator = GradientOperator(ig, correlation=GradientOperator.CORRELATION_SPACE, backend='numpy')
 
         f1 =  alpha * MixedL21Norm() 
                     
@@ -349,7 +349,7 @@ class TestAlgorithms(CCPiTestClass):
         which_noise = 2
         noise = noises[which_noise]
         noisy_data, alpha, g = setup(data, noise)
-        operator = GradientOperator(ig, correlation=GradientOperator.CORRELATION_SPACE)
+        operator = GradientOperator(ig, correlation=GradientOperator.CORRELATION_SPACE, backend='numpy')
 
         f1 =  alpha * MixedL21Norm()
    


### PR DESCRIPTION
## Describe your changes
Removed code using deprecated numpy calls (`np.int`, `np.complex`) and `np.matrix()`

This involved a slight clean up of the gradient operator set-up, and then a bigger clean up of the unittests to remove output from 'warnings' when numpy backend was used instead.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
All unit tests pass

## Link relevant issues
closes #1239

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

All contributed code must be under [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html)