### PR TITLE
Image data circular mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - Update version of download_artifact github action to version 3.0.1
     - Update version of checkout github action to version 3.1.0
     - Update build-sphinx action to version 0.1.3
+  - Added `ImageData.apply_circular_mask` method to mask out detector edge artefacts on reconstructed volumes
 
 * 22.1.0
   - use assert_allclose in test_DataContainer

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -3305,7 +3305,7 @@ class ImageData(DataContainer):
         Y, X = numpy.ogrid[-y_range:y_range+1,-x_range:x_range+1]
         
         # use centre from geometry in units distance to account for aspect ratio of pixels
-        dist_from_center = numpy.sqrt((X*ig.voxel_size_x- ig.center_x)**2 + (Y*ig.voxel_size_y-ig.center_y)**2)
+        dist_from_center = numpy.sqrt((X*ig.voxel_size_x+ ig.center_x)**2 + (Y*ig.voxel_size_y+ig.center_y)**2)
 
         size_x = ig.voxel_num_x * ig.voxel_size_x
         size_y = ig.voxel_num_y * ig.voxel_size_y

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -463,6 +463,32 @@ class TestDataContainer(CCPiTestClass):
         self.assertNumpyArrayEqual(numpy.asarray(data.shape), data.as_array().shape)
 
 
+    def test_ImageData_apply_circular_mask(self):
+        ig = ImageGeometry(voxel_num_x=6, voxel_num_y=3, voxel_size_x=0.5, voxel_size_y = 1)
+        data_orig = ig.allocate(1)
+
+        data_masked1 = data_orig.copy()
+        data_masked1.apply_circular_mask(0.8)
+
+        self.assertEqual(data_orig.geometry, data_masked1.geometry)
+        self.assertEqual(numpy.count_nonzero(data_masked1.array), 14)
+
+        data_masked1 = data_orig.copy()
+        data_masked1.apply_circular_mask(0.5)
+
+        self.assertEqual(data_orig.geometry, data_masked1.geometry)
+        self.assertEqual(numpy.count_nonzero(data_masked1.array), 8)
+
+        data2 = data_orig.copy()
+        data_masked2 = data2.apply_circular_mask(0.5, False)
+
+        numpy.testing.assert_allclose(data_orig.array, data2.array)
+        self.assertEqual(numpy.count_nonzero(data_masked2.array), 8)
+
+
+
+
+
     def test_AcquisitionData(self):
         sgeometry = AcquisitionGeometry.create_Parallel3D().set_angles(numpy.linspace(0, 180, num=10)).set_panel((5,3)).set_channels(2)
 


### PR DESCRIPTION
## Describe your changes
 Add an `apply_circular_mask` method to `ImageData`. It will set pixels outside the mask to zero. Commonly needed with FBP reconstructions where there is a discontinuity at the border of the detector back projection.

There's a basic anti-aliasing fudge to keep it as a smooth circle. 

The mask is centred on the rotation axis, compensating for any `ImageGeometry` centre offsets.

![image](https://user-images.githubusercontent.com/47746591/215539897-baff3364-cb84-4acd-9222-edc7f2df9ddd.png)

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues


## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
