### PR TITLE
Fix divide by 0 error when update_objective_interval=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Add ndim property for DataContainer class.
   - Fixes show_geometry compatibility issue with matplotlib 3.5
   - Added ZEISSDataReader with cone/parallel beam, slicing, TXM Functionality.
+  - Fixes error when update_objective_interval is set to 0 in an algorithm run.
   - Deprecated:
     - TXRMDataReader is deprecated in favour of ZEISSDataReader 
   - GitHub Actions:

--- a/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
@@ -274,7 +274,8 @@ class Algorithm(object):
                 if callback is not None:
                     callback(self.iteration, self.get_last_objective(return_all=very_verbose), self.x)
             if verbose:
-                if (self.iteration % print_interval == 0) or self.iteration % self.update_objective_interval == 0:
+                if (print_interval != 0 and self.iteration % print_interval == 0) or \
+                        ( self.update_objective_interval != 0 and self.iteration % self.update_objective_interval == 0):
                     print (self.verbose_output(very_verbose))
 
         if verbose:

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -67,22 +67,6 @@ has_astra = has_astra and has_gpu_astra()
 
 
 class TestAlgorithms(CCPiTestClass):
-    def setUp(self):
-        #wget.download('https://github.com/DiamondLightSource/Savu/raw/master/test_data/data/24737_fd.nxs')
-        #self.filename = '24737_fd.nxs'
-        # we use Identity as the operator and solve the simple least squares 
-        # problem for a random-valued ImageData or AcquisitionData b?  
-        # Then we know the minimiser is b itself
-        
-        # || I x -b ||^2
-        
-        # create an ImageGeometry
-        ig = ImageGeometry(12,13,14)
-        pass
-
-    def tearDown(self):
-        #os.remove(self.filename)
-        pass
     
     def test_GD(self):
         ig = ImageGeometry(12,13,14)
@@ -111,6 +95,28 @@ class TestAlgorithms(CCPiTestClass):
         self.assertTrue(alg.max_iteration == 20)
         self.assertTrue(alg.update_objective_interval==2)
         alg.run(20, verbose=0)
+        self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
+
+    def test_update_interval_0(self):
+        '''
+        Checks that an algorithm runs with no problems when 
+        the update_objective interval is set to 0 and with
+        verbose on / off
+        '''
+        ig = ImageGeometry(12,13,14)
+        initial = ig.allocate()
+        b = ig.allocate('random')
+        identity = IdentityOperator(ig)
+        norm2sq = LeastSquares(identity, b)
+        alg = GD(initial=initial, 
+                 objective_function=norm2sq, 
+                 max_iteration=20,
+                 update_objective_interval=0,
+                 atol=1e-9, rtol=1e-6)
+        self.assertTrue(alg.update_objective_interval==0)
+        alg.run(20, verbose=True)
+        self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
+        alg.run(20, verbose=False)
         self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
 
 
@@ -1167,8 +1173,3 @@ class TestADMM(unittest.TestCase):
         admm.run(verbose=0)
         np.testing.assert_almost_equal(admm.solution.array, pdhg.solution.array,  decimal=3)
 
-
-    def tearDown(self):
-        pass
-
-    


### PR DESCRIPTION
## Describe your changes
Closes #930 
Also removed some unused parts of the Algorithm unit tests

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
Added unit test to check there are no errors when self.update_objective_interval is 0

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
