### PR TITLE
Update action versions to prevent warnings

### DIFF
--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: 3.7
-    - uses: lauramurgatroyd/build-sphinx-action@v0.1.1
+    - uses: lauramurgatroyd/build-sphinx-action@v0.1.2
       with:
         DOCS_PATH: 'docs'
         CONDA_BUILD_ENV_FILEPATH: 'docs/docs_environment.yml'

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.5.0
+      with:
+        fetch-depth: 0
     - name: conda-build
       uses: paskino/conda-package-publish-action@v1.4.3
       with:

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: 3.7
-    - uses: lauramurgatroyd/build-sphinx-action@set_output_update
+    - uses: lauramurgatroyd/build-sphinx-action@set_output_update 
       with:
         DOCS_PATH: 'docs'
         CONDA_BUILD_ENV_FILEPATH: 'docs/docs_environment.yml'

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -23,7 +23,7 @@ jobs:
         convert_win: false
         convert_osx: false
     - name: Upload artifact of the conda package.
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: cil-package
         path: recipe/linux-64/cil*

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: 3.7
-    - uses: lauramurgatroyd/build-sphinx-action@set_output_update 
+    - uses: lauramurgatroyd/build-sphinx-action@v0.1.3
       with:
         DOCS_PATH: 'docs'
         CONDA_BUILD_ENV_FILEPATH: 'docs/docs_environment.yml'

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -33,7 +33,7 @@ jobs:
     needs: conda_build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.5.0
+    - uses: actions/checkout@v3.1.0
       with:
         fetch-depth: 0
     - name: change directory

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -14,7 +14,7 @@ jobs:
   conda_build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.5.0
     - name: conda-build
       uses: paskino/conda-package-publish-action@v1.4.3
       with:
@@ -31,7 +31,7 @@ jobs:
     needs: conda_build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.5.0
       with:
         fetch-depth: 0
     - name: change directory

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: 3.7
-    - uses: lauramurgatroyd/build-sphinx-action@v0.1.2
+    - uses: lauramurgatroyd/build-sphinx-action@set_output_update
       with:
         DOCS_PATH: 'docs'
         CONDA_BUILD_ENV_FILEPATH: 'docs/docs_environment.yml'

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -14,7 +14,7 @@ jobs:
   conda_build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.5.0
+    - uses: actions/checkout@v3.1.0
       with:
         fetch-depth: 0
     - name: conda-build

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         ls
     - name: Download artifact of the conda package.
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3.0.1
       with:
         name: 'cil-package'
         path: 'conda_package'
@@ -60,7 +60,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
     - name: Download artifact of the html output.
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3.0.1
       with:
         name: DocumentationHTML
         path: docs/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
     - Update version of upload_artifact github action to version 3.1.1
     - Update version of download_artifact github action to version 3.0.1
     - Update version of checkout github action to version 3.1.0
-    - Update build-sphinx action to version 0.1.2
+    - Update build-sphinx action to version 0.1.3
 
 * 22.1.0
   - use assert_allclose in test_DataContainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
     - `get_centre_of_rotation()` calculates the centre of rotation of the system
     - `set_centre_of_rotation()` sets the system centre of rotation with an offset and angle
     - `set_centre_of_rotation_by_slice()` sets the system centre of rotation with offsets from two slices
+  - Github Actions:
+    - Update version of upload_artifact github action to version 3.1.1
+    - Update version of download_artifact github action to version 3.0.1
+    - Update version of checkout github action to version 3.1.0
+    - Update build-sphinx action to version 0.1.2
 
 * 22.1.0
   - use assert_allclose in test_DataContainer


### PR DESCRIPTION
## Describe your changes
Update version of upload_artifact github action to version 3.1.1
Update version of download_artifact github action to version 3.0.1
Update version of checkout github action to version 3.1.0
Update build-sphinx action to version v0.1.3

## Describe any testing you have performed
The docs build action in this PR no longer results in the warnings described in #1380. An example of where the warnings are seen is in this action build on a different PR: https://github.com/TomographicImaging/CIL/actions/runs/3549485639

## Link relevant issues
#1380 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
