### PR TITLE
CofR getter and setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+* Next
+  - Added convenience centre of rotation methods to `AcquisitionGeometry` class.
+    - `get_centre_of_rotation()` calculates the centre of rotation of the system
+    - `set_centre_of_rotation()` sets the system centre of rotation with an offset and angle
+    - `set_centre_of_rotation_by_slice()` sets the system centre of rotation with offsets from two slices
+
 * 22.1.0
   - added multiple colormaps to show2D
   - Fix segfault in GradientOperator due to parameter overflows on windows systems

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2062,7 +2062,7 @@ class AcquisitionGeometry(object):
         return {'offset': (offset, offset_units), 'angle': (angle, ang_units)}
 
 
-    def set_centre_of_rotation(self, offset, distance_units='default', angle=0, angle_units='radian'): 
+    def set_centre_of_rotation(self, offset=0.0, distance_units='default', angle=0.0, angle_units='radian'): 
         """
         Configures the system geometry to have the requested centre of rotation offset at the detector.
 
@@ -2073,7 +2073,7 @@ class AcquisitionGeometry(object):
 
         Parameters
         ----------
-        offset: float
+        offset: float, default 0.0
             The position of the centre of rotation along the detector x_axis at y=0
 
         distance_units : string, default='default'
@@ -2103,10 +2103,10 @@ class AcquisitionGeometry(object):
         else:
             raise ValueError("`angle_units` is not recognised. Must be 'radian' or 'degree'. Got {}".format(angle_units))
 
-        if 'default':
+        if distance_units =='default':
             offset_distance = offset
-        elif distance_units=='pixels':
-            offset_distance = offset_distance * self.config.panel.pixel_size[0]
+        elif distance_units =='pixels':
+            offset_distance = offset * self.config.panel.pixel_size[0]
         else:
             raise ValueError("`distance_units` is not recognised. Must be 'default' or 'pixels'. Got {}".format(distance_units))
 
@@ -2160,9 +2160,9 @@ class AcquisitionGeometry(object):
                 raise ValueError("Cannot calculate angle. Please specify `slice_index1` and `slice_index2` to define a rotated axis")
 
             offset_x_y0 = offset1 -slice_index1 * (offset2 - offset1)/(slice_index2-slice_index1)
-            angle = numpy.degrees(math.atan2(offset2 - offset1, slice_index2 - slice_index1))
+            angle = math.atan2(offset2 - offset1, slice_index2 - slice_index1)
 
-        self.set_centre_of_rotation(offset_x_y0, angle)
+        self.set_centre_of_rotation(offset_x_y0, 'pixels', angle, 'radian')
 
 
     def set_angles(self, angles, initial_angle=0, angle_unit='degree'):

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -973,16 +973,20 @@ class Cone2D(SystemConfiguration):
             \nReturns `offset` if the the geometry matches the default definitions with centre-of-rotation or detector offsets
             \nReturns `advanced` if the the geometry has rotated or tilted rotation axis or detector, can also have offsets
         '''           
+        
+        vec_a = ComponentDescription.CreateUnitVector(self.detector.position - self.source.position)
 
-        vec_a = ComponentDescription.CreateUnitVector(self.detector.position - self.rotation_axis.position)
-        vec_b = ComponentDescription.CreateUnitVector(self.detector.position - self.source.position)
+        dot_prod_a = vec_a.dot(self.detector.direction_x)
 
-        dot_prod_a = vec_b.dot(self.detector.direction_x)
-        dot_prod_b = vec_b.dot(vec_a)
+        if numpy.allclose(self.rotation_axis.position, self.detector.position): #points are equal so on ray path
+            dot_prod_b = 1
+        else:
+            vec_b = ComponentDescription.CreateUnitVector(self.detector.position - self.rotation_axis.position)
+            dot_prod_b = vec_a.dot(vec_b)
 
         if abs(dot_prod_a)>1e-10: #test perpendicular
             config = SystemConfiguration.SYSTEM_ADVANCED
-        elif abs(dot_prod_b - 1)>1e-10: #test parallel
+        elif (1 - abs(dot_prod_b))>1e-10: #test parallel
             config = SystemConfiguration.SYSTEM_OFFSET 
         else:
             config = SystemConfiguration.SYSTEM_SIMPLE
@@ -1149,16 +1153,18 @@ class Cone3D(SystemConfiguration):
             \nReturns `advanced` if the the geometry has rotated or tilted rotation axis or detector, can also have offsets
         '''       
 
-        vec_a = ComponentDescription.CreateUnitVector(self.detector.position - self.rotation_axis.position)
-        vec_b = ComponentDescription.CreateUnitVector(self.detector.position - self.source.position)
+        vec_a = ComponentDescription.CreateUnitVector(self.detector.position - self.source.position)
 
-        dot_prod_a = vec_b.dot(self.detector.direction_x)
-        dot_prod_b = vec_b.dot(self.detector.direction_y)
+        dot_prod_a = vec_a.dot(self.detector.direction_x)
+        dot_prod_b = vec_a.dot(self.detector.direction_y)
         dot_prod_c = (self.detector.direction_x).dot(self.rotation_axis.direction)
-        dot_prod_d = vec_b.dot(self.rotation_axis.direction)
+        dot_prod_d = vec_a.dot(self.rotation_axis.direction)
 
-        dot_prod_e = vec_b.dot(vec_a)
-
+        if numpy.allclose(self.rotation_axis.position, self.detector.position): #points are equal so on ray path
+            dot_prod_e = 1
+        else:
+            vec_b = ComponentDescription.CreateUnitVector(self.detector.position - self.rotation_axis.position)
+            dot_prod_e = vec_a.dot(vec_b)
 
         if abs(dot_prod_a)>1e-10 or\
             abs(dot_prod_b)>1e-10 or\
@@ -1166,7 +1172,7 @@ class Cone3D(SystemConfiguration):
             abs(dot_prod_d)>1e-10: #test perpendicular
             config =  SystemConfiguration.SYSTEM_ADVANCED
 
-        elif abs(dot_prod_e - 1)>1e-10:#test parallel
+        elif (1 - abs(dot_prod_e))>1e-10:#test parallel
             config = SystemConfiguration.SYSTEM_OFFSET
         else:
             config = SystemConfiguration.SYSTEM_SIMPLE

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -1071,21 +1071,16 @@ class Cone2D(SystemConfiguration):
         return self
 
     def calculate_magnification(self):
-        #64bit for maths
-        rotation_axis_position = self.rotation_axis.position.astype(numpy.float64)
-        source_position = self.source.position.astype(numpy.float64)
-        detector_position = self.detector.position.astype(numpy.float64)
-        direction_x = self.detector.direction_x.astype(numpy.float64)
 
-        ab = (rotation_axis_position - source_position)
+        ab = (self.rotation_axis.position - self.source.position)
         dist_source_center = float(numpy.sqrt(ab.dot(ab)))
 
         ab_unit = ab / numpy.sqrt(ab.dot(ab))
 
-        n = ComponentDescription.create_vector([direction_x[1], -direction_x[0]]).astype(numpy.float64)
+        n = self.detector.normal
 
         #perpendicular distance between source and detector centre
-        sd = float((detector_position - source_position).dot(n))
+        sd = float((self.detector.position - self.source.position).dot(n))
         ratio = float(ab_unit.dot(n))
 
         source_to_detector = sd / ratio

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -652,24 +652,24 @@ class Test_Cone2D(unittest.TestCase):
     def test_calculate_magnification(self):
         AG = AcquisitionGeometry.create_Cone2D(source_position=[0,-500], detector_position=[0.,1000.])
         out = AG.config.system.calculate_magnification()
-        self.assertEqual(out, [500, 1000, 3]) 
+        numpy.testing.assert_almost_equal(out, [500, 1000, 3]) 
 
         AG = AcquisitionGeometry.create_Cone2D(source_position=[0,-500], detector_position=[0.,1000.], rotation_axis_position=[0.,250.])
         out = AG.config.system.calculate_magnification()
-        self.assertEqual(out, [750, 750, 2]) 
+        numpy.testing.assert_almost_equal(out, [750, 750, 2]) 
 
         AG = AcquisitionGeometry.create_Cone2D(source_position=[0,-500], detector_position=[0.,1000.], rotation_axis_position=[5.,0.])
         out = AG.config.system.calculate_magnification()
         source_to_object = numpy.sqrt(5.0**2 + 500.0**2)
         theta = math.atan2(5.0,500.0)
         source_to_detector = 1500.0/math.cos(theta)
-        self.assertEqual(out, [source_to_object, source_to_detector - source_to_object, source_to_detector/source_to_object]) 
+        numpy.testing.assert_almost_equal(out, [source_to_object, source_to_detector - source_to_object, source_to_detector/source_to_object]) 
 
         AG = AcquisitionGeometry.create_Cone2D(source_position=[0,-500], detector_position=[0.,1000.], rotation_axis_position=[5.,0.],detector_direction_x=[math.sqrt(5),math.sqrt(5)])
         out = AG.config.system.calculate_magnification()
         source_to_object = numpy.sqrt(5.0**2 + 500.0**2)
 
-        ab = (AG.config.system.rotation_axis.position - AG.config.system.source.position).astype(numpy.float64)/source_to_object
+        ab = (AG.config.system.rotation_axis.position - AG.config.system.source.position)/source_to_object
 
         #source_position + d * ab = detector_position + t * detector_direction_x
         #x: d *  ab[0] =  t * detector_direction_x[0]
@@ -680,7 +680,7 @@ class Test_Cone2D(unittest.TestCase):
 
         source_to_detector = 1500 / (ab[1]  - ab[0])
 
-        self.assertEqual(out, [source_to_object, source_to_detector - source_to_object, source_to_detector/source_to_object]) 
+        numpy.testing.assert_almost_equal(out, [source_to_object, source_to_detector - source_to_object, source_to_detector/source_to_object]) 
 
     def test_calculate_centre_of_rotation(self):
         pass

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -268,12 +268,91 @@ class Test_AcquisitionGeometry(unittest.TestCase):
         self.assertDictEqual(gold1_3D, out1, "Failed Cone3D")
         self.assertDictEqual(gold2_3D, out2, "Failed Cone3D")
 
+        with self.assertRaises(ValueError):
+            ag.get_centre_of_rotation(distance_units='bad input')
+
+        with self.assertRaises(ValueError):
+            ag.get_centre_of_rotation(angle_units='bad input')
+
 
     def test_set_centre_of_rotation(self):
-        pass
+        # Functionality is tested in specific implementations
+        # this checks the pixel size scaling and return format for each geometry type
+        
+        gold_2D = {'offset':(0.25,'units distance'), 'angle':(0.0,'radian')}
+        gold_3D = {'offset':(0.25,'units distance'), 'angle':(math.pi/4,'radian')}
+
+        #check outputs for each geometry type
+        ag = AcquisitionGeometry.create_Parallel2D().set_panel(10,0.5)
+        ag.set_centre_of_rotation(0.25)
+        out = ag.get_centre_of_rotation()
+        self.assertDictEqual(gold_2D, out, "Failed Parallel2D default")
+
+        ag.set_centre_of_rotation(0.5, 'pixels')
+        out = ag.get_centre_of_rotation()
+        self.assertDictEqual(gold_2D, out, "Failed Parallel2D unit")
+
+        ag = AcquisitionGeometry.create_Parallel3D().set_panel([10,10],[0.5,0.5])
+        ag.set_centre_of_rotation(0.25, angle=math.pi/4)
+        out = ag.get_centre_of_rotation()
+        self.assertDictEqual(gold_3D, out, "Failed Parallel3D default")
+
+        ag.set_centre_of_rotation(0.5, 'pixels', 45, 'degree')
+        out = ag.get_centre_of_rotation()        
+        self.assertDictEqual(gold_3D, out, "Failed Parallel3D units")
+
+        ag = AcquisitionGeometry.create_Cone2D([0,-50], [0,50]).set_panel(10,0.5)
+        ag.set_centre_of_rotation(0.25)
+        out = ag.get_centre_of_rotation()
+        self.assertDictEqual(gold_2D, out, "Failed Cone2D default")
+
+        ag.set_centre_of_rotation(0.5, 'pixels')
+        out = ag.get_centre_of_rotation()       
+        self.assertDictEqual(gold_2D, out, "Failed Cone2D units")
+
+        ag = AcquisitionGeometry.create_Cone3D([0,-50,0], [0,50,0]).set_panel([10,10],[0.5,0.5])
+        ag.set_centre_of_rotation(0.25, angle=math.pi/4)
+        out = ag.get_centre_of_rotation()
+        self.assertDictEqual(gold_3D, out, "Failed Cone3D default")
+
+        ag.set_centre_of_rotation(0.5,'pixels', 45, 'degree')
+        out = ag.get_centre_of_rotation()        
+        self.assertDictEqual(gold_3D, out, "Failed Cone3D units")
+
+        with self.assertRaises(ValueError):
+            ag.set_centre_of_rotation(distance_units='bad input')
+
+        with self.assertRaises(ValueError):
+            ag.set_centre_of_rotation(angle_units='bad input')
+
 
     def test_set_centre_of_rotation_by_slice(self):
-        pass
+        # Functionality is tested in specific implementations
+        # this checks the pixel size scaling and return format for each geometry type
+        
+        gold_2D = {'offset':(0.25,'units distance'), 'angle':(0.0,'radian')}
+        gold_3D = {'offset':(0.25,'units distance'), 'angle':(math.pi/4,'radian')}
+
+        #check outputs for each geometry type
+        ag = AcquisitionGeometry.create_Parallel2D().set_panel(10,0.5)
+        ag.set_centre_of_rotation_by_slice(0.5)
+        out = ag.get_centre_of_rotation()
+        self.assertDictEqual(gold_2D, out, "Failed Parallel2D")
+
+        ag = AcquisitionGeometry.create_Parallel3D().set_panel([10,10],[0.5,0.5])
+        ag.set_centre_of_rotation_by_slice(-4.5, -5, 5.5, 5)
+        out = ag.get_centre_of_rotation()        
+        self.assertDictEqual(gold_3D, out, "Failed Parallel3D")
+
+        ag = AcquisitionGeometry.create_Cone2D([0,-50], [0,50]).set_panel(10,0.5)
+        ag.set_centre_of_rotation_by_slice(0.5)
+        out = ag.get_centre_of_rotation()       
+        self.assertDictEqual(gold_2D, out, "Failed Cone2D")
+
+        ag = AcquisitionGeometry.create_Cone3D([0,-50,0], [0,50,0]).set_panel([10,10],[0.5,0.5])
+        ag.set_centre_of_rotation_by_slice(-4.5, -5, 5.5, 5)
+        out = ag.get_centre_of_rotation()        
+        self.assertDictEqual(gold_3D, out, "Failed Cone3D")
 
 
     def test_equal(self):

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -235,7 +235,7 @@ class Test_AcquisitionGeometry(unittest.TestCase):
 
     def test_centre_of_rotation(self):
         pass
-    
+
     def test_set_centre_of_rotation(self):
         pass
 
@@ -540,7 +540,56 @@ class Test_Parallel2D(unittest.TestCase):
         self.assertAlmostEqual(distance, out['offset'][0], 5, "Failed with rotated detector")
 
     def test_set_centre_of_rotation(self):
-        pass
+        AG = AcquisitionGeometry.create_Parallel2D()
+
+        offset_in = 1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed positive offset")
+
+        offset_in = -1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed negative offset")
+
+        offset_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed reset offset")
+
+        AG = AcquisitionGeometry.create_Parallel2D(detector_direction_x=[-1,0])
+
+        offset_in = 1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed positive offset")
+
+        offset_in = -1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed negative offset")
+
+        offset_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed reset offset")
+
+
+        AG = AcquisitionGeometry.create_Parallel2D(detector_direction_x=[0.5,0.5],rotation_axis_position=[0.5,0.])
+        offset_in = 1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed positive offset")
+
+        offset_in = -1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed negative offset")
+
+        offset_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed reset offset")
 
 
 class Test_Parallel3D(unittest.TestCase):
@@ -616,38 +665,39 @@ class Test_Parallel3D(unittest.TestCase):
 
         AG = AcquisitionGeometry.create_Parallel3D()
         out = AG.config.system.calculate_centre_of_rotation()
-        gold = {'offset':(0,'units'), 'angle':(0,'degree')}
+        gold = {'offset':(0,'units'), 'angle':(0,'radian')}
         self.assertDictEqual(gold, out, "Failed basic")
 
         AG = AcquisitionGeometry.create_Parallel3D(units='mm')
         out = AG.config.system.calculate_centre_of_rotation()
-        gold = {'offset':(0,'mm'), 'angle':(0,'degree')}
+        gold = {'offset':(0,'mm'), 'angle':(0,'radian')}
         self.assertDictEqual(gold, out, "Failed basic, with units")
 
+        angle = math.pi/4
         AG = AcquisitionGeometry.create_Parallel3D(rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[0.5,0,0.5])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(0.5, out['offset'][0], 5, "Failed positive offset")
-        self.assertAlmostEqual(45, out['angle'][0], 5, "Failed positive angle")
+        self.assertAlmostEqual(angle, out['angle'][0], 5, "Failed positive angle")
 
         AG = AcquisitionGeometry.create_Parallel3D(rotation_axis_position=[-0.5,0.,0.], rotation_axis_direction=[-0.5,0,0.5])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(-0.5, out['offset'][0], 5, "Failed negative offset")
-        self.assertAlmostEqual(-45, out['angle'][0], 5, "Failed negative angle")
+        self.assertAlmostEqual(-angle, out['angle'][0], 5, "Failed negative angle")
 
         AG = AcquisitionGeometry.create_Parallel3D(rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[0.5,0,0.5], detector_direction_x=[-1,0,0.])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(-0.5, out['offset'][0], 5, "Failed detector direction_x: offset")        
-        self.assertAlmostEqual(-45, out['angle'][0], 5, "Failed detector direction_x: angle")
+        self.assertAlmostEqual(-angle, out['angle'][0], 5, "Failed detector direction_x: angle")
 
         AG = AcquisitionGeometry.create_Parallel3D(rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[0.5,0,0.5], detector_direction_y=[0,0,-1])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(0.5, out['offset'][0], 5, "Failed detector direction_y: offset")        
-        self.assertAlmostEqual(135, out['angle'][0], 5, "Failed detector direction_y: angle") #from det_y axis to rotate axis, taking in to account direction
+        self.assertAlmostEqual(math.pi-angle, out['angle'][0], 5, "Failed detector direction_y: angle") #from det_y axis to rotate axis, taking in to account direction
 
         AG = AcquisitionGeometry.create_Parallel3D(rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[-0.5,0,-0.5], detector_direction_y=[0,0,-1])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(0.5, out['offset'][0], 5, "Failed invert rotate axis: offset")        
-        self.assertAlmostEqual(-45, out['angle'][0], 5, "Failed invert rotate axis: angle")
+        self.assertAlmostEqual(-angle, out['angle'][0], 5, "Failed invert rotate axis: angle")
 
 
         theta = math.pi/4 #detector angle
@@ -665,7 +715,160 @@ class Test_Parallel3D(unittest.TestCase):
 
 
     def test_set_centre_of_rotation(self):
-        pass
+        AG = AcquisitionGeometry.create_Parallel3D()
+
+        offset_in = 1.5
+        angle_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed positive offset: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed positive offset: angle")
+
+        offset_in = -1.5
+        angle_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed negative offset: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed negative offset: angle")
+
+        offset_in = 0
+        angle_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed reset offset: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed reset offset: angle")
+
+        offset_in = 0
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed positive angle: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed positive angle: angle")
+
+        offset_in = 0
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed negative angle: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed negative angle: angle")
+
+        offset_in = 0
+        angle_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed reset angle: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed reset angle: angle")
+
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed combination A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed combination A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed combination A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed combination B: angle")
+
+
+
+        AG = AcquisitionGeometry.create_Parallel3D(detector_direction_x=[-1,0,0.])
+
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert detector x A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert detector x B: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert detector x B: angle")
+
+
+        AG = AcquisitionGeometry.create_Parallel3D(rotation_axis_direction=[0,0,-1])
+        
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert rotate axis A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert rotate axis A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert rotate axis B: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert rotate axis B: angle")
+
+
+        AG = AcquisitionGeometry.create_Parallel3D(detector_direction_y=[0,0,-1])
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert detector y A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert detector y A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert detector y A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert detector y A: angle")
+
+        AG = AcquisitionGeometry.create_Parallel3D(rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[-0.5,0,-0.5], detector_direction_y=[0,0,-1])
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed rolled and inverted detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed rolled and inverted detector x A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed rolled and inverted detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed rolled and inverted detector x B: angle")
+
+
+        AG = AcquisitionGeometry.create_Parallel3D(detector_direction_x=[0.5,0.5,0],rotation_axis_position=[0.5,0.,0])
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed rotated detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed rotated detector x A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed rotated detector x B: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed rotated detector x B: angle")
+
+        AG = AcquisitionGeometry.create_Parallel3D(detector_direction_y=[0.0,-0.5,0.5],rotation_axis_position=[0.5,0.,0.])
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed tilted detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed tilted detector x A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed tilted detector x B: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed tilted detector x B: angle")
 
 class Test_Cone2D(unittest.TestCase):
     
@@ -798,7 +1001,58 @@ class Test_Cone2D(unittest.TestCase):
         self.assertAlmostEqual(distance, out['offset'][0], 5, "Failed with rotated detector")
 
     def test_set_centre_of_rotation(self):
-        pass
+
+        AG = AcquisitionGeometry.create_Cone2D(source_position=[0,-500], detector_position=[0.,1000.])
+
+        offset_in = 1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed positive offset")
+
+        offset_in = -1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed negative offset")
+
+        offset_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed reset offset")
+
+        AG = AcquisitionGeometry.create_Cone2D(source_position=[0,-500], detector_position=[0.,1000.], detector_direction_x=[-1,0])
+
+        offset_in = 1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed positive offset")
+
+        offset_in = -1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed negative offset")
+
+        offset_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed reset offset")
+
+
+        AG = AcquisitionGeometry.create_Cone2D(source_position=[0,-500], detector_position=[0.,500.], detector_direction_x=[0.5,0.5],rotation_axis_position=[0.5,0.])
+        offset_in = 1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed positive offset")
+
+        offset_in = -1.5
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed negative offset")
+
+        offset_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in)
+        offset_out = AG.config.system.calculate_centre_of_rotation()['offset'][0]
+        self.assertAlmostEqual(offset_in, offset_out, 5, "Failed reset offset")
+
 
 class Test_Cone3D(unittest.TestCase):
     
@@ -914,39 +1168,45 @@ class Test_Cone3D(unittest.TestCase):
     def test_calculate_centre_of_rotation(self):
         AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0])
         out = AG.config.system.calculate_centre_of_rotation()
-        gold = {'offset':(0,'units'), 'angle':(0,'degree')}
+        gold = {'offset':(0,'units'), 'angle':(0,'radian')}
         self.assertDictEqual(gold, out, "Failed basic")
 
         AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0],units='mm')
         out = AG.config.system.calculate_centre_of_rotation()
-        gold = {'offset':(0,'mm'), 'angle':(0,'degree')}
+        gold = {'offset':(0,'mm'), 'angle':(0,'radian')}
         self.assertDictEqual(gold, out, "Failed basic, with units")
 
+        angle = math.pi/4 
         AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[0.5,0,0.5])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(1.5, out['offset'][0], 5, "Failed positive offset")
-        self.assertAlmostEqual(45, out['angle'][0], 5, "Failed positive angle")
+        self.assertAlmostEqual(angle, out['angle'][0], 5, "Failed positive angle")
 
         AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], rotation_axis_position=[-0.5,0.,0.], rotation_axis_direction=[-0.5,0,0.5])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(-1.5, out['offset'][0], 5, "Failed negative offset")
-        self.assertAlmostEqual(-45, out['angle'][0], 5, "Failed negative angle")
+        self.assertAlmostEqual(-angle, out['angle'][0], 5, "Failed negative angle")
 
         AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[0.5,0,0.5], detector_direction_x=[-1,0,0.])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(-1.5, out['offset'][0], 5, "Failed detector direction_x: offset")        
-        self.assertAlmostEqual(-45, out['angle'][0], 5, "Failed detector direction_x: angle")
+        self.assertAlmostEqual(-angle, out['angle'][0], 5, "Failed detector direction_x: angle")
 
         AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[0.5,0,0.5], detector_direction_y=[0,0,-1])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(1.5, out['offset'][0], 5, "Failed detector direction_y: offset")        
-        self.assertAlmostEqual(135, out['angle'][0], 5, "Failed detector direction_y: angle") #from det_y axis to rotate axis, taking in to account direction
+        self.assertAlmostEqual(math.pi-angle, out['angle'][0], 5, "Failed detector direction_y: angle") #from det_y axis to rotate axis, taking in to account direction
+
 
         AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[-0.5,0,-0.5], detector_direction_y=[0,0,-1])
         out = AG.config.system.calculate_centre_of_rotation()
         self.assertAlmostEqual(1.5, out['offset'][0], 5, "Failed invert rotate axis: offset")        
-        self.assertAlmostEqual(-45, out['angle'][0], 5, "Failed invert rotate axis: angle")
+        self.assertAlmostEqual(-angle, out['angle'][0], 5, "Failed invert rotate axis: angle")
 
+        AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[0,0,-1])
+        out = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(1.5, out['offset'][0], 5, "Failed invert rotate axis: offset")        
+        self.assertAlmostEqual(math.pi, out['angle'][0], 5, "Failed invert rotate axis: angle")
 
         #offset * mag = 1
         theta = math.pi/4 #detector angle
@@ -971,7 +1231,7 @@ class Test_Cone3D(unittest.TestCase):
         L = -Y * math.sin(theta)
 
         X = L * math.tan(phi)
-        angle = math.atan2(X,Y)*180./math.pi
+        angle = math.atan2(X,Y)
 
         AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,500.,0], detector_direction_y=[0.0,-0.5,0.5],rotation_axis_position=[0.5,0.,0.])
         out = AG.config.system.calculate_centre_of_rotation()
@@ -979,4 +1239,158 @@ class Test_Cone3D(unittest.TestCase):
         self.assertAlmostEqual(angle, out['angle'][0], 5, "Failed tilted detector: angle")
 
     def test_set_centre_of_rotation(self):
-        pass
+
+        AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0])
+
+        offset_in = 1.5
+        angle_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed positive offset: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed positive offset: angle")
+
+        offset_in = -1.5
+        angle_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed negative offset: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed negative offset: angle")
+
+        offset_in = 0
+        angle_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed reset offset: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed reset offset: angle")
+
+        offset_in = 0
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed positive angle: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed positive angle: angle")
+
+        offset_in = 0
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed negative angle: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed negative angle: angle")
+
+        offset_in = 0
+        angle_in = 0
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed reset angle: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed reset angle: angle")
+
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed combination A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed combination A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed combination A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed combination B: angle")
+
+
+
+        AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], detector_direction_x=[-1,0,0.])
+
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert detector x A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert detector x B: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert detector x B: angle")
+
+
+        AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], rotation_axis_direction=[0,0,-1])
+        
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert rotate axis A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert rotate axis A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert rotate axis B: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert rotate axis B: angle")
+
+
+        AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], detector_direction_y=[0,0,-1])
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert detector y A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert detector y A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed invert detector y A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed invert detector y A: angle")
+
+        AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0], rotation_axis_position=[0.5,0.,0.], rotation_axis_direction=[-0.5,0,-0.5], detector_direction_y=[0,0,-1])
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed rolled and inverted detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed rolled and inverted detector x A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed rolled and inverted detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed rolled and inverted detector x B: angle")
+
+
+        AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,500.,0], detector_direction_x=[0.5,0.5,0],rotation_axis_position=[0.5,0.,0])
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed rotated detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed rotated detector x A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed rotated detector x B: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed rotated detector x B: angle")
+
+        AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,500.,0], detector_direction_y=[0.0,-0.5,0.5],rotation_axis_position=[0.5,0.,0.])
+        offset_in = -1.5
+        angle_in = -0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed tilted detector x A: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed tilted detector x A: angle")
+
+        offset_in = 1.5
+        angle_in = 0.2
+        AG.config.system.set_centre_of_rotation(offset_in, angle_in)
+        cofr_set = AG.config.system.calculate_centre_of_rotation()
+        self.assertAlmostEqual(offset_in, cofr_set['offset'][0], 5, "Failed tilted detector x B: offset")
+        self.assertAlmostEqual(angle_in, cofr_set['angle'][0], 5, "Failed tilted detector x B: angle")

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -233,6 +233,12 @@ class Test_AcquisitionGeometry(unittest.TestCase):
         self.assertEqual(AG.dimension_labels, ('horizontal','channel','vertical'))
         self.assertEqual(AG.shape, (2,4,3))
 
+    def test_set_centre_of_rotation(self):
+        pass
+
+    def test_get_centre_of_rotation(self):
+        pass
+
     def test_equal(self):
         AG = AcquisitionGeometry.create_Parallel3D()
         AG.set_channels(4, ['a','b','c','d'])
@@ -500,6 +506,13 @@ class Test_Parallel2D(unittest.TestCase):
         out = AG.config.system.calculate_magnification()
         self.assertEqual(out, [None, None, 1]) 
 
+    def test_calculate_centre_of_rotation(self):
+        pass
+
+    def test_get_centre_of_rotation(self):
+        pass
+
+
 class Test_Parallel3D(unittest.TestCase):
 
     def test_align_reference_frame_cil(self):
@@ -568,6 +581,12 @@ class Test_Parallel3D(unittest.TestCase):
         AG = AcquisitionGeometry.create_Parallel3D()
         out = AG.config.system.calculate_magnification()
         self.assertEqual(out, [None, None, 1]) 
+
+    def test_calculate_centre_of_rotation(self):
+        pass
+
+    def test_get_centre_of_rotation(self):
+        pass
 
 class Test_Cone2D(unittest.TestCase):
     
@@ -662,6 +681,12 @@ class Test_Cone2D(unittest.TestCase):
         source_to_detector = 1500 / (ab[1]  - ab[0])
 
         self.assertEqual(out, [source_to_object, source_to_detector - source_to_object, source_to_detector/source_to_object]) 
+
+    def test_calculate_centre_of_rotation(self):
+        pass
+
+    def test_get_centre_of_rotation(self):
+        pass
 
 class Test_Cone3D(unittest.TestCase):
     
@@ -774,4 +799,8 @@ class Test_Cone3D(unittest.TestCase):
         source_to_detector = 1500 / (ab[1]  - ab[0])
         self.assertEqual(out, [source_to_object, source_to_detector - source_to_object, source_to_detector/source_to_object]) 
 
+    def test_calculate_centre_of_rotation(self):
+        pass
 
+    def test_get_centre_of_rotation(self):
+        pass

--- a/Wrappers/Python/test/test_NexusReaderWriter.py
+++ b/Wrappers/Python/test/test_NexusReaderWriter.py
@@ -162,8 +162,6 @@ class TestNexusReaderWriter(unittest.TestCase):
         self.assertEqual(ag3d.pixel_size_h, self.ag3d.pixel_size_h, 'AcquisitionGeometry.pixel_size_h is not correct')
         self.assertEqual(ag3d.pixel_num_v, self.ag3d.pixel_num_v, 'AcquisitionGeometry.pixel_num_v is not correct')
         self.assertEqual(ag3d.pixel_size_v, self.ag3d.pixel_size_v, 'AcquisitionGeometry.pixel_size_v is not correct')
-        self.assertEqual(ag3d.dist_source_center, self.ag3d.dist_source_center, 'AcquisitionGeometry.dist_source_center is not correct')
-        self.assertEqual(ag3d.dist_center_detector, self.ag3d.dist_center_detector, 'AcquisitionGeometry.dist_center_detector is not correct')
         self.assertEqual(ag3d.channels, self.ag3d.channels, 'AcquisitionGeometry.channels is not correct')
 
         assert ag3d == self.ag3d


### PR DESCRIPTION
## Describe your changes
Added convenience methods:
 - `acquisition_geometry.get_centre_of_rotation()`
 - `acquisition_geometry.set_centre_of_rotation()`
 - `acquisition_geometry.set_centre_of_rotation_by_slice()`

This allows you to set/get the projection of the rotation axis on the detector.

Each type of acquisition geometries (Cone2D/3D Parallel2D/3D) have their own methods to configure the system as requested by moving the relative positions of the source/detector/rotation axis in 3D space. These include:
 - `rotation_axis_on_detector()`
 - `calculate_centre_of_rotation()`
 - `set_centre_of_rotation()`

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
Added unit tests for all methods. Extensive testing of the underlying calculations. Tested on full datasets from demos.

## Link relevant issues
closes #1133

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
