### PR TITLE
add symmetric flag to PowerMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Fix for show_geometry bug for 2D data
   - Added warmstart capability to proximal evaluation of the CIL TotalVariation function.
   - FBP split processing bug fix - now respects panel origin
-
+  - Bug fix in the LinearOperator norm with an additional flag for the algorithm linearOperator.PowerMethod
 
 * 23.0.1
   - Fix bug with NikonReader requiring ROI to be set in constructor.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ The documentation for CIL can be accessed [here](https://tomographicimaging.gith
 Binary installation of CIL can be done with `conda`. Install a new environment using:
 
 ```bash
-conda create --name cil -c conda-forge -c intel -c ccpi cil=23.0.0
+conda create --name cil -c conda-forge -c intel -c ccpi cil=23.0.1
 ```
 
 To install CIL and the additional packages and plugins needed to run the [CIL demos](https://github.com/TomographicImaging/CIL-Demos) install the environment with:
 
 ```bash
-conda create --name cil -c conda-forge -c intel -c astra-toolbox -c ccpi cil=23.0.0 astra-toolbox tigre ccpi-regulariser tomophantom "ipywidgets<8"
+conda create --name cil -c conda-forge -c intel -c ccpi cil=23.0.1 astra-toolbox tigre ccpi-regulariser tomophantom "ipywidgets<8"
 ```
 where,
 

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -20,7 +20,7 @@
 from numbers import Number
 import numpy
 import functools
-import warnings
+import logging
 
 
 class Operator(object):
@@ -61,7 +61,7 @@ class Operator(object):
         '''
 
         if len(kwargs) != 0:
-            warnings.warn('norm: the norm method does not use any parameters.\n\
+            logging.warning('norm: the norm method does not use any parameters.\n\
                 For LinearOperators you can use PowerMethod to calculate the norm with non-default parameters and use set_norm to set it')
 
         if self._norm is None:
@@ -273,7 +273,7 @@ class LinearOperator(Operator):
             # Get eigenvalue using Rayleigh quotient: denominator=1, due to normalization
             x0_norm = x0.norm()
             if x0_norm < tolerance:
-                Warning(
+                logging.warning(
                     'The operator has at least one zero eigenvector and is likely to be nilpotent')
                 eig_new = 0.
                 break

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -225,11 +225,9 @@ class LinearOperator(Operator):
         diff = numpy.finfo('d').max
         i = 0
         while (i < max_iteration and diff > tolerance):
-            i+=1
             
             operator.direct(x0, out = y_tmp)
-
-            
+           
             if square:                
                 #swap datacontainer references
                 tmp = x0

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -141,13 +141,16 @@ class LinearOperator(Operator):
         raise NotImplementedError
     
     @staticmethod
-    def PowerMethod(operator, max_iteration=10, initial=None, tolerance = 1e-5,  return_all=False):
+    def PowerMethod(operator, max_iteration=10, initial=None, tolerance=1e-5,  return_all=False, symmetric=False):
 
         r"""Power method or Power iteration algorithm 
         
         The Power method computes the largest (dominant) eigenvalue of a square matrix in magnitude, e.g.,
         absolute value in the real case and module in the complex case.        
-        For the non-square case, the power method is applied for the matrix :math: A^{T}*A.
+        Since we cannot estimate if the operator is diagonisable, the power method is applied on the diagonizable operator
+        :math:`A^{T}*A`.
+        
+        If the operator :math:`A` is diagonizable, the user can pass the flag `symmetric=True`.
 
         Parameters
         ----------
@@ -161,6 +164,8 @@ class LinearOperator(Operator):
             Stopping criterion for the Power method. Check if two consecutive eigenvalue evaluations are below the tolerance.                    
         return_all: boolean, default = False
             Toggles the verbosity of the return
+        symmetric: boolean, default False
+             Set this to True if the operator is symmetric
     
 
         Returns
@@ -188,16 +193,6 @@ class LinearOperator(Operator):
         2.0005647295658866
 
         """
-
-        # Default case: non-symmetric
-        symmetric = False
-        try:
-            if operator.domain_geometry()==operator.range_geometry():
-                symmetric = True
-        except AssertionError:
-            # catch AssertionError for SIRF objects https://github.com/SyneRBI/SIRF-SuperBuild/runs/5110228626?check_suite_focus=true#step:8:972
-            pass
-
         if initial is None:
             x0 = operator.domain_geometry().allocate('random')
         else:

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -22,6 +22,7 @@ import numpy
 import functools
 import warnings
 
+
 class Operator(object):
     """
     Operator that maps from a space X -> Y
@@ -45,10 +46,10 @@ class Operator(object):
     def is_linear(self):
         '''Returns if the operator is linear'''
         return False
-    def direct(self,x, out=None):
+
+    def direct(self, x, out=None):
         '''Returns the application of the Operator on x'''
         raise NotImplementedError
-
 
     def norm(self, **kwargs):
         '''Returns the norm of the Operator. On first call the norm will be calculated using the operator's calculate_norm
@@ -68,7 +69,7 @@ class Operator(object):
 
         return self._norm
 
-    def set_norm(self,norm=None):
+    def set_norm(self, norm=None):
         '''Sets the norm of the operator to a custom value.
         '''
         self._norm = norm
@@ -76,44 +77,49 @@ class Operator(object):
     def calculate_norm(self):
         '''Calculates the norm of the Operator'''
         raise NotImplementedError
+
     def range_geometry(self):
         '''Returns the range of the Operator: Y space'''
         return self._range_geometry
+
     def domain_geometry(self):
         '''Returns the domain of the Operator: X space'''
         return self._domain_geometry
+
     @property
     def domain(self):
         return self.domain_geometry()
+
     @property
     def range(self):
         return self.range_geometry()
+
     def __rmul__(self, scalar):
         '''Defines the multiplication by a scalar on the left
 
         returns a ScaledOperator'''
         return ScaledOperator(self, scalar)
-    
+
     def compose(self, *other, **kwargs):
-        # TODO: check equality of domain and range of operators        
-        #if self.operator2.range_geometry != self.operator1.domain_geometry:
-        #    raise ValueError('Cannot compose operators, check domain geometry of {} and range geometry of {}'.format(self.operato1,self.operator2))    
-        
-        return CompositionOperator(self, *other, **kwargs) 
+        # TODO: check equality of domain and range of operators
+        # if self.operator2.range_geometry != self.operator1.domain_geometry:
+        #    raise ValueError('Cannot compose operators, check domain geometry of {} and range geometry of {}'.format(self.operato1,self.operator2))
+
+        return CompositionOperator(self, *other, **kwargs)
 
     def __add__(self, other):
         return SumOperator(self, other)
 
     def __mul__(self, scalar):
-        return self.__rmul__(scalar)    
-    
+        return self.__rmul__(scalar)
+
     def __neg__(self):
         """ Return -self """
-        return -1 * self    
-        
+        return -1 * self
+
     def __sub__(self, other):
         """ Returns the subtraction of the operators."""
-        return self + (-1) * other   
+        return self + (-1) * other
 
 
 class LinearOperator(Operator):
@@ -129,28 +135,30 @@ class LinearOperator(Operator):
     range_geometry : ImageGeometry or AcquisitionGeometry, optional, default None
         range of the operator 
     """
+
     def __init__(self, domain_geometry, **kwargs):
         super(LinearOperator, self).__init__(domain_geometry, **kwargs)
+
     def is_linear(self):
         '''Returns if the operator is linear'''
         return True
-    def adjoint(self,x, out=None):
+
+    def adjoint(self, x, out=None):
         '''returns the adjoint/inverse operation
-        
+
         only available to linear operators'''
         raise NotImplementedError
-    
-    @staticmethod
-    def PowerMethod(operator, max_iteration=10, initial=None, tolerance=1e-5,  return_all=False,range_is_domain=None ):
 
+    @staticmethod
+    def PowerMethod(operator, max_iteration=10, initial=None, tolerance=1e-5,  return_all=False, range_is_domain=None):
         r"""Power method or Power iteration algorithm 
-        
+
         The Power method computes the largest (dominant) eigenvalue of a square matrix in magnitude, e.g.,
         absolute value in the real case and modulus in the complex case.        
 
         If the matrix is not square. The algorithm computes the largest (dominant) eigenvalue of :math:  A^{T}*A :math:, returning the square root of this value. 
-        
-        
+
+
         Parameters
         ----------
 
@@ -161,12 +169,12 @@ class LinearOperator(Operator):
             Starting point for the Power method.
         tolerance: positive:`float`, default = 1e-5
             Stopping criterion for the Power method. Check if two consecutive eigenvalue evaluations are below the tolerance.                    
-        return_all: boolean, default = False
+        return_all: `boolean`, default = False
             Toggles the verbosity of the return
         range_is_domain: `boolean`, default None
              Set this to `True` to apply the power method directly on the operator, :math: A :math:, and `False` to apply the power method to :math:A^TA:math: before taking the square root of the result.
              Leave as default `None` to determine this from domain and range geometry.  
-    
+
 
         Returns
         -------
@@ -195,18 +203,18 @@ class LinearOperator(Operator):
         2.0005647295658866
 
         """
-        convergence_check=True
+        convergence_check = True
         if range_is_domain is None:
             square = False
             try:
-                if operator.domain_geometry()==operator.range_geometry():
+                if operator.domain_geometry() == operator.range_geometry():
                     square = True
             except AssertionError:
                 # catch AssertionError for SIRF objects https://github.com/SyneRBI/SIRF-SuperBuild/runs/5110228626?check_suite_focus=true#step:8:972
                 pass
         else:
-            square=range_is_domain
-            
+            square = range_is_domain
+
         if initial is None:
             x0 = operator.domain_geometry().allocate('random')
         else:
@@ -225,60 +233,52 @@ class LinearOperator(Operator):
         diff = numpy.finfo('d').max
         i = 0
         while (i < max_iteration and diff > tolerance):
-            
-            operator.direct(x0, out = y_tmp)
-           
-            if square:                
-                #swap datacontainer references
+            operator.direct(x0, out=y_tmp)
+
+            if square:
+                # swap datacontainer references
                 tmp = x0
                 x0 = y_tmp
                 y_tmp = tmp
             else:
-                operator.adjoint(y_tmp,out=x0)
-            
-           
+                operator.adjoint(y_tmp, out=x0)
+
             # Get eigenvalue using Rayleigh quotient: denominator=1, due to normalization
-            x0_norm=x0.norm()
-            if x0_norm<tolerance:
-                Warning('The operator has at least one zero eigenvector and is likely to be nilpotent')
-                eig_new=0
+            x0_norm = x0.norm()
+            if x0_norm < tolerance:
+                Warning(
+                    'The operator has at least one zero eigenvector and is likely to be nilpotent')
+                eig_new = 0.
                 break
             x0 /= x0_norm
 
-            eig_new =  numpy.abs(x0_norm)
+            eig_new = numpy.abs(x0_norm)
             if not square:
                 eig_new = numpy.sqrt(eig_new)
             diff = numpy.abs(eig_new - eig_old)
-            eig_list.append(eig_new)   
+            eig_list.append(eig_new)
             eig_old = eig_new
-            i+=1
+            i += 1
 
-        if i==max_iteration:
-               convergence_check=False
-        
+        if i == max_iteration:
+            convergence_check = False
+
         if return_all:
             return eig_new, i, x0, eig_list, convergence_check
         else:
             return eig_new
-            
 
     def calculate_norm(self):
-        
         r""" Returns the norm of the LinearOperator calculated by the PowerMethod with default values.
                 """
         return LinearOperator.PowerMethod(self)
 
-
     @staticmethod
     def dot_test(operator, domain_init=None, range_init=None, tolerance=1e-6, **kwargs):
         r'''Does a dot linearity test on the operator
-        
         Evaluates if the following equivalence holds
-        
         .. math::
-        
           Ax\times y = y \times A^Tx
-        
         :param operator: operator to test the dot_test
         :param range_init: optional initialisation container in the operator range 
         :param domain_init: optional initialisation container in the operator domain 
@@ -286,53 +286,52 @@ class LinearOperator(Operator):
         :type : int, default = 1
         :param tolerance: Check if the following expression is below the tolerance
         .. math:: 
-        
+
             |Ax\times y - y \times A^Tx|/(\|A\|\|x\|\|y\| + 1e-12) < tolerance
-        
+
         :type : float, default 1e-6
         :returns: boolean, True if the test is passed.       
         '''
 
         seed = kwargs.get('seed', 1)
-    
+
         if range_init is None:
-            y = operator.range_geometry().allocate('random', seed = seed + 10)
+            y = operator.range_geometry().allocate('random', seed=seed + 10)
         else:
             y = range_init
         if domain_init is None:
-            x = operator.domain_geometry().allocate('random', seed = seed)
+            x = operator.domain_geometry().allocate('random', seed=seed)
         else:
             x = domain_init
-        
+
         fx = operator.direct(x)
         by = operator.adjoint(y)
         a = fx.dot(y)
         b = by.dot(x).conjugate()
 
-        # Check relative tolerance but normalised with respect to 
+        # Check relative tolerance but normalised with respect to
         # operator, x and y norms and avoid zero division
-        error = numpy.abs( a - b )/ (operator.norm()*x.norm()*y.norm() + 1e-12)
-            
+        error = numpy.abs(a - b) / (operator.norm()*x.norm()*y.norm() + 1e-12)
+
         if error < tolerance:
             return True
         else:
-            print ('Left hand side  {}, \nRight hand side {}'.format(a, b))
-            return False    
-        
-        
+            print('Left hand side  {}, \nRight hand side {}'.format(a, b))
+            return False
+
+
 class ScaledOperator(Operator):
-    
-    
+
     '''ScaledOperator
 
     A class to represent the scalar multiplication of an Operator with a scalar.
     It holds an operator and a scalar. Basically it returns the multiplication
     of the result of direct and adjoint of the operator with the scalar.
     For the rest it behaves like the operator it holds.
-    
+
     :param operator: a Operator or LinearOperator
     :param scalar: a scalar multiplier
-    
+
     Example:
        The scaled operator behaves like the following:
 
@@ -346,7 +345,7 @@ class ScaledOperator(Operator):
       sop.domain_geometry() = operator.domain_geometry()
 
     '''
-    
+
     def __init__(self, operator, scalar, **kwargs):
         '''creator
 
@@ -354,12 +353,13 @@ class ScaledOperator(Operator):
         :param scalar: a scalar multiplier
         :type scalar: Number'''
 
-        super(ScaledOperator, self).__init__(domain_geometry=operator.domain_geometry(), 
+        super(ScaledOperator, self).__init__(domain_geometry=operator.domain_geometry(),
                                              range_geometry=operator.range_geometry())
-        if not isinstance (scalar, Number):
+        if not isinstance(scalar, Number):
             raise TypeError('expected scalar: got {}'.format(type(scalar)))
         self.scalar = scalar
         self.operator = operator
+
     def direct(self, x, out=None):
         '''direct method'''
         if out is None:
@@ -369,6 +369,7 @@ class ScaledOperator(Operator):
         else:
             self.operator.direct(x, out=out)
             out *= self.scalar
+
     def adjoint(self, x, out=None):
         '''adjoint method'''
         if self.operator.is_linear():
@@ -381,62 +382,62 @@ class ScaledOperator(Operator):
                 out *= self.scalar
         else:
             raise TypeError('Operator is not linear')
+
     def norm(self, **kwargs):
         '''norm of the operator'''
         return numpy.abs(self.scalar) * self.operator.norm(**kwargs)
 
     def is_linear(self):
         '''returns whether the operator is linear
-        
+
         :returns: boolean '''
         return self.operator.is_linear()
 
 
 ###############################################################################
 ################   SumOperator  ###########################################
-###############################################################################      
-    
+###############################################################################
+
 class SumOperator(Operator):
-    
-    
+
     def __init__(self, operator1, operator2):
-                
+
         self.operator1 = operator1
         self.operator2 = operator2
-        
+
         # if self.operator1.domain_geometry() != self.operator2.domain_geometry():
-        #     raise ValueError('Domain geometry of {} is not equal with domain geometry of {}'.format(self.operator1.__class__.__name__,self.operator2.__class__.__name__))    
-                
+        #     raise ValueError('Domain geometry of {} is not equal with domain geometry of {}'.format(self.operator1.__class__.__name__,self.operator2.__class__.__name__))
+
         # if self.operator1.range_geometry() != self.operator2.range_geometry():
-        #     raise ValueError('Range geometry of {} is not equal with range geometry of {}'.format(self.operator1.__class__.__name__,self.operator2.__class__.__name__))    
-            
-        self.linear_flag = self.operator1.is_linear() and self.operator2.is_linear()            
-        
+        #     raise ValueError('Range geometry of {} is not equal with range geometry of {}'.format(self.operator1.__class__.__name__,self.operator2.__class__.__name__))
+
+        self.linear_flag = self.operator1.is_linear() and self.operator2.is_linear()
+
         super(SumOperator, self).__init__(domain_geometry=self.operator1.domain_geometry(),
-                                          range_geometry=self.operator1.range_geometry()) 
-                                  
+                                          range_geometry=self.operator1.range_geometry())
+
     def direct(self, x, out=None):
-        
+
         if out is None:
             return self.operator1.direct(x) + self.operator2.direct(x)
         else:
             self.operator1.direct(x, out=out)
-            out.add(self.operator2.direct(x), out=out)     
+            out.add(self.operator2.direct(x), out=out)
 
     def adjoint(self, x, out=None):
-        
-        if self.linear_flag:        
+
+        if self.linear_flag:
             if out is None:
                 return self.operator1.adjoint(x) + self.operator2.adjoint(x)
             else:
                 self.operator1.adjoint(x, out=out)
-                out.add(self.operator2.adjoint(x), out=out) 
+                out.add(self.operator2.adjoint(x), out=out)
         else:
             raise ValueError('No adjoint operation with non-linear operators')
-                                        
+
     def is_linear(self):
-        return self.linear_flag 
-    
+        return self.linear_flag
+
     def calculate_norm(self):
         if self.is_linear():
             return LinearOperator.calculate_norm(self)
@@ -445,43 +446,46 @@ class SumOperator(Operator):
 
 ###############################################################################
 ################   Composition  ###########################################
-###############################################################################             
+###############################################################################
+
 
 class CompositionOperator(Operator):
-    
+
     def __init__(self, *operators, **kwargs):
-        
+
         # get a reference to the operators
         self.operators = operators
-        
-        self.linear_flag = functools.reduce(lambda x,y: x and y.is_linear(),
+
+        self.linear_flag = functools.reduce(lambda x, y: x and y.is_linear(),
                                             self.operators, True)
         # self.preallocate = kwargs.get('preallocate', False)
         self.preallocate = False
         if self.preallocate:
-            self.tmp_domain = [op.domain_geometry().allocate() for op in self.operators[:-1]]
-            self.tmp_range = [op.range_geometry().allocate() for op in self.operators[1:]]
+            self.tmp_domain = [op.domain_geometry().allocate()
+                               for op in self.operators[:-1]]
+            self.tmp_range = [op.range_geometry().allocate()
+                              for op in self.operators[1:]]
             # pass
-        
+
         # TODO address the equality of geometries
         # if self.operator2.range_geometry() != self.operator1.domain_geometry():
-        #     raise ValueError('Domain geometry of {} is not equal with range geometry of {}'.format(self.operator1.__class__.__name__,self.operator2.__class__.__name__))    
-                
+        #     raise ValueError('Domain geometry of {} is not equal with range geometry of {}'.format(self.operator1.__class__.__name__,self.operator2.__class__.__name__))
+
         super(CompositionOperator, self).__init__(
             domain_geometry=self.operators[-1].domain_geometry(),
-            range_geometry=self.operators[0].range_geometry()) 
-        
-    def direct(self, x, out = None):
+            range_geometry=self.operators[0].range_geometry())
+
+    def direct(self, x, out=None):
 
         if out is None:
-            #return self.operator1.direct(self.operator2.direct(x))
-            # return functools.reduce(lambda X,operator: operator.direct(X), 
+            # return self.operator1.direct(self.operator2.direct(x))
+            # return functools.reduce(lambda X,operator: operator.direct(X),
             #                        self.operators[::-1][1:],
             #                        self.operators[-1].direct(x))
             if self.preallocate:
                 pass
             else:
-                for i,operator in enumerate(self.operators[::-1]):
+                for i, operator in enumerate(self.operators[::-1]):
                     if i == 0:
                         step = operator.direct(x)
                     else:
@@ -492,76 +496,73 @@ class CompositionOperator(Operator):
             # tmp = self.operator2.range_geometry().allocate()
             # self.operator2.direct(x, out = tmp)
             # self.operator1.direct(tmp, out = out)
-            
+
             # out.fill (
-            #     functools.reduce(lambda X,operator: operator.direct(X), 
+            #     functools.reduce(lambda X,operator: operator.direct(X),
             #                        self.operators[::-1][1:],
             #                        self.operators[-1].direct(x))
             # )
-            
+
             # TODO this is a bit silly but will handle the pre allocation later
             if self.preallocate:
 
-                for i,operator in enumerate(self.operators[::-1]):
+                for i, operator in enumerate(self.operators[::-1]):
                     if i == 0:
                         operator.direct(x, out=self.tmp_range[i])
                     elif i == len(self.operators) - 1:
                         operator.direct(self.tmp_range[i-1], out=out)
                     else:
-                        operator.direct(self.tmp_range[i-1], out=self.tmp_range[i])
+                        operator.direct(
+                            self.tmp_range[i-1], out=self.tmp_range[i])
             else:
-                for i,operator in enumerate(self.operators[::-1]):
+                for i, operator in enumerate(self.operators[::-1]):
                     if i == 0:
                         step = operator.direct(x)
                     else:
                         step = operator.direct(step)
                 out.fill(step)
 
-            
-    def adjoint(self, x, out = None):
-        
-        if self.linear_flag: 
-            
+    def adjoint(self, x, out=None):
+
+        if self.linear_flag:
+
             if out is not None:
                 # return self.operator2.adjoint(self.operator1.adjoint(x))
-                # return functools.reduce(lambda X,operator: operator.adjoint(X), 
+                # return functools.reduce(lambda X,operator: operator.adjoint(X),
                 #                    self.operators[1:],
                 #                    self.operators[0].adjoint(x))
                 if self.preallocate:
-                    for i,operator in enumerate(self.operators):
+                    for i, operator in enumerate(self.operators):
                         if i == 0:
                             operator.adjoint(x, out=self.tmp_domain[i])
                         elif i == len(self.operators) - 1:
-                            step = operator.adjoint(self.tmp_domain[i-1], out=out)
+                            step = operator.adjoint(
+                                self.tmp_domain[i-1], out=out)
                         else:
-                            operator.adjoint(self.tmp_domain[i-1], out=self.tmp_domain[i])
+                            operator.adjoint(
+                                self.tmp_domain[i-1], out=self.tmp_domain[i])
                     return
                 else:
-                    for i,operator in enumerate(self.operators):
+                    for i, operator in enumerate(self.operators):
                         if i == 0:
                             step = operator.adjoint(x)
                         else:
                             step = operator.adjoint(step)
                     out.fill(step)
-                
+
             else:
                 if self.preallocate:
                     pass
                 else:
-                    for i,operator in enumerate(self.operators):
+                    for i, operator in enumerate(self.operators):
                         if i == 0:
                             step = operator.adjoint(x)
                         else:
                             step = operator.adjoint(step)
-                    
+
                     return step
         else:
             raise ValueError('No adjoint operation with non-linear operators')
-            
 
     def is_linear(self):
-        return self.linear_flag             
-            
-
-
-
+        return self.linear_flag

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -219,9 +219,9 @@ class LinearOperator(Operator):
         while (i < max_iteration and diff > tolerance):
             i+=1
             if i==max_iteration:
-                warnings.warn('In {} iterations, the difference in eigenvalue between the last two iterations was {} over the tolerance of {}. \n \
+                warnings.warn('In {} iterations, the difference in eigenvalue between the last two iterations was {} larger than the tolerance of {}. \n \
                 First try a larger iteration number and then a different initial vector. If that does not work consider the operator. For convergence, \n \
-                 we need the operator to have an eigenvalue that is strictly greater in magnitude than the magnitude of its other eigenvalues'.format(i, diff, tolerance))
+                we need the operator to have an eigenvalue that is strictly greater in magnitude than the magnitude of its other eigenvalues'.format(i, diff, tolerance))
 
             operator.direct(x0, out = y_tmp)
 
@@ -237,6 +237,8 @@ class LinearOperator(Operator):
            
             # Get eigenvalue using Rayleigh quotient: denominator=1, due to normalization
             x0_norm=x0.norm()
+            if x0_norm<tolerance:
+                raise ValueError('The operator has at least one zero eigenvector and is likely to be nilpotent')
             x0 /= x0_norm
 
             eig_new =  numpy.abs(x0_norm)

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -216,10 +216,13 @@ class LinearOperator(Operator):
 
         """
         convergence_check = True
+        
         if compose_with_adjoint is None:
             try:
                 if operator.domain_geometry() == operator.range_geometry():
                     compose_with_adjoint= False
+                else:
+                    compose_with_adjoint=True
             except AssertionError:
                 # catch AssertionError for SIRF objects https://github.com/SyneRBI/SIRF-SuperBuild/runs/5110228626?check_suite_focus=true#step:8:972
                 compose_with_adjoint=True

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -155,7 +155,7 @@ class LinearOperator(Operator):
 
         The Power method computes the largest (dominant) eigenvalue of a matrix in magnitude, e.g.,
         absolute value in the real case and modulus in the complex case.        
-        
+
         Parameters
         ----------
 
@@ -168,9 +168,9 @@ class LinearOperator(Operator):
             Stopping criterion for the Power method. Check if two consecutive eigenvalue evaluations are below the tolerance.                    
         return_all: `boolean`, default = False
             Toggles the verbosity of the return
-        method: `string` one of `auto`, `composed_with_adjoint` and `direct_only`, default = `auto` 
-            The default `auto` lets the code choose the method, this can be specified with `direct_only` or `compose_with_adjoint`
-            
+        method: `string` one of `"auto"`, `"composed_with_adjoint"` and `"direct_only"`, default = `"auto"` 
+            The default `auto` lets the code choose the method, this can be specified with `"direct_only"` or `"composed_with_adjoint"`
+
 
         Returns
         -------
@@ -183,8 +183,8 @@ class LinearOperator(Operator):
             List of eigenvalues. Only returned if return_all is True.
         convergence: `boolean'
             Check on wether the difference between the last two iterations is less than tolerance. Only returned if return_all is True.
-        
-            
+
+
         Note
         -----
         The power method contains two different algorithms chosen by the `method` flag. 
@@ -220,27 +220,26 @@ class LinearOperator(Operator):
         2.0005647295658866
 
         """
-        
-        
-        allowed_methods = ["auto","direct_only","composed_with_adjoint"]
-        
-        if method not in allowed_methods:
-            raise ValueError("The argument 'method' can be set to one of {0} got {1}".format(allowed_methods, method))
 
-        apply_adjoint=True
+        allowed_methods = ["auto", "direct_only", "composed_with_adjoint"]
+
+        if method not in allowed_methods:
+            raise ValueError("The argument 'method' can be set to one of {0} got {1}".format(
+                allowed_methods, method))
+
+        apply_adjoint = True
         if method == "direct_only":
-            apply_adjoint=False
-        if method=="auto":
+            apply_adjoint = False
+        if method == "auto":
             try:
                 geometries_match = operator.domain_geometry() == operator.range_geometry()
 
             except AssertionError:
                 # catch AssertionError for SIRF objects https://github.com/SyneRBI/SIRF-SuperBuild/runs/5110228626?check_suite_focus=true#step:8:972
-                    pass
+                pass
             else:
                 if geometries_match:
-                    apply_adjoint=False
-        
+                    apply_adjoint = False
 
         if initial is None:
             x0 = operator.domain_geometry().allocate('random')
@@ -594,13 +593,12 @@ class CompositionOperator(Operator):
             raise ValueError('No adjoint operation with non-linear operators')
 
     def is_linear(self):
-        return self.linear_flag             
-            
+        return self.linear_flag
 
     def calculate_norm(self):
         '''Returns the norm of the CompositionOperator, that is the product of the norms
         of its operators.'''
         norm = 1.
         for operator in self.operators:
-                norm *= operator.norm()
+            norm *= operator.norm()
         return norm

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -181,7 +181,7 @@ class LinearOperator(Operator):
             Corresponding eigenvector of the dominant eigenvalue. Only returned if return_all is True.
         list of eigenvalues: :obj:`list`
             List of eigenvalues. Only returned if return_all is True.
-        convergence: `boolean'
+        convergence: `boolean`
             Check on wether the difference between the last two iterations is less than tolerance. Only returned if return_all is True.
 
 

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -190,17 +190,11 @@ class LinearOperator(Operator):
         The power method contains two different algorithms chosen by the `method` flag. 
 
         In the case `method="direct_only"`, for operator, :math:`A`, the power method computes the iterations 
-        .. math::
-          x_{k+1} = A (\frac{x_k}{\|x_{k}\|}) \; (*)
-
-        initialised with a random vector :math:`x_0` and returning the largest (dominant) eigenvalue in magnitude given by :math:`\|x_k\|`. 
+        :math:`x_{k+1} = A (x_k/\|x_{k}\|)` initialised with a random vector :math:`x_0` and returning the largest (dominant) eigenvalue in magnitude given by :math:`\|x_k\|`. 
 
         In the case `method="composed_with_adjoint"`, the algorithm computes the largest (dominant) eigenvalue of :math:`A^{T}A` 
-          returning the square root of this value, i.e. the iterations:
-          .. math::
-          x_{k+1} = A^*A (\frac{x_k}{\|x_{k}\|})
-
-        and returning  :math:`\sqrt{\|x_k\|}`.
+        returning the square root of this value, i.e. the iterations:
+        :math:`x_{k+1} = A^TA (x_k/\|x_{k}\|)` and returning  :math:`\sqrt{\|x_k\|}`.
 
         The default flag is `method="auto"`, the algorithm checks to see if the `operator.domain_geometry() == operator.range_geometry()` and if so
         uses the method "direct_only" and if not the method "composed_with_adjoint".

--- a/Wrappers/Python/test/test_BlockOperator.py
+++ b/Wrappers/Python/test/test_BlockOperator.py
@@ -26,7 +26,7 @@ from cil.optimisation.operators import IdentityOperator
 from cil.framework import ImageGeometry, ImageData
 import numpy
 from cil.optimisation.operators import FiniteDifferenceOperator
-
+from cil.optimisation.operators import LinearOperator
 initialise_tests()
 
 class TestBlockOperator(unittest.TestCase):
@@ -187,9 +187,9 @@ class TestBlockOperator(unittest.TestCase):
         G = FiniteDifferenceOperator(ig, direction=0, bnd_cond = 'Neumann')
         logging.info("{} {}".format(type(u), str(u.as_array())))    
         logging.info(str(G.direct(u).as_array()))
-
+        LinearOperator.PowerMethod(G, range_is_domain=False)
         # Gradient Operator norm, for one direction should be close to 2
-        numpy.testing.assert_allclose(G.norm(), numpy.sqrt(4), atol=0.1)
+        numpy.testing.assert_allclose(LinearOperator.PowerMethod(G, range_is_domain=False), numpy.sqrt(4), atol=0.1)
 
         M1, N1, K1 = 200, 300, 2
         ig1 = ImageGeometry(voxel_num_x = M1, voxel_num_y = N1, channels = K1)

--- a/Wrappers/Python/test/test_BlockOperator.py
+++ b/Wrappers/Python/test/test_BlockOperator.py
@@ -26,7 +26,6 @@ from cil.optimisation.operators import IdentityOperator
 from cil.framework import ImageGeometry, ImageData
 import numpy
 from cil.optimisation.operators import FiniteDifferenceOperator
-from cil.optimisation.operators import LinearOperator
 initialise_tests()
 
 class TestBlockOperator(unittest.TestCase):

--- a/Wrappers/Python/test/test_BlockOperator.py
+++ b/Wrappers/Python/test/test_BlockOperator.py
@@ -26,6 +26,7 @@ from cil.optimisation.operators import IdentityOperator
 from cil.framework import ImageGeometry, ImageData
 import numpy
 from cil.optimisation.operators import FiniteDifferenceOperator
+
 initialise_tests()
 
 class TestBlockOperator(unittest.TestCase):

--- a/Wrappers/Python/test/test_BlockOperator.py
+++ b/Wrappers/Python/test/test_BlockOperator.py
@@ -187,9 +187,8 @@ class TestBlockOperator(unittest.TestCase):
         G = FiniteDifferenceOperator(ig, direction=0, bnd_cond = 'Neumann')
         logging.info("{} {}".format(type(u), str(u.as_array())))    
         logging.info(str(G.direct(u).as_array()))
-        LinearOperator.PowerMethod(G, range_is_domain=False)
         # Gradient Operator norm, for one direction should be close to 2
-        numpy.testing.assert_allclose(LinearOperator.PowerMethod(G, range_is_domain=False), numpy.sqrt(4), atol=0.1)
+        numpy.testing.assert_allclose(G.norm(), numpy.sqrt(4), atol=0.1)
 
         M1, N1, K1 = 200, 300, 2
         ig1 = ImageGeometry(voxel_num_x = M1, voxel_num_y = N1, channels = K1)

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -33,7 +33,7 @@ from cil.optimisation.operators import SumOperator,  ZeroOperator, CompositionOp
 from cil.utilities import dataexample
 import logging
 from testclass import CCPiTestClass
-import numpy as np
+
 
 initialise_tests()
 
@@ -303,7 +303,22 @@ class TestOperator(CCPiTestClass):
         M1 = numpy.array([[2,0,0],[1,2j,1j],[3, 3-1j,3]])
         M1op = MatrixOperator(M1)
         res1 = M1op.PowerMethod(M1op,100)
-        numpy.testing.assert_almost_equal(res1,3.1624439599276974, decimal=4)                
+        numpy.testing.assert_almost_equal(res1,3.1624439599276974, decimal=4) 
+
+        # 2x2 non-diagonalisable nilpotent matrix
+        with self.assertRaises(ValueError):
+            
+            M1=numpy.array([[0.,1.], [0.,0.]])
+            M1op = MatrixOperator(M1)
+            res1 = M1op.PowerMethod(M1op,5)
+            
+        # 2x2 nil
+        with self.assertWarns(Warning):
+            M1=numpy.array([[2.,1.], [0.,-2.]])
+            M1op = MatrixOperator(M1)
+            res1 = M1op.PowerMethod(M1op,100, initial=DataContainer(numpy.array([1.,1.])))
+
+            
 
         # Gradient Operator (float)
         ig = ImageGeometry(30,30)

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -312,7 +312,7 @@ class TestOperator(CCPiTestClass):
             M1op = MatrixOperator(M1)
             res1 = M1op.PowerMethod(M1op,5)
             
-        # 2x2 nil
+        # 2x2 matrix, max absolute eigenvalue is not unique and initial vector chosen for non-convergence
         with self.assertWarns(Warning):
             M1=numpy.array([[2.,1.], [0.,-2.]])
             M1op = MatrixOperator(M1)

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -285,7 +285,7 @@ class TestOperator(CCPiTestClass):
 
         # Test with the norm       
         res2 = M1op.norm()
-        res1 = M1op.PowerMethod(M1op,100, compose_with_adjoint=True)
+        res1 = M1op.PowerMethod(M1op,100, method="composed_with_adjoint")
         numpy.testing.assert_almost_equal(res1,res2, decimal=4)
 
 
@@ -313,10 +313,10 @@ class TestOperator(CCPiTestClass):
         res1 = M1op.PowerMethod(M1op,5)
         numpy.testing.assert_almost_equal(res1,0, decimal=4) 
 
-        # 2x2 non-diagonalisable nilpotent matrix where compose_with_adjoint=True 
+        # 2x2 non-diagonalisable nilpotent matrix where method="composed_with_adjoint"
         M1=numpy.array([[0.,1.], [0.,0.]])
         M1op = MatrixOperator(M1)
-        res1 = M1op.PowerMethod(M1op,5, compose_with_adjoint=True)
+        res1 = M1op.PowerMethod(M1op,5, method="composed_with_adjoint")
         numpy.testing.assert_almost_equal(res1,1, decimal=4) 
 
 
@@ -350,7 +350,13 @@ class TestOperator(CCPiTestClass):
         # Identity Operator
         Id = IdentityOperator(ig)
         res1 = Id.PowerMethod(Id,100)
-        numpy.testing.assert_almost_equal(res1,1.0, decimal=4)                
+        numpy.testing.assert_almost_equal(res1,1.0, decimal=4)        
+
+        # Test errors produced if not a valid method
+        try:
+            res1 = Id.PowerMethod(Id,100, method='gobledigook')
+        except ValueError:
+            pass      
 
 
     def test_Norm(self):
@@ -376,6 +382,17 @@ class TestOperator(CCPiTestClass):
         G.set_norm(None)
         #recalculates norm
         self.assertAlmostEqual(G.norm(), numpy.sqrt(8), 2)
+
+         # 2x2 real matrix, dominant eigenvalue = 2. Check norm uses the right flag for power method 
+        M1 = numpy.array([[1,0],[1,2]], dtype=float)
+        M1op = MatrixOperator(M1)
+        res1 = M1op.norm()
+        res2 = M1op.PowerMethod(M1op,100)
+        res3 = M1op.PowerMethod(M1op,100, method="composed_with_adjoint")
+        res4 = M1op.PowerMethod(M1op,100, method="direct_only")
+        numpy.testing.assert_almost_equal(res1,res3, decimal=4)
+        self.assertNotEqual(res1, res2)
+        self.assertNotEqual(res1,res4)
 
 
     def test_ProjectionMap(self):

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -284,6 +284,7 @@ class TestOperator(CCPiTestClass):
 
         # Test with the norm       
         res2 = M1op.norm()
+        res1 = M1op.PowerMethod(M1op,100, compose_with_adjoint=True)
         numpy.testing.assert_almost_equal(res1,res2, decimal=4)
 
 
@@ -302,8 +303,8 @@ class TestOperator(CCPiTestClass):
         # 3x3 complex matrix, (real+complex eigenvalue), dominant eigenvalue = 3.1624439599276974
         M1 = numpy.array([[2,0,0],[1,2j,1j],[3, 3-1j,3]])
         M1op = MatrixOperator(M1)
-        res1 = M1op.PowerMethod(M1op,100)
-        numpy.testing.assert_almost_equal(res1,3.1624439599276974, decimal=4) 
+        res1 = M1op.PowerMethod(M1op,120)
+        numpy.testing.assert_almost_equal(res1,3.1624439599276974, decimal=3) 
 
         # 2x2 non-diagonalisable nilpotent matrix
         M1=numpy.array([[0.,1.], [0.,0.]])
@@ -311,10 +312,10 @@ class TestOperator(CCPiTestClass):
         res1 = M1op.PowerMethod(M1op,5)
         numpy.testing.assert_almost_equal(res1,0, decimal=4) 
 
-        # 2x2 non-diagonalisable nilpotent matrix where range_is_domain is False
+        # 2x2 non-diagonalisable nilpotent matrix where compose_with_adjoint=True 
         M1=numpy.array([[0.,1.], [0.,0.]])
         M1op = MatrixOperator(M1)
-        res1 = M1op.PowerMethod(M1op,5, range_is_domain=False)
+        res1 = M1op.PowerMethod(M1op,5, compose_with_adjoint=True)
         numpy.testing.assert_almost_equal(res1,1, decimal=4) 
 
 

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -318,6 +318,12 @@ class TestOperator(CCPiTestClass):
             M1op = MatrixOperator(M1)
             res1 = M1op.PowerMethod(M1op,100, initial=DataContainer(numpy.array([1.,1.])))
 
+        # 2x2 matrix, max absolute eigenvalue is not unique and initial vector chosen for convergence
+        
+        M1=numpy.array([[2.,1.,0.],[0.,1.,1.], [0.,0.,1.]])
+        M1op = MatrixOperator(M1)
+        res1 = M1op.PowerMethod(M1op,100)
+        numpy.testing.assert_almost_equal(res1,2., decimal=4) 
             
 
         # Gradient Operator (float)

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -33,6 +33,7 @@ from cil.optimisation.operators import SumOperator,  ZeroOperator, CompositionOp
 from cil.utilities import dataexample
 import logging
 from testclass import CCPiTestClass
+import numpy as np
 
 initialise_tests()
 

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -306,25 +306,32 @@ class TestOperator(CCPiTestClass):
         numpy.testing.assert_almost_equal(res1,3.1624439599276974, decimal=4) 
 
         # 2x2 non-diagonalisable nilpotent matrix
-        with self.assertRaises(ValueError):
-            
-            M1=numpy.array([[0.,1.], [0.,0.]])
-            M1op = MatrixOperator(M1)
-            res1 = M1op.PowerMethod(M1op,5)
-            
+        M1=numpy.array([[0.,1.], [0.,0.]])
+        M1op = MatrixOperator(M1)
+        res1 = M1op.PowerMethod(M1op,5)
+        numpy.testing.assert_almost_equal(res1,0, decimal=4) 
+
+        # 2x2 non-diagonalisable nilpotent matrix where range_is_domain is False
+        M1=numpy.array([[0.,1.], [0.,0.]])
+        M1op = MatrixOperator(M1)
+        res1 = M1op.PowerMethod(M1op,5, range_is_domain=False)
+        numpy.testing.assert_almost_equal(res1,1, decimal=4) 
+
+
         # 2x2 matrix, max absolute eigenvalue is not unique and initial vector chosen for non-convergence
-        with self.assertWarns(Warning):
-            M1=numpy.array([[2.,1.], [0.,-2.]])
-            M1op = MatrixOperator(M1)
-            res1 = M1op.PowerMethod(M1op,100, initial=DataContainer(numpy.array([1.,1.])))
+        
+        M1=numpy.array([[2.,1.], [0.,-2.]])
+        M1op = MatrixOperator(M1)
+        _,_,_,_,convergence = M1op.PowerMethod(M1op,100, initial=DataContainer(numpy.array([1.,1.])), return_all=True)
+        numpy.testing.assert_equal(convergence,False) 
 
         # 2x2 matrix, max absolute eigenvalue is not unique and initial vector chosen for convergence
         
         M1=numpy.array([[2.,1.,0.],[0.,1.,1.], [0.,0.,1.]])
         M1op = MatrixOperator(M1)
-        res1 = M1op.PowerMethod(M1op,100)
+        res1,_,_,_,convergence = M1op.PowerMethod(M1op,100, return_all=True)
         numpy.testing.assert_almost_equal(res1,2., decimal=4) 
-            
+        numpy.testing.assert_equal(convergence,True)     
 
         # Gradient Operator (float)
         ig = ImageGeometry(30,30)


### PR DESCRIPTION
## Describe your changes

This pull request introduces a new argument to the power method, called "method".

If `method="direct_only"` then the power method computes $x_{k+1} = A (x_k / | x_{k}|)$ then $|A|= |x_k|$.

If `method="composed_with_adjoint"` then the power method computes $x_{k+1} = A^TA(x_k/|x_k|)$. $|A| = \sqrt{|x_k|}$, i.e. it applies the power method to $A^TA$ before taking the square root. 

If `method="auto"` then the code checks to see if the operator range and domain are equal, if they are then it uses the "direct_only" method, if they aren't or there are no range and domain geometries defined, it uses the "composed_with_adjoint" method. 

The LinearOperator::Calculate_norm method has been updated to use the "composed_with_adjoint" method to match the behaviour of norm with e.g. Matlab. 

A `check_convergence` flag has been added in the case `return_all=True` to check if the tolerance has been reached at the end of the iterations.  This is only relevant in the case that a user would use the power method directly with  `return_all=True`.

## Link relevant issues

closes #1468


## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
