### PR TITLE
Pixelwise indicatorbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 * Next
-  - IndicatorBox can handle masks
+  - Extended IndicatorBox to behave as IndicatorBoxPixelwise by passing masks in lower and upper bounds
   - added yml file to create test environment
   - LeastSquares fixed docstring and unified gradient code when out is passed or not.
   - Add compression to 8bit and 16bit to TIFFWriter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Next
+  - IndicatorBox can handle masks
   - added yml file to create test environment
   - LeastSquares fixed docstring and unified gradient code when out is passed or not.
   - Add compression to 8bit and 16bit to TIFFWriter

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2829,8 +2829,13 @@ class DataContainer(object):
             else:
                 raise ValueError(message(type(self),"Wrong size for data memory: out {} x2 {} expected {}".format( out.shape,x2.shape ,self.shape)))
         elif issubclass(type(out), DataContainer) and \
-             isinstance(x2, Number):
+             isinstance(x2, (Number, numpy.ndarray)):
             if self.check_dimensions(out):
+                if isinstance(x2, numpy.ndarray) and\
+                    not (x2.shape == self.shape and x2.dtype == self.dtype):
+                    raise ValueError(message(type(self),
+                        "Wrong size for data memory: out {} x2 {} expected {}"\
+                            .format( out.shape,x2.shape ,self.shape)))
                 kwargs['out']=out.as_array()
                 pwop(self.as_array(), x2, *args, **kwargs )
                 return out

--- a/Wrappers/Python/cil/optimisation/functions/IndicatorBox.py
+++ b/Wrappers/Python/cil/optimisation/functions/IndicatorBox.py
@@ -39,27 +39,22 @@ class IndicatorBox(Function):
 
         Parameters:
         -----------
-        lower : float, DataContainer or numpy array, default -np.inf
+        lower : float, DataContainer or numpy array, default ``-np.inf``
           Lower bound
-        upper : float, DataContainer or numpy array, default -np.inf
+        upper : float, DataContainer or numpy array, default ``np.inf``
           upper bound
         
         If passed a DataContainer or numpy array, the bounds can be set to different values for each element.
         '''
         super(IndicatorBox, self).__init__()
         
-        self.pixelwise_lower = False
-        self.pixelwise_upper = False
-
         # We set lower and upper to either a float or a numpy array        
         self.lower = lower
         self.upper = upper
         if isinstance(lower, (np.ndarray, DataContainer, AcquisitionData, ImageData)):
-            self.pixelwise_lower = True
             if not isinstance(lower, np.ndarray):
                 self.lower = lower.as_array()
         if isinstance(upper, (np.ndarray, DataContainer, AcquisitionData, ImageData)):
-            self.pixelwise_lower = True
             if not isinstance(upper, np.ndarray):
                 self.upper = upper.as_array()
 


### PR DESCRIPTION
## Describe your changes

Extends `IndicatorBox` to behave as [`IndicatorBoxPixelwise`](https://github.com/TomographicImaging/CIL-HTC2022-Algo3/blob/dc735fc0c87ae9243e099c2833245d5906dc50c6/algo.py#L26-L60) by passing masks in lower and upper bounds.

Notice that this requires changing `pixelwise_binary` in `DataContainer` which was not required in the `IndicatorBoxPixelwise` since it did not work with both numbers and arrays.

A slight memory optimisation has been made.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*

Added unittests for both `__call__` and `proximal` methods, for a mixture of cases where the user passes either or both `upper` and `lower` as number and/or `ndarray` or `DataContainer`. 

It passes old `IndicatorBox` unittests.

## Link relevant issues

closes #1396 
## Checklist when you are ready to request a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [ ] I confirm that the contribution does not violate any intellectual property rights of third parties
