### PR TITLE
Add show1D for line plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Update version of download_artifact github action to version 3.0.1
     - Update version of checkout github action to version 3.1.0
     - Update build-sphinx action to version 0.1.3
+  - Add show1D display utility
 
 * 22.1.0
   - use assert_allclose in test_DataContainer

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -126,7 +126,7 @@ class show1D(show_base):
         A title for the plot
     color : str, list of str, default=None
         Color(s) for each line plot
-    ls : {"-","--","-.",":"}, dict of {"-","--","-.",":"}, default=None
+    ls : {"-","--","-.",":"}, list of {"-","--","-.",":"}, default=None
         Linestyle(s) for each line plot
     axis_labels : tuple of str, list of str, default=('Pixel','Pixel value')
         Axis labels in the form (x_axis_label,y_axis_label)
@@ -155,7 +155,7 @@ class show1D(show_base):
     >>> data_channel0 = data.get_slice(channel=0)
     >>> data_channel1 = data.get_slice(channel=1)
     >>> show1D([data_channel0, data_channel1], line_coords=[('horizontal_x', 256)],
-    ...        label=['Channel 0', 'Channel 1'])
+    ...        label=['Channel 0', 'Channel 1'], ls=["--", "-"])
 
     The following example uses two sets of slicing information applied to a
     single dataset, resulting in two separate plots.
@@ -307,7 +307,7 @@ class show1D(show_base):
             A title for the plot
         colors : str, list of str, default=None
             Color(s) for each line plot
-        ls : {"-","--","-.",":"}, dict of {"-","--","-.",":"}, default=None
+        ls : {"-","--","-.",":"}, list of {"-","--","-.",":"}, default=None
             Linestyle(s) for each line plot
         axis_labels : tuple of str, list of str, default=('Pixel','Pixel value')
             Axis labels in the form (x_axis_label,y_axis_label)

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -31,8 +31,8 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from itertools import cycle
 
 CB_PALETTE = ['#377eb8', '#ff7f00', '#4daf4a',
-                        '#f781bf', '#a65628', '#984ea3',
-                        '#999999', '#e41a1c', '#dede00']
+              '#f781bf', '#a65628', '#984ea3',
+              '#999999', '#e41a1c', '#dede00']
 
 class _PlotData(object):
     def __init__(self, data, title, axis_labels, origin):
@@ -127,6 +127,8 @@ class show1D(show_base):
         A title for the plot
     color : str, list of str, default=None
         Color(s) for each line plot
+    ls : {"-","--","-.",":"}, dict of {"-","--","-.",":"}, default=None
+        Linestyle(s) for each line plot
     axis_labels : tuple of str, list of str, default=('Pixel','Pixel value')
         Axis labels in the form (x_axis_label,y_axis_label)
     num_cols : int, default=3

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -126,7 +126,31 @@ class show1D(show_base):
     ----------
     figure : matplotlib.figure.Figure
 
+    Examples
+    --------
+
+    This example creates two 2D datasets (images), and uses the provided slicing
+    information to generate two plots on the same axis, corresponding to the two
+    datasets.
+
+    >>> from cil.utilities.display import show1D
+    >>> from cil.utilities.dataexample import PEPPERS
+    >>> data = PEPPERS.get()
+    >>> data_channel0 = data.get_slice(channel=0)
+    >>> data_channel1 = data.get_slice(channel=1)
+    >>> show1D([data_channel0, data_channel1], line_coords=[('horizontal_x', 256)],
+    ...        label=['Channel 0', 'Channel 1'])
+
+    The following example uses two sets of slicing information applied to a single
+    dataset, resulting in two separate plots.
+
+    >>> from cil.utilities.display import show1D
+    >>> from cil.utilities.dataexample import PEPPERS
+    >>> data = PEPPERS.get()
+    >>> slices = [[('channel', 0), ('horizontal_x', 256)], [('channel', 1), ('horizontal_y', 256)]]
+    >>> show1D(data, line_coords=slices, title=['Channel 0', 'Channel 1'])
     """
+
     def __init__(self, data, line_coords=None, label=None, title=None,
                  color=None, axis_labels=('Pixel', 'Pixel value'), num_cols=3,
                  size=(8,6), force=True):

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -96,27 +96,37 @@ class show_base(object):
 
 class show1D(show_base):
     """
