### PR TITLE
remove _ from fix_weight method name in docstring

### DIFF
--- a/Wrappers/Python/cil/optimisation/algorithms/SIRT.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/SIRT.py
@@ -74,7 +74,7 @@ class SIRT(Algorithm):
 
     .. math:: D = \frac{1}{A*\mathbb{1}} = \frac{1}{\sum_{i}a_{i,j}}
 
-    In case of division errors above, :meth:`._fix_weights` can be used, where :code:`np.nan`, :code:`+np.inf` and :code:`-np.inf` values
+    In case of division errors above, :meth:`.fix_weights` can be used, where :code:`np.nan`, :code:`+np.inf` and :code:`-np.inf` values
     are replaced with 1.0.
 
 


### PR DESCRIPTION
Signed-off-by: Edoardo Pasca <edo.paskino@gmail.com>

## Describe your changes

update to SIRT docstring

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues

closes #1405

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
