### PR TITLE
Fix bug in NikonReader when ROI is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 23.0.1
+  - Fix bug with NikonReader requiring ROI to be set in constructor.
+
 * 23.0.0
   - Partitioner is now able to create batches even if angle is not the outer dimension
   - Renamed `max_iteration_stop_cryterion` method in the Algorithm class to `max_iteration_stop_criterion`

--- a/Wrappers/Python/cil/io/NikonDataReader.py
+++ b/Wrappers/Python/cil/io/NikonDataReader.py
@@ -102,11 +102,11 @@ class NikonDataReader(object):
         self.fliplr = fliplr
         
         if self.file_name is None:
-            raise Exception('Path to xtekct file is required.')
+            raise ValueError('Path to xtekct file is required.')
         
         # check if xtekct file exists
         if not(os.path.isfile(self.file_name)):
-            raise Exception('File\n {}\n does not exist.'.format(self.file_name))
+            raise FileNotFoundError('File\n {}\n does not exist.'.format(self.file_name))
         
         if os.path.basename(self.file_name).split('.')[-1].lower() != 'xtekct':
             raise TypeError('This reader can only process xtekct files. Got {}'.format(os.path.basename(self.file_name)))
@@ -117,7 +117,7 @@ class NikonDataReader(object):
         # check labels     
         for key in self.roi.keys():
             if key not in ['angle', 'horizontal', 'vertical']:
-                raise Exception("Wrong label. One of the following is expected: angle, horizontal, vertical")            
+                raise ValueError("Wrong label. One of the following is expected: angle, horizontal, vertical")            
         
         roi = self.roi.copy()
         

--- a/Wrappers/Python/test/test_io.py
+++ b/Wrappers/Python/test/test_io.py
@@ -24,7 +24,7 @@ from cil.framework import AcquisitionGeometry
 import numpy as np
 import os
 from cil.framework import ImageGeometry
-from cil.io import TXRMDataReader, NEXUSDataReader
+from cil.io import TXRMDataReader, NEXUSDataReader, NikonDataReader, ZEISSDataReader
 from cil.io import TIFFWriter, TIFFStackReader
 from cil.io.utilities import HDF5_utilities
 from cil.processors import Slicer
@@ -522,3 +522,37 @@ class Test_HDF5_utilities(unittest.TestCase):
 
         HDF5_utilities.read_to(self.path, self.dset_path, data_partial, source_sel=subset, dest_sel=subset)
         np.testing.assert_allclose(data_partial_by_hand,data_partial)
+
+
+class TestNikonReader(unittest.TestCase):
+
+    def test_setup(self):
+
+        reader = NikonDataReader()
+        self.assertEqual(reader.file_name, None)
+        self.assertEqual(reader.roi, None)
+        self.assertTrue(reader.normalise)
+        self.assertEqual(reader.mode, 'bin')
+        self.assertFalse(reader.fliplr)
+
+        roi = {'vertical':(1,-1),'horizontal':(1,-1),'angle':(1,-1)}
+        reader = NikonDataReader(file_name=None, roi=roi, normalise=False, mode='slice', fliplr=True)
+        self.assertEqual(reader.file_name, None)
+        self.assertEqual(reader.roi, roi)
+        self.assertFalse(reader.normalise)
+        self.assertEqual(reader.mode, 'slice')
+        self.assertTrue(reader.fliplr)
+
+        with self.assertRaises(FileNotFoundError):
+            reader = NikonDataReader(file_name='no-file')
+        
+
+class TestZeissReader(unittest.TestCase):
+
+    def test_setup(self):
+
+        reader = ZEISSDataReader()
+        self.assertEqual(reader.file_name, None)
+
+        with self.assertRaises(FileNotFoundError):
+            reader = ZEISSDataReader(file_name='no-file')


### PR DESCRIPTION
## Describe your changes
Added check for if ROI is None, which sets ROI appropriately.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*

Tested locally reading a Nikon dataset, with and without an ROI set.

## Link relevant issues
Closes #1456 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