-    This creates and displays 1D plots of pixel values by slicing multi-dimensional
-    data.
+    This creates and displays 1D plots of pixel values by slicing
+    multi-dimensional data.
+
+    When provided one or more datasets, alongside dimensions and
+    coordinates at which to slice, this function will generate graphs
+    plotting the resultant 1D data. If a single set of slicing information
+    is given via `line_coords` (see the first example below), this function
+    will generate a single graph with one line plot per dataset provided.
+    If multiple sets of slicing information are given (see the second
+    example below), this function will generate one graph per set (i.e. per
+    1D slice), each with one line plot per dataset.
 
     Parameters
     ----------
     data : DataContainer, list of DataContainer, tuple of DataContainer
         Multi-dimensional data to be reduced to 1D.
-    line_coords : list of tuples, default=None
-        (dimension, coordinate) pairs for slicing `data`
+    line_coords : list of tuple or list of list of tuple, default=None
+        A list, or nested list, of (dimension, coordinate) pairs for
+        slicing `data` (default is None, which is only valid when 1D
+        data is passed)
     label : str, list of str, default=None
         Label(s) to use in the plot's legend
     title : str, default None
         A title for the plot
     color : str, list of str, default=None
         Color(s) for each line plot
-    axis_labels : tuple of str, list of str, default=('Pixel','Pixel
-    value')
+    axis_labels : tuple of str, list of str, default=('Pixel','Pixel value')
         Axis labels in the form (x_axis_label,y_axis_label)
     num_cols : int, default=3
-        The number of columns in the grid of subplots produced in the case of
-        multiple plots
+        The number of columns in the grid of subplots produced in the case
+        of multiple plots
     size : tuple, default=(8,6)
         The size of the figure
     force : bool, default=True
@@ -129,9 +139,9 @@ class show1D(show_base):
     Examples
     --------
 
-    This example creates two 2D datasets (images), and uses the provided slicing
-    information to generate two plots on the same axis, corresponding to the two
-    datasets.
+    This example creates two 2D datasets (images), and uses the provided
+    slicing information to generate two plots on the same axis,
+    corresponding to the two datasets.
 
     >>> from cil.utilities.display import show1D
     >>> from cil.utilities.dataexample import PEPPERS
@@ -141,8 +151,8 @@ class show1D(show_base):
     >>> show1D([data_channel0, data_channel1], line_coords=[('horizontal_x', 256)],
     ...        label=['Channel 0', 'Channel 1'])
 
-    The following example uses two sets of slicing information applied to a single
-    dataset, resulting in two separate plots.
+    The following example uses two sets of slicing information applied to a
+    single dataset, resulting in two separate plots.
 
     >>> from cil.utilities.display import show1D
     >>> from cil.utilities.dataexample import PEPPERS
@@ -309,28 +319,29 @@ class show1D(show_base):
                 axis_labels=('Pixel', 'Pixel value'), num_cols=3, plot_size=(8,6),
                 force=True):
         """
-        Displays 1D plots of pixel flux from multi-dimensional
-        data and slicing information.
+        Displays 1D plots of pixel flux from multi-dimensional data and
+        slicing information.
 
         Parameters
         ----------
-        data : DataContainer, list of DataContainer or tuple of DataContainer
+        data : DataContainer, list of DataContainer or tuple of
+        DataContainer
             The data to be sliced and plotted
-        line_coords : list of tuples, optional
-            (dimension, coordinate) pairs for slicing `data` (default is
-            None, which is only valid when 1D data is passed)
+        line_coords : list of tuple or list of list of tuple, optional
+            A list, or nested list, of (dimension, coordinate) pairs for
+            slicing `data` (default is None, which is only valid when 1D
+            data is passed)
         labels : str, list of str, default=None
             Label(s) to use in the plot's legend
         titles : str, default=None
             A title for the plot
         colors : str, list of str, default=None
             Color(s) for each line plot
-        axis_labels : tuple of str, list of str, default=('Pixel','Pixel
-        value')
+        axis_labels : tuple of str, list of str, default=('Pixel','Pixel value')
             Axis labels in the form (x_axis_label,y_axis_label)
         num_cols : int, default=3
-            The number of columns in the grid of subplots produced in the case of
-            multiple plots
+            The number of columns in the grid of subplots produced in the
+            case of multiple plots
         plot_size : tuple, default=(8,6)
             The size of the figure
         force : bool, default=True

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -114,6 +114,9 @@ class show1D(show_base):
             Color(s) for each line plot, by default None
         size : tuple, optional
             The size of the figure, by default (8,6)
+        axis_labels : tuple of str, list of str, default=('Pixel','Pixel
+        value')
+            Axis labels in the form (x_axis_label,y_axis_label)
         force : bool, optional
             Passed to `get_slice`, by default True
 
@@ -123,10 +126,13 @@ class show1D(show_base):
 
     """
     def __init__(self, data, line_coords=None, label=None, title=None,
-                color=None, size=(8,6), force=True):
+                 color=None, axis_labels=('Pixel', 'Pixel value'),
+                 size=(8,6), force=True):
 
         self.figure = self._line_plot(data, line_coords=line_coords, label=label,
-                                    title=title, color=color, size=size, force=force)
+                                      title=title, color=color,
+                                      axis_labels=axis_labels,
+                                      size=size, force=force)
 
     def _extract_vector(self, data, coords, force=True):
         """
@@ -198,7 +204,8 @@ class show1D(show_base):
         return vector
 
     def _line_plot(self, data, line_coords=None, label=None,
-                    title=None, color=None, size=(8,6), force=True):
+                   title=None, color=None, size=(8,6),
+                   axis_labels=('Pixel', 'Pixel value'), force=True):
         """
         Creates and displays a 1D plot of pixel flux from multi-dimensional
         data and slicing information.
