### PR TITLE
update initialisationn of image_sharpness

### DIFF
--- a/Wrappers/Python/cil/processors/CentreOfRotationCorrector.py
+++ b/Wrappers/Python/cil/processors/CentreOfRotationCorrector.py
@@ -30,36 +30,112 @@ class CentreOfRotationCorrector(object):
 
         For use on parallel-beam geometry it requires two projections 180 degree apart.
 
-        :param slice_index: An integer defining the vertical slice to run the algorithm on.
-        :type slice_index: int, str='centre', optional
-        :param projection_index: An integer defining the first projection the algorithm will use. The second projection at 180 degrees will be located automatically.
-        :type projection_index: int, optional
-        :param ang_tol: The angular tolerance in degrees between the two input projections 180degree gap
-        :type ang_tol: float, optional
-        :return: returns an AcquisitionData object with an updated AcquisitionGeometry
-        :rtype: AcquisitionData
+        Parameters
+        ----------
+
+        slice_index : int, str='centre', default='centre'
+            An integer defining the vertical slice to run the algorithm on.
+
+        projection_index : int
+            An integer defining the first projection the algorithm will use. The second projection at 180 degrees will be located automatically.
+
+        ang_tol : float, default=0.1
+            The angular tolerance in degrees between the two input projections 180 degree gap
+
+        Example
+        -------
+        >>> from cil.processors import CentreOfRotationCorrector
+        >>> processor = CentreOfRotationCorrector.xcorrelation('centre')
+        >>> processor.set_input(data)
+        >>> data_centred = processor.get_ouput()
+
+        Example
+        -------
+        >>> from cil.processors import CentreOfRotationCorrector
+        >>> processor = CentreOfRotationCorrector.xcorrelation(slice_index=120)
+        >>> processor.set_input(data)
+        >>> processor.get_ouput(out=data)
+
+
+        Example
+        -------
+        >>> from cil.processors import CentreOfRotationCorrector
+        >>> import logging
+        >>> logging.basicConfig(level=logging.WARNING)
+        >>> cil_log_level = logging.getLogger('cil.processors')
+        >>> cil_log_level.setLevel(logging.DEBUG)
+
+        >>> processor = CentreOfRotationCorrector.xcorrelation(slice_index=120)
+        >>> processor.set_input(data)
+        >>> data_centred = processor.get_ouput()
+
+
+        Note
+        ----
+        setting logging to 'debug' will give you more information about the algorithm progress
+
+
+
         '''
+
         processor = CofR_xcorrelation(slice_index, projection_index, ang_tol)
         return processor
 
     @staticmethod
-    def image_sharpness(slice_index='centre', FBP=None, tolerance=0.005, search_range=None, initial_binning=None):
-        r'''This creates a CentreOfRotationCorrector processor which will find the centre by maximising the sharpness of a reconstructed slice.
+    def image_sharpness(slice_index='centre', backend='astra', tolerance=0.005, search_range=None, initial_binning=None, **kwargs):
+        """
+        This creates a CentreOfRotationCorrector processor which will find the centre by maximising the sharpness of a reconstructed slice.
 
-        Can be used on single slice parallel-beam, and centre slice cone beam geometry. For use only with datasets that can be reconstructed with FBP.
+        Can be used on single slice parallel-beam, and centre slice cone beam geometry. For use only with datasets that can be reconstructed with FBP/FDK.
 
-        :param slice_index: An integer defining the vertical slice to run the algorithm on.
-        :type slice_index: int, str='centre', optional
-        :param FBP: A CIL FBP class imported from cil.plugins.tigre or cil.plugins.astra  
-        :type FBP: class
-        :param tolerance: The tolerance of the fit in pixels, the default is 1/200 of a pixel. Note this is a stopping critera, not a statement of accuracy of the algorithm.
-        :type tolerance: float, default = 0.001    
-        :param search_range: The range in pixels to search either side of the panel centre. If `None` the width of the panel/4 is used. 
-        :type search_range: int
-        :param initial_binning: The size of the bins for the initial grid. If `None` will bin the image to a step corresponding to <128 pixels. Note the fine search will be on unbinned data.
-        :type initial_binning: int
-        :return: returns an AcquisitionData object with an updated AcquisitionGeometry
-        :rtype: AcquisitionDataS
-        '''
-        processor = CofR_image_sharpness(slice_index=slice_index, FBP=FBP, tolerance=tolerance, search_range=search_range, initial_binning=initial_binning)
+        Parameters
+        ----------
+
+        slice_index : int, str='centre', default='centre'
+            An integer defining the vertical slice to run the algorithm on.
+
+        backend : str, default='astra'
+            The backend to use for the reconstruction, 'astra' or 'tigre'
+
+        tolerance : float, default=1./200.
+            The tolerance of the fit in pixels, the default is 1/200 of a pixel. This is a stopping criteria, not a statement of accuracy of the algorithm.
+
+        search_range : int, default 0.25*pixels_num_h
+            The range in pixels to search either side of the panel centre. If `None` a quarter of the width of the panel is used.  
+
+        initial_binning : int
+            The size of the bins for the initial grid. If `None` will bin the image to a step corresponding to <128 pixels. Note the fine search will be on unbinned data.
+
+
+        Kwargs
+        ------
+        FBP : Class
+            Deprecated parameter: the FBP class imported from cil.plugins.[backend].FBP Please use 'backend' instead
+
+
+        Example
+        -------
+        from cil.processors import CentreOfRotationCorrector
+
+        processor = CentreOfRotationCorrector.image_sharpness('centre', 'tigre')
+        processor.set_input(data)
+        data_centred = processor.get_ouput()
+
+
+        Example
+        -------
+        from cil.processors import CentreOfRotationCorrector
+
+        processor = CentreOfRotationCorrector.image_sharpness(slice_index=120, 'astra')
+        processor.set_input(data)
+        processor.get_ouput(out=data)
+
+
+        Note
+        ----
+        For best results data should be 360deg which leads to blurring with incorrect geometry.
+        This method is unreliable on half-scan data with 'tuning-fork' style artifacts.
+
+        """
+        processor = CofR_image_sharpness(slice_index=slice_index, backend=backend, tolerance=tolerance, search_range=search_range, initial_binning=initial_binning, **kwargs)
         return processor

