### PR TITLE
Padder, Slicer, Binner to respect panel origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   - Refactor SIRT algorithm to make it more computationally and memory efficient
   - Optimisation in L2NormSquared
   - Fix for show_geometry bug for 2D data
-  - FBP split processing bug fix - now respects panel origin
+  - FBP split processing bug fix - now respects panel origin set in geometry
+  - Binner/Padder/Slicer bug fix - now respects panel origin set in geometry
 
 * 23.0.1
   - Fix bug with NikonReader requiring ROI to be set in constructor.

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2000,12 +2000,12 @@ class Configuration(object):
         Notes:
         ------
         - If `direction` is 'horizontal':
-            - If the panel's origin is 'left', the detector's position is moved to the left.
-            - If the panel's origin is 'right', the detector's position is moved to the right.
+            - If the panel's origin is 'left', positive offsets translate the detector to the right.
+            - If the panel's origin is 'right', positive offsets translate the detector to the left.
 
         - If `direction` is 'vertical':
-            - If the panel's origin is 'bottom', the detector's position is moved downward.
-            - If the panel's origin is 'top', the detector's position is moved upward.
+            - If the panel's origin is 'bottom', positive offsets translate the detector upward.
+            - If the panel's origin is 'top', positive offsets translate the detector downward.
 
         Returns:
         --------

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -519,7 +519,7 @@ class ComponentDescription(object):
     @staticmethod  
     def create_vector(val):
         try:
-            vec = numpy.asarray(val, dtype=numpy.float64).reshape(len(val))
+            vec = numpy.array(val, dtype=numpy.float64).reshape(len(val))
         except:
             raise ValueError("Can't convert to numpy array")
    
@@ -1981,6 +1981,48 @@ class Configuration(object):
             print("Please configure the panel using the set_panel() method")
             configured = False
         return configured
+
+    def shift_detector_in_plane(self,
+                                          pixel_offset,
+                                          direction='horizontal'):
+        """
+        Adjusts the position of the detector in a specified direction within the imaging plane.
+
+        Parameters:
+        -----------
+        pixel_offset : float
+            The number of pixels to adjust the detector's position by.
+        direction : {'horizontal', 'vertical'}, optional
+            The direction in which to adjust the detector's position. Defaults to 'horizontal'.
+
+        Notes:
+        ------
+        - If `direction` is 'horizontal':
+            - If the panel's origin is 'left', the detector's position is moved to the left.
+            - If the panel's origin is 'right', the detector's position is moved to the right.
+
+        - If `direction` is 'vertical':
+            - If the panel's origin is 'bottom', the detector's position is moved downward.
+            - If the panel's origin is 'top', the detector's position is moved upward.
+
+        Returns:
+        --------
+        None
+        """
+
+        if direction == 'horizontal':
+            pixel_size = self.panel.pixel_size[0]
+            pixel_direction = self.system.detector.direction_x
+
+        elif direction == 'vertical':
+            pixel_size = self.panel.pixel_size[1]
+            pixel_direction = self.system.detector.direction_y
+
+        if 'bottom' in self.panel.origin or 'left' in self.panel.origin:
+            self.system.detector.position -= pixel_offset * pixel_direction * pixel_size
+        else:
+            self.system.detector.position += pixel_offset * pixel_direction * pixel_size
+
 
     def __str__(self):
         repres = ""

--- a/Wrappers/Python/cil/processors/Padder.py
+++ b/Wrappers/Python/cil/processors/Padder.py
@@ -555,7 +555,6 @@ class Padder(DataProcessor):
                 continue
 
             offset = (self._pad_width_param[i][0] -self._pad_width_param[i][1])*0.5