@@ -219,6 +226,9 @@ class show1D(show_base):
             Color(s) for each line plot
         size : tuple, default=(8,6)
             The size of the figure
+        axis_labels : tuple of str, list of str, default=('Pixel','Pixel
+        value')
+            Axis labels in the form (x_axis_label,y_axis_label)
         force : bool, default=True
             Passed to `get_slice`
 
@@ -268,12 +278,16 @@ class show1D(show_base):
                     color=color, label=label)
 
         ax.set_title(title)
-        ax.set_xlabel(f'Pixel')
-        ax.set_ylabel('Pixel value')
+        ax.set_xlabel(axis_labels[0]) # TODO determine axis labels from dimensions
+        ax.set_ylabel(axis_labels[1])
 
         fig2 = plt.gcf()
 
-        if label: plt.legend()
+        valid_labels = 0
+        if isinstance(label, list):
+            valid_labels = len([l for l in label if l is not None])
+
+        if valid_labels: plt.legend()
         plt.show()
 
         return fig2

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -153,7 +153,7 @@ class show1D(show_base):
     >>> data_channel0 = data.get_slice(channel=0)
     >>> data_channel1 = data.get_slice(channel=1)
     >>> show1D([data_channel0, data_channel1], slice_list=[('horizontal_x', 256)],
-    ...        label=['Channel 0', 'Channel 1'])
+    ...        label=['Channel 0', 'Channel 1'], line_styles=["--", "-"])
 
     The following example uses two sets of slicing information applied to a
     single dataset, resulting in two separate plots.

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -104,14 +104,13 @@ class show1D(show_base):
     This creates and displays 1D plots of pixel values by slicing
     multi-dimensional data.
 
