### PR TITLE
changes to arguments for PO and FBP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * 22.0.0
+  - Updated interface to `plugins.tigre`/`plugins.astra` `FBP` and `ProjectionOperator` classes
   - Update NikonDataReader to parse and set up geometry with: `ObjectTilt` `CentreOfRotationTop` and `CentreOfRotationBottom`
   - Cleaned up unit test structure and output
   - Removal of deprecated code

--- a/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
@@ -25,11 +25,10 @@ class ProjectionOperator(LinearOperator):
     """
     ProjectionOperator configures and calls appropriate ASTRA Projectors for your dataset.
 
-
     Parameters
     ----------
 
-    image_geometry : ImageGeometry
+    image_geometry : ImageGeometry, default used if None
         A description of the area/volume to reconstruct
 
     acquisition_geometry : AcquisitionGeometry
@@ -38,10 +37,8 @@ class ProjectionOperator(LinearOperator):
     device : string, default='gpu'
         'gpu' will run on a compatible CUDA capable device using the ASTRA 3D CUDA Projectors, 'cpu' will run on CPU using the ASTRA 2D CPU Projectors
 
-
     Example
     -------
-
     >>> from cil.plugins.astra import ProjectionOperator
     >>> PO = ProjectionOperator(image.geometry, data.geometry)
     >>> forward_projection = PO.direct(image)
@@ -52,8 +49,14 @@ class ProjectionOperator(LinearOperator):
     For multichannel data the ProjectionOperator will broadcast across all channels.
     """
 
-    def __init__(self, image_geometry, acquisition_geometry, device='gpu'):
+    def __init__(self, image_geometry=None, acquisition_geometry=None, device='gpu'):
         
+        if acquisition_geometry is None:
+            raise TypeError("Please specify an acquisition_geometry to configure this operator")
+
+        if image_geometry == None:
+            image_geometry = acquisition_geometry.get_ImageGeometry()
+
         super(ProjectionOperator, self).__init__(domain_geometry=image_geometry, range_geometry=acquisition_geometry)
 
         DataOrder.check_order_for_engine('astra', image_geometry)

--- a/Wrappers/Python/cil/plugins/astra/processors/FBP.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FBP.py
@@ -58,7 +58,7 @@ class FBP(DataProcessor):
     """
 
     
-    def __init__(self, image_geometry, acquisition_geometry, device='gpu', **kwargs): 
+    def __init__(self, image_geometry=None, acquisition_geometry=None, device='gpu', **kwargs): 
         
 
         sinogram_geometry = kwargs.get('sinogram_geometry', None)

--- a/Wrappers/Python/cil/plugins/astra/processors/FBP.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FBP.py
@@ -19,6 +19,7 @@ from cil.framework import DataOrder
 from cil.plugins.astra.processors.FBP_Flexible import FBP_Flexible
 from cil.plugins.astra.processors.FDK_Flexible import FDK_Flexible
 from cil.plugins.astra.processors.FBP_Flexible import FBP_CPU
+import logging
 
 class FBP(DataProcessor):
 
@@ -29,10 +30,10 @@ class FBP(DataProcessor):
 
     Parameters
     ----------
-    volume_geometry : ImageGeometry
+    image_geometry : ImageGeometry, default used if None
         A description of the area/volume to reconstruct
 
-    sinogram_geometry : AcquisitionGeometry
+    acquisition_geometry : AcquisitionGeometry
         A description of the acquisition data
 
     device : string, default='gpu'
@@ -57,34 +58,52 @@ class FBP(DataProcessor):
     """
 
     
-    def __init__(self, volume_geometry, sinogram_geometry, device='gpu'): 
+    def __init__(self, image_geometry, acquisition_geometry, device='gpu', **kwargs): 
         
-        DataOrder.check_order_for_engine('astra', volume_geometry)
-        DataOrder.check_order_for_engine('astra', sinogram_geometry) 
+
+        sinogram_geometry = kwargs.get('sinogram_geometry', None)
+        volume_geometry = kwargs.get('volume_geometry', None)
+
+        if sinogram_geometry is not None:
+            acquisition_geometry = sinogram_geometry
+            logging.warning("sinogram_geometry has been deprecated. Please use acquisition_geometry instead.")
+
+        if acquisition_geometry is None:
+            raise TypeError("Please specify an acquisition_geometry to configure this processor")
+            
+        if volume_geometry is not None:
+            image_geometry = volume_geometry
+            logging.warning("volume_geometry has been deprecated. Please use image_geometry instead.")
+
+        if image_geometry == None:
+            image_geometry = acquisition_geometry.get_ImageGeometry()
+
+        DataOrder.check_order_for_engine('astra', image_geometry)
+        DataOrder.check_order_for_engine('astra', acquisition_geometry) 
 
         if device == 'gpu':
