### PR TITLE
Changes github actions to run on python 3.9, numpy 1.22. Drops Python 3.6 and NumPy 1.15 support

### DIFF
--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: paskino/conda-package-publish-action@v2.0.0
       with:
         subDir: 'recipe'
-        channels: '-c conda-forge -c intel -c astra-toolbox/label/dev -c cvxgrp -c ccpi  --override-channels'
+        channels: '-c conda-forge -c intel -c astra-toolbox -c cvxgrp -c ccpi'
         convert_win: false
         convert_osx: false
         test_pyver: 3.9

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -24,6 +24,8 @@ jobs:
         channels: '-c conda-forge -c intel -c astra-toolbox/label/dev -c cvxgrp -c ccpi  --override-channels'
         convert_win: false
         convert_osx: false
+        test_pyver: 3.9
+        test_npver: 1.22
     - name: Upload artifact of the conda package.
       uses: actions/upload-artifact@v3.1.1
       with:

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: paskino/conda-package-publish-action@v1.4.4
       with:
         subDir: 'recipe'
-        channels: '-c conda-forge -c intel -c astra-toolbox -c cvxgrp -c ccpi'
+        channels: '-c conda-forge -c intel -c astra-toolbox -c ccpi'
         convert_win: false
         convert_osx: false
         test_pyver: 3.9

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -56,7 +56,7 @@ jobs:
         ARTIFACT_NAME: 'DocumentationHTML'
         PACKAGE_FOLDER_PATH: 'conda_package'
         PACKAGE_NAME: 'cil'
-        PACKAGE_CONDA_CHANNELS: 'conda-forge -c intel -c astra-toolbox -c cvxgrp -c ccpi'
+        PACKAGE_CONDA_CHANNELS: 'conda-forge -c intel -c astra-toolbox -c ccpi'
         BUILD_SUBDIR_NAME: 'nightly'
         python_version: 3.9
   docs_publish:

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -49,15 +49,16 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: 3.7
-    - uses: lauramurgatroyd/build-sphinx-action@v0.1.3
+    - uses: lauramurgatroyd/build-sphinx-action@v0.1.4
       with:
         DOCS_PATH: 'docs'
         CONDA_BUILD_ENV_FILEPATH: 'docs/docs_environment.yml'
         ARTIFACT_NAME: 'DocumentationHTML'
         PACKAGE_FOLDER_PATH: 'conda_package'
         PACKAGE_NAME: 'cil'
-        PACKAGE_CONDA_CHANNELS: 'conda-forge -c intel -c astra-toolbox/label/dev -c cvxgrp -c ccpi'
+        PACKAGE_CONDA_CHANNELS: 'conda-forge -c intel -c astra-toolbox -c cvxgrp -c ccpi'
         BUILD_SUBDIR_NAME: 'nightly'
+        python_version: 3.9
   docs_publish:
     needs: docs_build
     runs-on: ubuntu-latest

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: conda-build
-      uses: paskino/conda-package-publish-action@v2.0.0
+      uses: paskino/conda-package-publish-action@v1.4.4
       with:
         subDir: 'recipe'
         channels: '-c conda-forge -c intel -c astra-toolbox -c cvxgrp -c ccpi'

--- a/.github/workflows/conda_and_docs_build.yml
+++ b/.github/workflows/conda_and_docs_build.yml
@@ -48,7 +48,7 @@ jobs:
         path: 'conda_package'
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
     - uses: lauramurgatroyd/build-sphinx-action@v0.1.4
       with:
         DOCS_PATH: 'docs'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
     - Returned geometry is correctly offset where binning/cropping moves the origin
   - Github Actions:
     - update test python and numpy versions to 3.9 and 1.22
-    - Update conda build action to v2.0.0
     - Fixes actions to run on ubuntu-20.04
     - Update version of upload_artifact github action to version 3.1.1
     - Update version of download_artifact github action to version 3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 * Next
   
+  - Dropped support for Python 3.6 and NumPy 1.15
+  - Jenkins PR tests on Python 3.8 and NumPy 1.20
   - added yml file to create test environment
   - LeastSquares fixed docstring and unified gradient code when out is passed or not.
   - Add compression to 8bit and 16bit to TIFFWriter
@@ -11,6 +13,7 @@
     - Significant speed increase available via the C++ backend
     - Returned geometry is correctly offset where binning/cropping moves the origin
   - Github Actions:
+    - update test python and numpy versions to 3.9 and 1.22
     - Update conda build action to v2.0.0
     - Fixes actions to run on ubuntu-20.04
     - Update version of upload_artifact github action to version 3.1.1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,5 @@
 #creates pairs of versions using zip_keys, lists must be the same length
 python:
-  - 3.6 # [ linux ]
   - 3.8
   - 3.8
   - 3.8
@@ -10,7 +9,6 @@ python:
   - 3.10 
   - 3.10
 numpy:
-  - 1.15 # [ linux ]
   - 1.20
   - 1.21
   - 1.22


### PR DESCRIPTION
## Describe your changes

Update sphinx action. Use the parameter python version.

Set new defaults of Python/NumPy to 3.9 and 1.22. 

Drops support for Python 3.6 and NumPy 1.15

Reverts conda-package-publish-action to v1.4.4

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues


## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