-            system_detector = geometry.config.system.detector
 
             if dim == 'channel':
                 geometry.set_channels(num_channels= geometry.config.channels.num_channels + \
@@ -563,7 +562,6 @@ class Padder(DataProcessor):
             elif dim == 'angle':
                 # extrapolate pre-values from a[1]-a[0]
                 # extrapolate post-values from a[-1]-a[-2]
-
                 a = self._geometry.angles
                 end_values = (
                     a[0]-(a[1]-a[0] )* self._pad_width_param[i][0],
@@ -574,19 +572,13 @@ class Padder(DataProcessor):
             elif dim == 'vertical':
                 geometry.config.panel.num_pixels[1] += self._pad_width_param[i][0] 
                 geometry.config.panel.num_pixels[1] += self._pad_width_param[i][1]
-
-                if 'bottom' in geometry.config.panel.origin:
-                    system_detector.position = system_detector.position - offset * system_detector.direction_y * geometry.config.panel.pixel_size[1]
-                else:
-                    system_detector.position = system_detector.position + offset * system_detector.direction_y * geometry.config.panel.pixel_size[1]
+                geometry.config.shift_detector_in_plane(offset, dim)
                     
             elif dim == 'horizontal':
                 geometry.config.panel.num_pixels[0] += self._pad_width_param[i][0]
                 geometry.config.panel.num_pixels[0] += self._pad_width_param[i][1]
-                if 'left' in geometry.config.panel.origin:
-                    system_detector.position = system_detector.position - offset * system_detector.direction_x * geometry.config.panel.pixel_size[0]
-                else:
-                    system_detector.position = system_detector.position + offset * system_detector.direction_x * geometry.config.panel.pixel_size[0]
+                geometry.config.shift_detector_in_plane(offset, dim)
+
         return geometry
 
     def _process_image_geometry(self):

--- a/Wrappers/Python/cil/processors/Padder.py
+++ b/Wrappers/Python/cil/processors/Padder.py
@@ -574,12 +574,19 @@ class Padder(DataProcessor):
             elif dim == 'vertical':
                 geometry.config.panel.num_pixels[1] += self._pad_width_param[i][0] 
                 geometry.config.panel.num_pixels[1] += self._pad_width_param[i][1]
-                system_detector.position = system_detector.position - offset * system_detector.direction_y * geometry.config.panel.pixel_size[1]
+
+                if 'bottom' in geometry.config.panel.origin:
+                    system_detector.position = system_detector.position - offset * system_detector.direction_y * geometry.config.panel.pixel_size[1]
+                else:
+                    system_detector.position = system_detector.position + offset * system_detector.direction_y * geometry.config.panel.pixel_size[1]
+                    
             elif dim == 'horizontal':
                 geometry.config.panel.num_pixels[0] += self._pad_width_param[i][0]
                 geometry.config.panel.num_pixels[0] += self._pad_width_param[i][1]
-                system_detector.position = system_detector.position - offset * system_detector.direction_x * geometry.config.panel.pixel_size[0]
-        
+                if 'left' in geometry.config.panel.origin:
+                    system_detector.position = system_detector.position - offset * system_detector.direction_x * geometry.config.panel.pixel_size[0]
+                else:
+                    system_detector.position = system_detector.position + offset * system_detector.direction_x * geometry.config.panel.pixel_size[0]
         return geometry
 
     def _process_image_geometry(self):

--- a/Wrappers/Python/cil/processors/Slicer.py
+++ b/Wrappers/Python/cil/processors/Slicer.py
@@ -283,7 +283,11 @@ class Slicer(DataProcessor):
                 if n_elements > 1:
                     # difference in end indices, minus differences in start indices, divided by 2
                     pixel_offset = ((self._shape_in[vert_ind] -1 - self._pixel_indices[vert_ind][1]) - self._pixel_indices[vert_ind][0])*0.5
-                    system_detector.position = system_detector.position - pixel_offset * system_detector.direction_y * geometry_new.config.panel.pixel_size[1]
+                    if 'bottom' in geometry_new.config.panel.origin:
+                        system_detector.position = system_detector.position - pixel_offset * system_detector.direction_y * geometry_new.config.panel.pixel_size[1]
+                    else:
+                        system_detector.position = system_detector.position + pixel_offset * system_detector.direction_y * geometry_new.config.panel.pixel_size[1]
+                        
                     geometry_new.config.panel.num_pixels[1] = n_elements
                 else:
                     try:
@@ -314,7 +318,11 @@ class Slicer(DataProcessor):
 
             elif axis == 'horizontal':
                 pixel_offset = ((self._shape_in[i] -1 - self._pixel_indices[i][1]) - self._pixel_indices[i][0])*0.5
-                system_detector.position = system_detector.position - pixel_offset * system_detector.direction_x * geometry_new.config.panel.pixel_size[0]
+
+                if 'left' in geometry_new.config.panel.origin:
+                    system_detector.position = system_detector.position - pixel_offset * system_detector.direction_x * geometry_new.config.panel.pixel_size[0]
+                else:
+                    system_detector.position = system_detector.position + pixel_offset * system_detector.direction_x * geometry_new.config.panel.pixel_size[0]
                 geometry_new.config.panel.num_pixels[0] = n_elements
                 geometry_new.config.panel.pixel_size[0] *= roi.step
 

--- a/Wrappers/Python/cil/processors/Slicer.py
+++ b/Wrappers/Python/cil/processors/Slicer.py
@@ -269,7 +269,6 @@ class Slicer(DataProcessor):
         Creates the new acquisition geometry
         """
         geometry_new = self._geometry.copy()
-        system_detector = geometry_new.config.system.detector
 
         processed_dims = self._processed_dims.copy()
 
@@ -283,11 +282,7 @@ class Slicer(DataProcessor):
                 if n_elements > 1:
                     # difference in end indices, minus differences in start indices, divided by 2
                     pixel_offset = ((self._shape_in[vert_ind] -1 - self._pixel_indices[vert_ind][1]) - self._pixel_indices[vert_ind][0])*0.5
-                    if 'bottom' in geometry_new.config.panel.origin:
-                        system_detector.position = system_detector.position - pixel_offset * system_detector.direction_y * geometry_new.config.panel.pixel_size[1]
-                    else:
-                        system_detector.position = system_detector.position + pixel_offset * system_detector.direction_y * geometry_new.config.panel.pixel_size[1]
-                        
+                    geometry_new.config.shift_detector_in_plane(pixel_offset, 'vertical')
                     geometry_new.config.panel.num_pixels[1] = n_elements
                 else:
                     try:
@@ -319,10 +314,7 @@ class Slicer(DataProcessor):
             elif axis == 'horizontal':
                 pixel_offset = ((self._shape_in[i] -1 - self._pixel_indices[i][1]) - self._pixel_indices[i][0])*0.5
 
-                if 'left' in geometry_new.config.panel.origin:
-                    system_detector.position = system_detector.position - pixel_offset * system_detector.direction_x * geometry_new.config.panel.pixel_size[0]
-                else:
-                    system_detector.position = system_detector.position + pixel_offset * system_detector.direction_x * geometry_new.config.panel.pixel_size[0]
+                geometry_new.config.shift_detector_in_plane(pixel_offset, axis)
                 geometry_new.config.panel.num_pixels[0] = n_elements
                 geometry_new.config.panel.pixel_size[0] *= roi.step
 

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -157,6 +157,84 @@ class Test_AcquisitionGeometry(unittest.TestCase):
         np.testing.assert_allclose(AG.config.system.rotation_axis.position, rotation_axis_position, rtol=1E-6)
         np.testing.assert_allclose(AG.config.system.rotation_axis.direction, rotation_axis_direction, rtol=1E-6)
 
+
+    def test_shift_detector_origin_bottom_left(self):
+        initial_position = np.array([2.5, -1.3, 10.2])
+        pixel_size = np.array([0.5, 0.7])
+        detector_direction_x=np.array([1/math.sqrt(2),0,1/math.sqrt(2)])
+        detector_direction_y=np.array([-1/math.sqrt(2),0,1/math.sqrt(2)])
+
+        geometry = AcquisitionGeometry.create_Parallel3D(detector_position=initial_position, detector_direction_x=detector_direction_x, detector_direction_y=detector_direction_y)\
+                                      .set_panel([10, 5], [0.5, 0.7], origin='bottom-left')\
+                                      .set_angles([0])
+        # Test horizontal shift to the left
+        shift = -1.5
+        geometry.config.shift_detector_in_plane(shift, 'horizontal')
+        updated_position = geometry.config.system.detector.position
+        expected_position = initial_position - detector_direction_x * pixel_size[0] * shift
+        np.testing.assert_array_almost_equal(updated_position, expected_position)
+
+        # Test horizontal shift to the right
+        shift = 3.0
+        geometry.config.shift_detector_in_plane(shift, 'horizontal')
+        updated_position = geometry.config.system.detector.position
+        expected_position = expected_position - detector_direction_x * pixel_size[0] * shift
+        np.testing.assert_array_almost_equal(updated_position, expected_position)
+
+        # Test vertical shift down
+        shift = -1.5
+        geometry.config.shift_detector_in_plane(shift, 'vertical')
+        updated_position = geometry.config.system.detector.position
+        expected_position = expected_position - detector_direction_y * pixel_size[1] * shift
+        np.testing.assert_array_almost_equal(updated_position, expected_position)
+
+        # Test vertical shift up
+        shift = 3.0
+        geometry.config.shift_detector_in_plane(shift, 'vertical')
+        updated_position = geometry.config.system.detector.position
+        expected_position = expected_position - detector_direction_y * pixel_size[1] * shift
+        np.testing.assert_array_almost_equal(updated_position, expected_position)
+
+
+    def test_shift_detector_origin_top_right(self):
+        initial_position = np.array([2.5, -1.3, 10.2])
+        detector_direction_x=np.array([1/math.sqrt(2),0,1/math.sqrt(2)])
+        detector_direction_y=np.array([-1/math.sqrt(2),0,1/math.sqrt(2)])
+
+        pixel_size = np.array([0.5, 0.7])
+        geometry = AcquisitionGeometry.create_Parallel3D(detector_position=initial_position, detector_direction_x=detector_direction_x, detector_direction_y=detector_direction_y)\
+                                      .set_panel([10, 5], [0.5, 0.7], origin='top-right')\
+                                      .set_angles([0])
+
+        # Test horizontal shift to the right
+        shift = -1.5
+        geometry.config.shift_detector_in_plane(shift, 'horizontal')
+        updated_position = geometry.config.system.detector.position
+        expected_position = initial_position + detector_direction_x * pixel_size[0] * shift
+        np.testing.assert_array_almost_equal(updated_position, expected_position)
+
+        # Test horizontal shift to the left
+        shift = 3.0
+        geometry.config.shift_detector_in_plane(shift, 'horizontal')
+        updated_position = geometry.config.system.detector.position
+        expected_position = expected_position + detector_direction_x * pixel_size[0] * shift
+        np.testing.assert_array_almost_equal(updated_position, expected_position)
+
+        # Test vertical shift up
+        shift = -1.5
+        geometry.config.shift_detector_in_plane(shift, 'vertical')
+        updated_position = geometry.config.system.detector.position
+        expected_position = expected_position + detector_direction_y * pixel_size[1] * shift
+        np.testing.assert_array_almost_equal(updated_position, expected_position)
+
+        # Test vertical shift down
+        shift = 3.0
+        geometry.config.shift_detector_in_plane(shift, 'vertical')
+        updated_position = geometry.config.system.detector.position
+        expected_position = expected_position +  detector_direction_y * pixel_size[1] * shift
+        np.testing.assert_array_almost_equal(updated_position, expected_position)
+
+
     def test_SystemConfiguration(self):
         
         #SystemConfiguration error handeling


### PR DESCRIPTION
## Describe your changes
Padder, Slicer, Binner bug fix to respect panel origin.

Previously the geometry was being returned incorrectly for the non-default origin option. 
If Padder, Slicer or Binner result in an asymmetric change to the number of pixels from the centre of the detector then the acquisition geometry is not updated correctly. The offset to detector position is updated as if the panel origin was 'bottom-left' (the default).

In the case where the origin is not the default we expect the data to be manipulated in the same way, however the geometry detector position will be offset in the opposite direction.

I've updated the offset calculations for the acquisition geometry for the case where the panel origin is not 'bottom-left' (default).

I've added extensive tests to cover these cases.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
Added all relevant unit tests. Testing geometry is returned correctly if the origin is not the default and that the out put of the processor applied to the data meets expectations.

This is all added for padder, slicer and binner.

## Link relevant issues
closes #1508

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