-            if sinogram_geometry.geom_type == 'parallel':
-                processor = FBP_Flexible(volume_geometry, sinogram_geometry)
+            if acquisition_geometry.geom_type == 'parallel':
+                processor = FBP_Flexible(image_geometry, acquisition_geometry)
             else:
-                processor = FDK_Flexible(volume_geometry, sinogram_geometry)
+                processor = FDK_Flexible(image_geometry, acquisition_geometry)
             
         else:
             UserWarning("ASTRA back-projector running on CPU will not make use of enhanced geometry parameters")
 
-            if sinogram_geometry.geom_type == 'cone':
+            if acquisition_geometry.geom_type == 'cone':
                 raise NotImplementedError("Cannot process cone-beam data without a GPU")
 
-            if sinogram_geometry.dimension == '2D':
-                processor = FBP_CPU(volume_geometry, sinogram_geometry) 
+            if acquisition_geometry.dimension == '2D':
+                processor = FBP_CPU(image_geometry, acquisition_geometry) 
             else:
                 raise NotImplementedError("Cannot process 3D data without a GPU")
 
-        if sinogram_geometry.channels > 1: 
+        if acquisition_geometry.channels > 1: 
             raise NotImplementedError("Cannot process multi-channel data")
-            #processor_full = ChannelwiseProcessor(processor, self.sinogram_geometry.channels, dimension='prepend')
+            #processor_full = ChannelwiseProcessor(processor, self.acquisition_geometry.channels, dimension='prepend')
             #self.processor = operator_full
         
-        super(FBP, self).__init__( volume_geometry=volume_geometry, sinogram_geometry=sinogram_geometry, device=device, processor=processor)  
+        super(FBP, self).__init__( image_geometry=image_geometry, acquisition_geometry=acquisition_geometry, device=device, processor=processor)  
 
     def set_input(self, dataset):       
         return self.processor.set_input(dataset)

--- a/Wrappers/Python/cil/plugins/tigre/FBP.py
+++ b/Wrappers/Python/cil/plugins/tigre/FBP.py
@@ -61,13 +61,17 @@ class FBP(DataProcessor):
 
         if acquisition_geometry is None:
             raise TypeError("Please specify an acquisition_geometry to configure this processor")
-            
+
         if volume_geometry is not None:
             image_geometry = volume_geometry
             logging.warning("volume_geometry has been deprecated. Please use image_geometry instead.")
 
         if image_geometry == None:
             image_geometry = acquisition_geometry.get_ImageGeometry()
+
+        device = kwargs.get('device', 'gpu')
+        if device != 'gpu':
+            raise ValueError("TIGRE FBP is GPU only. Got device = {}".format(device))
 
         DataOrder.check_order_for_engine('tigre', image_geometry)
         DataOrder.check_order_for_engine('tigre', acquisition_geometry) 

--- a/Wrappers/Python/cil/plugins/tigre/FBP.py
+++ b/Wrappers/Python/cil/plugins/tigre/FBP.py
@@ -1,24 +1,23 @@
 # -*- coding: utf-8 -*-
-#   This work is part of the Core Imaging Library (CIL) developed by CCPi 
-#   (Collaborative Computational Project in Tomographic Imaging), with 
-#   substantial contributions by UKRI-STFC and University of Manchester.
-
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-
-#   http://www.apache.org/licenses/LICENSE-2.0
-
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+#  Copyright 2018 - 2022 United Kingdom Research and Innovation
+#  Copyright 2018 - 2022 The University of Manchester
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 from cil.framework import DataProcessor, ImageData
 from cil.framework import DataOrder
 from cil.plugins.tigre import CIL2TIGREGeometry
-
+import logging
 import numpy as np
 
 try:
@@ -30,38 +29,60 @@ except ModuleNotFoundError:
 class FBP(DataProcessor):
 
     '''FBP Filtered Back Projection is a reconstructor for 2D and 3D parallel and cone-beam geometries.
-    It is able to back-project circular trajectories with 2 PI anglar range and equally spaced anglular steps.
+    It is able to back-project circular trajectories with 2 PI angular range and equally spaced angular steps.
 
     This uses the ram-lak filter
     This is provided for simple and offset parallel-beam geometries only
    
-    Input: Volume Geometry
-           Sinogram Geometry
-                             
-    Example:  fbp = FBP(ig, ag, device)
-              fbp.set_input(data)
-              reconstruction = fbp.get_ouput()
-                           
-    Output: ImageData                             
-
-        '''
+    acquisition_geometry : AcquisitionGeometry
+        A description of the acquisition data
     