-    When provided one or more datasets, alongside dimensions and
-    coordinates at which to slice, this function will generate graphs
-    plotting the resultant 1D data. If a single set of slicing information
-    is given via `line_coords` (see the first example below), this function
-    will generate a single graph with one line plot per dataset provided.
-    If multiple sets of slicing information are given (see the second
-    example below), this function will generate one graph per set (i.e. per
-    1D slice), each with one line plot per dataset.
+    The behaviour is as follows: if provided multiple datasets and a single
+    slice set (see first example below), one line plot will be generated
+    per dataset; if provided a single dataset and multiple sets of slices
+    (see second example below), one line plot will be generated per slice
+    set;  if provided multiple datasets and multiple slice sets, the
+    :math:`i`-th set of slices will apply to the :math:`i`-th dataset, with
+    a line plot generated in each case.
 
     Parameters
     ----------
@@ -248,7 +247,7 @@ class show1D(show_base):
     def _plot_slice(self, ax, data, line_coords=None,
                    label=None, color=None, ls=None, force=True):
         """
-        Creates 1D plots pixel flux from multi-dimensional data and slicing information.
+        Creates 1D plots of pixel flux from multi-dimensional data and slicing information.
 
         Parameters
         ----------

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -126,7 +126,7 @@ class show1D(show_base):
         A title for the plot
     line_colours : str, list of str, default=None
         Colour(s) for each line plot
-    line_styles : {"-","--","-.",":"}, dict of {"-","--","-.",":"}, default=None
+    line_styles : {"-","--","-.",":"}, list of {"-","--","-.",":"}, default=None
         Linestyle(s) for each line plot
     axis_labels : tuple of str, list of str, default=('Index','Value')
         Axis labels in the form (x_axis_label,y_axis_label)
@@ -301,7 +301,7 @@ class show1D(show_base):
             A title for the plot
         line_colours : str, list of str, default=None
             Colour(s) for each line plot
-        line_styles : {"-","--","-.",":"}, dict of {"-","--","-.",":"}, default=None
+        line_styles : {"-","--","-.",":"}, list of {"-","--","-.",":"}, default=None
             Linestyle(s) for each line plot
         axis_labels : tuple of str, list of str, default=('Index','Value')
             Axis labels in the form (x_axis_label,y_axis_label)

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -95,10 +95,25 @@ class show_base(object):
 
 class show1D(show_base):
     """
-    This creates 1D plots of pixel flux.
+    This creates 1D plots of pixel values by slicing multi-dimensional data.
 
     Parameters
-    ----------
+        ----------
+        data : AcquisitionData, ImageData, list/tuple of AcquisitionData or
+        ImageData
+            Multi-dimensional data to be reduced to 1D.
+        line_coords : list of tuples
+            (dimension, coordinate) pairs for slicing `data`, by default None
+        label : str, list of str, optional
+            Label(s) to use in the plot's legend, by default None
+        title : str, optional
+            A title for the plot, by default None
+        color : str, list of str, optional
+            Color(s) for each line plot, by default None
+        size : tuple, optional
+            The size of the figure, by default (8,6)
+        force : bool, optional
+            Passed to `get_slice`, by default True
 
     Attributes
     ----------
@@ -148,16 +163,16 @@ class show1D(show_base):
 
         remaining_dimensions = set(possible_dimensions) - set(coords.keys())
         if len(remaining_dimensions) > 1:
-            raise ValueError(f'One remaining dimension required, \
-                                found {remaining_dimensions}')
+            raise ValueError(f'One remaining dimension required, ' \
+                            f'found {len(remaining_dimensions)}: {remaining_dimensions}')
 
         if isinstance(data, np.ndarray):
 
             s = data
             for d, i in coords.items():
                 if d not in possible_dimensions:
-                    raise ValueError(f'Unexpected key "{d}", not in \
-                                        {possible_dimensions}')
+                    raise ValueError(f'Unexpected key "{d}", not in ' \
+                                    f'{possible_dimensions}')
                 else:
                     s = s.take(indices=i, axis=d)
 
@@ -168,8 +183,8 @@ class show1D(show_base):
             sliceme = {**kwargs}
             for k,v in coords.items():
                 if k not in possible_dimensions:
