### PR TITLE
allows to specify colormaps to show2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* 22.x.x
+ - added multiple colormaps to show2D
 * 22.0.0
   - Strongly convex functionality in TotalVariation and FGP_TV Functions
   - Refactored KullbackLeibler function class. Fix bug on gradient method for SIRF objects

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -115,8 +115,9 @@ class show2D(show_base):
         The axis labels for each figure e.g. ('x','y')
     origin: string, list of strings
         Sets the display origin. 'lower/upper-left/right'
-    cmap: str
-        Sets the colour map of the plot (see matplotlib.pyplot)
+    cmap: str, list or tuple of strings
+        Sets the colour map of the plot (see matplotlib.pyplot). If passed a list or tuple of the
+        length of datacontainers, allows to set a different color map for each datacontainer.
     num_cols: int
         Sets the number of columns of subplots to display
     size: tuple
@@ -341,8 +342,11 @@ class show2D(show_base):
 
             #set origin
             data, data_origin, extent = set_origin(subplot.data, subplot.origin)
-            
-            sp = axes[i].imshow(data, cmap=cmap, origin=data_origin, extent=extent)
+            if isinstance(cmap, (list, tuple)):
+                dcmap = cmap[i]
+            else:
+                dcmap = cmap
+            sp = axes[i].imshow(data, cmap=dcmap, origin=data_origin, extent=extent)
 
             im_ratio = subplot.data.shape[0]/subplot.data.shape[1]
 


### PR DESCRIPTION
## Describe your changes
Enables `show2D` to display images with different colormaps.
Colormaps need to be passed either as a string, i.e. one colormap for all plots, or as a list/tuple of the same length of the data to be plotted, then each plot will use the specified colormap.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*

https://github.com/TomographicImaging/CIL-Demos/blob/add_gentle_intro/misc/00_gentle_intro.py

I tried with a `cmap` list of the wrong size and it fails. I also tried with wrong names for a colormap and it also fails, with an error that is not very clear.

## Link relevant issues
closes #1347 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