-    def __init__(self, volume_geometry, sinogram_geometry): 
+    image_geometry : ImageGeometry, default used if None
+        A description of the area/volume to reconstruct
+                             
+    Example
+    -------
+    >>> from cil.plugins.tigre import FBP
+    >>> fbp = FBP(image_geometry, data.geometry)
+    >>> fbp.set_input(data)
+    >>> reconstruction = fbp.get_ouput()                       
+
+    '''
+    
+    def __init__(self, image_geometry=None, acquisition_geometry=None, **kwargs): 
         
-        DataOrder.check_order_for_engine('tigre', volume_geometry)
-        DataOrder.check_order_for_engine('tigre', sinogram_geometry) 
 
-        tigre_geom, tigre_angles = CIL2TIGREGeometry.getTIGREGeometry(volume_geometry,sinogram_geometry)
+        sinogram_geometry = kwargs.get('sinogram_geometry', None)
+        volume_geometry = kwargs.get('volume_geometry', None)
 
-        super(FBP, self).__init__(  volume_geometry = volume_geometry, sinogram_geometry = sinogram_geometry,\
+        if sinogram_geometry is not None:
+            acquisition_geometry = sinogram_geometry
+            logging.warning("sinogram_geometry has been deprecated. Please use acquisition_geometry instead.")
+
+        if acquisition_geometry is None:
+            raise TypeError("Please specify an acquisition_geometry to configure this processor")
+            
+        if volume_geometry is not None:
+            image_geometry = volume_geometry
+            logging.warning("volume_geometry has been deprecated. Please use image_geometry instead.")
+
+        if image_geometry == None:
+            image_geometry = acquisition_geometry.get_ImageGeometry()
+
+        DataOrder.check_order_for_engine('tigre', image_geometry)
+        DataOrder.check_order_for_engine('tigre', acquisition_geometry) 
+
+        tigre_geom, tigre_angles = CIL2TIGREGeometry.getTIGREGeometry(image_geometry,acquisition_geometry)
+
+        super(FBP, self).__init__(  image_geometry = image_geometry, acquisition_geometry = acquisition_geometry,\
                                     tigre_geom=tigre_geom, tigre_angles=tigre_angles)
 
 
     def check_input(self, dataset):
         
-        if self.sinogram_geometry.channels != 1:
+        if self.acquisition_geometry.channels != 1:
             raise ValueError("Expected input data to be single channel, got {0}"\
-                 .format(self.sinogram_geometry.channels))  
+                 .format(self.acquisition_geometry.channels))  
 
         DataOrder.check_order_for_engine('tigre', dataset.geometry)
         return True
@@ -71,19 +92,19 @@ class FBP(DataProcessor):
         if self.tigre_geom.is2D:
             data_temp = np.expand_dims(self.get_input().as_array(), axis=1)
 
-            if self.sinogram_geometry.geom_type == 'cone':
+            if self.acquisition_geometry.geom_type == 'cone':
                 arr_out = fdk(data_temp, self.tigre_geom, self.tigre_angles)
             else:
                 arr_out = fbp(data_temp, self.tigre_geom, self.tigre_angles)
             arr_out = np.squeeze(arr_out, axis=0)
         else:
-            if self.sinogram_geometry.geom_type == 'cone':
+            if self.acquisition_geometry.geom_type == 'cone':
                 arr_out = fdk(self.get_input().as_array(), self.tigre_geom, self.tigre_angles)
             else:
                 arr_out = fbp(self.get_input().as_array(), self.tigre_geom, self.tigre_angles)
 
         if out is None:
-            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
+            out = ImageData(arr_out, deep_copy=False, geometry=self.image_geometry.copy(), suppress_warning=True)
             return out
         else:
             out.fill(arr_out)

--- a/Wrappers/Python/cil/plugins/tigre/FBP.py
+++ b/Wrappers/Python/cil/plugins/tigre/FBP.py
@@ -66,7 +66,7 @@ class FBP(DataProcessor):
             image_geometry = volume_geometry
             logging.warning("volume_geometry has been deprecated. Please use image_geometry instead.")
 
-        if image_geometry == None:
+        if image_geometry is None:
             image_geometry = acquisition_geometry.get_ImageGeometry()
 
         device = kwargs.get('device', 'gpu')

--- a/Wrappers/Python/cil/plugins/tigre/Geometry.py
+++ b/Wrappers/Python/cil/plugins/tigre/Geometry.py
@@ -1,19 +1,18 @@
 # -*- coding: utf-8 -*-
-#   This work is part of the Core Imaging Library (CIL) developed by CCPi 
-#   (Collaborative Computational Project in Tomographic Imaging), with 
-#   substantial contributions by UKRI-STFC and University of Manchester.
-
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-
-#   http://www.apache.org/licenses/LICENSE-2.0
-
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+#  Copyright 2018 - 2022 United Kingdom Research and Innovation
+#  Copyright 2018 - 2022 The University of Manchester
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 from cil.framework import AcquisitionGeometry, ImageGeometry
 import numpy as np

--- a/Wrappers/Python/cil/plugins/tigre/ProjectionOperator.py
+++ b/Wrappers/Python/cil/plugins/tigre/ProjectionOperator.py
@@ -47,7 +47,7 @@ class ProjectionOperator(LinearOperator):
         https://github.com/CERN/TIGRE
         https://iopscience.iop.org/article/10.1088/2057-1976/2/5/055010
                         
-
+                        
         Parameters
         ----------
 
@@ -57,10 +57,10 @@ class ProjectionOperator(LinearOperator):
         acquisition_geometry : AcquisitionGeometry
             A description of the acquisition data
 
-        direct_method: str,  default 'interpolated'
+        direct_method : str,  default 'interpolated'
             The method used by the forward projector, 'Siddon' for ray-voxel intersection, 'interpolated' for interpolated projection
 
-        adjoint_weights str, default 'matched'
+        adjoint_weights : str, default 'matched'
             The weighting method used by the cone-beam backward projector, 'matched' for weights to approximately match the 'interpolated' forward projector, 'FDK' for FDK weights
 
         Example

--- a/Wrappers/Python/test/test_PluginsAstra_FBP.py
+++ b/Wrappers/Python/test/test_PluginsAstra_FBP.py
@@ -21,9 +21,7 @@ from utils import has_astra, has_nvidia, initialise_tests
 initialise_tests()
 
 if has_astra:
-    from cil.plugins.astra import ProjectionOperator
     from cil.plugins.astra import FBP
-
 
 def setup_parameters(self):
 

--- a/Wrappers/Python/test/test_PluginsAstra_GPU.py
+++ b/Wrappers/Python/test/test_PluginsAstra_GPU.py
@@ -26,6 +26,7 @@ if has_astra:
     from cil.plugins.astra import ProjectionOperator
     import astra
 
+
 def setup_parameters(self):
 
     self.backend = 'astra'

--- a/Wrappers/Python/test/utils_projectors.py
+++ b/Wrappers/Python/test/utils_projectors.py
@@ -443,6 +443,14 @@ class TestCommon_ProjectionOperator_SIM(SimData):
         np.testing.assert_allclose(bp.as_array(), bp2.as_array(), 1e-8)    
 
 
+    def test_input_arguments(self):
+
+        #default image_geometry, named parameter acquisition_geometry
+        Op = self.ProjectionOperator(acquisition_geometry=self.ag, **self.PO_args)
+        fp = Op.direct(self.img_data)
+        np.testing.assert_allclose(fp.as_array(), self.acq_data.as_array(),atol=self.tolerance_fp)        
+
+
 class TestCommon_FBP_SIM(SimData):
     '''
     FBP tests on simulated data