-                    raise ValueError(f'Unexpected key "{k}", not in \
-                                        {possible_dimensions}')
+                    raise ValueError(f'Unexpected key "{k}", not in ' \
+                                    f'{possible_dimensions}')
                 else:
                     sliceme[k] = v
 
@@ -189,17 +204,17 @@ class show1D(show_base):
         ImageData, BlockDataContainers?
             _description_
         line_coords : list of tuples
-            _description_, by default None
+            (dimension, coordinate) pairs for slicing `data`, by default None
         label : str, list of str, optional
-            _description_, by default None
+            Label(s) to use in the plot's legend, by default None
         title : str, optional
-            _description_, by default None
+            A title for the plot, by default None
         color : str, list of str, optional
-            _description_, by default None
+            Color(s) for each line plot, by default None
         size : tuple, optional
-            _description_, by default (15,15)
+            The size of the figure, by default (8,6)
         force : bool, optional
-            _description_, by default False
+            Passed to `get_slice`, by default True
 
         Returns
         -------
@@ -235,9 +250,10 @@ class show1D(show_base):
                 for el in line_coords:
                     dims[el[0]] = el[1]
             except TypeError:
-                raise TypeError(f'Expected list of tuples for slicing, \
-                                received {type(line_coords)}')
+                raise TypeError(f'Expected list of tuples for slicing, ' \
+                                f'received {type(line_coords)}')
 
+        # TODO support VectorData
         fig, ax = plt.subplots(1, 1, figsize=size)
         if multi:
             for i, el in enumerate(data):

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -100,25 +100,24 @@ class show1D(show_base):
     data.
 
     Parameters
-        ----------
-        data : DataContainer, list of DataContainer, tuple of DataContainer
-            Multi-dimensional data to be reduced to 1D.
-        line_coords : list of tuples
-            (dimension, coordinate) pairs for slicing `data`, by default
-            None
-        label : str, list of str, optional
-            Label(s) to use in the plot's legend, by default None
-        title : str, optional
-            A title for the plot, by default None
-        color : str, list of str, optional
-            Color(s) for each line plot, by default None
-        size : tuple, optional
-            The size of the figure, by default (8,6)
-        axis_labels : tuple of str, list of str, default=('Pixel','Pixel
-        value')
-            Axis labels in the form (x_axis_label,y_axis_label)
-        force : bool, optional
-            Passed to `get_slice`, by default True
+    ----------
+    data : DataContainer, list of DataContainer, tuple of DataContainer
+        Multi-dimensional data to be reduced to 1D.
+    line_coords : list of tuples, default=None
+        (dimension, coordinate) pairs for slicing `data`
+    label : str, list of str, default=None
+        Label(s) to use in the plot's legend
+    title : str, default None
+        A title for the plot
+    color : str, list of str, default=None
+        Color(s) for each line plot
+    size : tuple, default=(8,6)
+        The size of the figure
+    axis_labels : tuple of str, list of str, default=('Pixel','Pixel
+    value')
+        Axis labels in the form (x_axis_label,y_axis_label)
+    force : bool, default=True
+        Passed to `get_slice`
 
     Attributes
     ----------

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -54,6 +54,12 @@ show2D - Display 2D slices
    :members:
    :inherited-members:
 
+show1D - Display 1D slices
+--------------------------
+
+.. autoclass:: cil.utilities.display.show1D
+   :members:
+   :inherited-members:
 
 show_geometry - Display system geometry
 ---------------------------------------


### PR DESCRIPTION
## Describe your changes
Adds a `cil.utilities.display.show1D` class for producing 1D line plots from multi-dimensional data. Currently, multiple lines can be drawn on the same set of axes, based on slicing information that is applied to all input data.

Example (e.g. cross-sections of an object, reconstructed using two different methods):
<img width="339" alt="show1D_image" src="https://user-images.githubusercontent.com/92022089/200362903-e4a46fe5-4ac4-4f93-8c16-989382816191.png">
<img width="339" alt="show1D_output" src="https://user-images.githubusercontent.com/92022089/200363107-0160d86d-375b-43b6-9e01-a0b934a944de.png">

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*

## Link relevant issues
closes #1391

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
