### PR TITLE
fix angle display precision and matplotlib warning

### DIFF
--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -358,8 +358,8 @@ class show2D(show_base):
 
                     ang = subplot.data.geometry.config.angles
 
-                    labels_new = [str(i) for i in np.take(ang.angle_data, location_new)]
-                    axes[i].set_yticklabels(labels_new)
+                    labels_new = ["{:.2f}".format(i) for i in np.take(ang.angle_data, location_new)]
+                    axes[i].set_yticks(location_new, labels=labels_new)
                     
                     axes[i].set_ylabel('angle / ' + str(ang.angle_unit))
 


### PR DESCRIPTION
## Describe your changes
fix angle display precision to 2 d.p.
fixed matplotlib warning by setting tick location and labels explicitly


## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues
closes #1353

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