@@ -462,4 +470,13 @@ class TestCommon_FBP_SIM(SimData):
     def test_FBP_roi(self):
         self.FBP = self.FBP(self.ig_roi, self.ag, **self.FBP_args)
         reco = self.FBP(self.acq_data)
-        np.testing.assert_allclose(reco.as_array(), self.gold_roi, atol=self.tolerance_fbp_roi)    
+        np.testing.assert_allclose(reco.as_array(), self.gold_roi, atol=self.tolerance_fbp_roi) 
+
+    
+    def test_input_arguments(self):
+
+        #default image_geometry, named parameter acquisition_geometry
+        self.FBP = self.FBP(acquisition_geometry = self.ag, **self.FBP_args)
+        reco = self.FBP(self.acq_data)
+        np.testing.assert_allclose(reco.as_array(), self.img_data.as_array(),atol=self.tolerance_fbp)    
+


### PR DESCRIPTION
## Describe your changes
Updated the input parameters for  astra and tigre plugins `FBP` and `ProjectionOperator`

Deprecated `sinogram_geometry` `volume_geometry` `aquisition_geometry`

Added default `image_geometry` option if input is None.
Handle `device` by tigre for ease of switching astra/tigre backends.

Updated docstings

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues
closes #1135
closes #1231 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