--- a/Wrappers/Python/cil/processors/CofR_image_sharpness.py
+++ b/Wrappers/Python/cil/processors/CofR_image_sharpness.py
@@ -15,47 +15,94 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from cil.framework import Processor, AcquisitionData, AcquisitionGeometry
-from cil.processors.Binner import Binner
+from cil.framework import Processor, AcquisitionData, DataOrder
 import matplotlib.pyplot as plt
 import scipy
 import numpy as np
 import inspect
 import logging
 import math
+import importlib
 
 logger = logging.getLogger(__name__)
 
 class CofR_image_sharpness(Processor):
 
-    r'''CofR_image_sharpness processor maximises the sharpness of a reconstructed slice.
+    """
+    This creates a CentreOfRotationCorrector processor which will find the centre by maximising the sharpness of a reconstructed slice.
 
-    The centre-of-rotation offset is fitted using a reconstruction of edge-enhanced data. Auto-correlation is used to assess sharpness of the reconstructed slice. 
+    Can be used on single slice parallel-beam, and centre slice cone beam geometry. For use only with datasets that can be reconstructed with FBP/FDK.
 
-    For use on data-sets that can be reconstructed with FBP.
+    Parameters
+    ----------
 
-    :param slice_index: An integer defining the vertical slice to run the algorithm on.
-    :type slice_index: int, str='centre', optional
-    :param FBP: A CIL FBP class imported from cil.plugins.tigre or cil.plugins.astra  
-    :type FBP: class
-    :param tolerance: The tolerance of the fit in pixels, the default is 1/200 of a pixel. Note this is a stopping critera, not a statement of accuracy of the algorithm.
-    :type tolerance: float, default = 0.001    
-    :param search_range: The range in pixels to search either side of the panel centre. If `None` the width of the panel/4 is used. 
-    :type search_range: int
-    :param initial_binning: The size of the bins for the initial grid. If `None` will bin the image to a step corresponding to <128 pixels. Note the fine search will be on unbinned data.
-    :type initial_binning: int
-    :return: returns an AcquisitionData object with an updated AcquisitionGeometry
-    :rtype: AcquisitionData
-    '''
+    slice_index : int, str='centre', default='centre'
+        An integer defining the vertical slice to run the algorithm on.
 
-    def __init__(self, slice_index='centre', FBP=None, tolerance=0.005, search_range=None, initial_binning=None):
+    backend : str, default='astra'
+        The backend to use for the reconstruction, 'astra' or 'tigre'
+
+    tolerance : float, default=1./200.
+        The tolerance of the fit in pixels, the default is 1/200 of a pixel. This is a stopping criteria, not a statement of accuracy of the algorithm.
+
+    search_range : int, default 0.25*pixels_num_h
+        The range in pixels to search either side of the panel centre. If `None` a quarter of the width of the panel is used.  
+
+    initial_binning : int
+        The size of the bins for the initial grid. If `None` will bin the image to a step corresponding to <128 pixels. Note the fine search will be on unbinned data.
+
+
+    Kwargs
+    ------
+    FBP : Class
+        Deprecated parameter: the FBP class imported from cil.plugins.[backend].FBP Please use 'backend' instead
+
+
+    Example
+    -------
+    from cil.processors import CentreOfRotationCorrector
+
+    processor = CentreOfRotationCorrector.image_sharpness('centre', 'tigre')
+    processor.set_input(data)
+    data_centred = processor.get_ouput()
+
+
+    Example
+    -------
+    from cil.processors import CentreOfRotationCorrector
+
+    processor = CentreOfRotationCorrector.image_sharpness(slice_index=120, 'astra')
+    processor.set_input(data)
+    processor.get_ouput(out=data)
+
+
+    Note
+    ----
+    For best results data should be 360deg which leads to blurring with incorrect geometry.
+    This method is unreliable on half-scan data with 'tuning-fork' style artifacts.
+
+    """
+    _supported_backends = ['astra', 'tigre']
+
+    def __init__(self, slice_index='centre', backend='astra', tolerance=0.005, search_range=None, initial_binning=None, **kwargs):
         
-        if not inspect.isclass(FBP):
-            raise ValueError("Please pass a CIL FBP class from cil.plugins.tigre or cil.plugins.astra")
+
+        FBP = kwargs.get('FBP', None)
+        if  FBP is not None:
+            logging.warning("Instantiation with an FBP class has been deprecated and will be removed in future versions.\
+                            Please pass backend='astra' or 'tigre'")
+
+            if inspect.isclass(FBP):
+                if 'tigre' in str(inspect.getmodule(FBP)):
+                    backend = 'tigre'
+
+        FBP = self._configure_FBP(backend)
+
 
         kwargs = {
                     'slice_index': slice_index,
                     'FBP': FBP,
+                    'backend' : backend,
                     'tolerance': tolerance,
                     'search_range': search_range,
                     'initial_binning': initial_binning
@@ -71,10 +118,10 @@ class CofR_image_sharpness(Processor):
             raise Exception('Geometry is not defined.')
 
         if data.geometry.geom_type == 'cone' and self.slice_index != 'centre':
-            raise ValueError("Only the centre slice is supported with this alogrithm")
+            raise ValueError("Only the centre slice is supported with this algorithm")
 
         if data.geometry.system_description not in ['simple','offset']:
-            raise NotImplementedError("Not implemented for advanced systsem geometries")
+            raise NotImplementedError("Not implemented for rotated system geometries")
             
         if data.geometry.channels > 1:
             raise ValueError("Only single channel data is supported with this algorithm")
@@ -88,7 +135,36 @@ class CofR_image_sharpness(Processor):
             if self.slice_index < 0 or self.slice_index >= data.get_dimension_size('vertical'):
                 raise ValueError('slice_index is out of range. Must be in range 0-{0}. Got {1}'.format(data.get_dimension_size('vertical'), self.slice_index))
 
+        #check order for single slice data
+        if data.geometry.dimension == '3D':
+            test_geom = data.geometry.get_slice(vertical='centre')
+        else:
+            test_geom = data.geometry
+
+        if not DataOrder.check_order_for_engine(self.backend, test_geom):
+            raise ValueError("Input data must be reordered for use with selected backend. Use input.reorder{'{0}')".format(self.backend))
+
         return True
+
+
+    def _configure_FBP(self, backend='tigre'):
+        """
+        Configures the processor for the right engine. Checks the data order.
+        """        
+        if backend not in self._supported_backends:
+            raise ValueError("Backend unsupported. Supported backends: {}".format(self._supported_backends))
+
+        #set FBPOperator class from backend
+        try:
+            module = importlib.import_module('cil.plugins.'+backend)
+        except ImportError:
+            if backend == 'tigre':
+                raise ImportError("Cannot import the {} plugin module. Please install TIGRE or select a different backend".format(self.backend))
+            if backend == 'astra':
+                raise ImportError("Cannot import the {} plugin module. Please install ASTRA-TOOLBOX or select a different backend".format(self.backend))
+
+        return module.FBP
+
 
     def gss(self, data, ig, search_range, tolerance, binning):
         '''Golden section search'''
@@ -230,7 +306,7 @@ class CofR_image_sharpness(Processor):
             half_panel = (width - 1)/2
 
             sampling_points = np.mgrid[-self.initial_binning*new_half_panel:self.initial_binning*new_half_panel+1:self.initial_binning]
-            initial_cordinates = np.mgrid[-half_panel:half_panel+1:1]
+            initial_coordinates = np.mgrid[-half_panel:half_panel+1:1]
 
             new_geom = data.geometry.copy()
             new_geom.config.panel.num_pixels[0] = num_pix_new
@@ -238,7 +314,7 @@ class CofR_image_sharpness(Processor):
             data_binned = new_geom.allocate()
 
             for i in range(data.shape[0]):
-                data_binned.fill(np.interp(sampling_points, initial_cordinates, data.array[i,:]),angle=i)
+                data_binned.fill(np.interp(sampling_points, initial_coordinates, data.array[i,:]),angle=i)
 
             #filter 
             data_binned_filtered = data_binned.copy()
@@ -286,6 +362,7 @@ class CofR_image_sharpness(Processor):
         new_geometry.config.system.rotation_axis.position[0] = centre
         
         logger.info("Centre of rotation correction found using image_sharpness")
+        logger.info("backend FBP/FDK {}".format(self.backend))
         logger.info("Calculated from slice: %s", str(self.slice_index))
         logger.info("Centre of rotation shift = %f pixels", centre/ig.voxel_size_x)
         logger.info("Centre of rotation shift = %f units at the object", centre)


### PR DESCRIPTION
## Describe your changes
change initialisation parameter for image_sharpness CofR to `backend`. and moved `FBP` to kwarg.

This will allow the user to set up the processor with a backend string which simplifies the usage.


## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues
#1278

## Checklist when you are ready to request a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [ ] I confirm that the contribution does not violate any intellectual property rights of third parties
