### PR TITLE
Add norm for CompositionOperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* x.x.x
+  - Add norm for CompositionOperator.
+
 * 23.0.1
   - Fix bug with NikonReader requiring ROI to be set in constructor.
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -52,6 +52,7 @@ Richard Brown (2020-2021) - 5
 Sam Tygier (2022) - 1
 Andrew Sharits (2022) - 8
 Kyle Pidgeon (2023) - 1
+Letizia Protopapa (2023) - 1
 
 CIL Advisory Board:
 Llion Evans - 9

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -547,5 +547,8 @@ class CompositionOperator(Operator):
         return self.linear_flag             
             
 
-
-
+    def norm(self):
+        norm = 1.
+        for operator in self.operators:
+                norm *= operator.norm()
+        return norm

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -548,6 +548,8 @@ class CompositionOperator(Operator):
             
 
     def calculate_norm(self):
+        '''Returns the norm of the CompositionOperator, that is the product of the norms
+        of its operators.'''
         norm = 1.
         for operator in self.operators:
                 norm *= operator.norm()

--- a/Wrappers/Python/cil/optimisation/operators/Operator.py
+++ b/Wrappers/Python/cil/optimisation/operators/Operator.py
@@ -547,7 +547,7 @@ class CompositionOperator(Operator):
         return self.linear_flag             
             
 
-    def norm(self):
+    def calculate_norm(self):
         norm = 1.
         for operator in self.operators:
                 norm *= operator.norm()

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -1033,3 +1033,16 @@ class TestOperatorCompositionSum(unittest.TestCase):
         out2 = d.norm()
 
         numpy.testing.assert_almost_equal(out2, out1)
+
+
+    def test_CompositionOperator_norm3(self):
+
+        example_operator1 = Mock()
+        example_operator1.norm.return_value = 2.6
+
+        d = CompositionOperator(example_operator1)
+
+        out1 = 2.6
+        out2 = d.norm()
+
+        numpy.testing.assert_almost_equal(out2, out1)

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -1033,22 +1033,3 @@ class TestOperatorCompositionSum(unittest.TestCase):
         out2 = d.norm()
 
         numpy.testing.assert_almost_equal(out2, out1)
-
-
-    def test_CompositionOperator_norm3(self):
-
-        example_operator1 = Mock()
-        example_operator1.norm.return_value = 1
-
-        example_operator2 = Mock()
-        example_operator2.norm.return_value = 3
-
-        example_operator3 = Mock()
-        example_operator3.norm.return_value = 0
-
-        d = CompositionOperator(example_operator1, example_operator2, example_operator3)
-
-        out1 = 0
-        out2 = d.norm()
-
-        numpy.testing.assert_almost_equal(out2, out1)

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -18,6 +18,7 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 import unittest
+from unittest.mock import Mock
 from utils import initialise_tests
 from cil.framework import ImageGeometry, BlockGeometry, VectorGeometry, BlockDataContainer, DataContainer
 from cil.optimisation.operators import BlockOperator,\
@@ -997,3 +998,57 @@ class TestOperatorCompositionSum(unittest.TestCase):
                                                 2 * out2.as_array())
         numpy.testing.assert_array_almost_equal(d_out.as_array(),
                                                 2 * out2.as_array())
+
+
+    def test_CompositionOperator_norm1(self):
+
+        example_operator1 = Mock()
+        example_operator1.norm.return_value = 2
+
+        example_operator2 = Mock()
+        example_operator2.norm.return_value = 3
+
+        d = CompositionOperator(example_operator1, example_operator2)
+
+        out1 = 6
+        out2 = d.norm()
+
+        numpy.testing.assert_almost_equal(out2, out1)
+
+
+    def test_CompositionOperator_norm2(self):
+
+        example_operator1 = Mock()
+        example_operator1.norm.return_value = 2
+
+        example_operator2 = Mock()
+        example_operator2.norm.return_value = 3
+
+        example_operator3 = Mock()
+        example_operator3.norm.return_value = 5
+
+        d = CompositionOperator(example_operator1, example_operator2, example_operator3)
+
+        out1 = 30
+        out2 = d.norm()
+
+        numpy.testing.assert_almost_equal(out2, out1)
+
+
+    def test_CompositionOperator_norm3(self):
+
+        example_operator1 = Mock()
+        example_operator1.norm.return_value = 1
+
+        example_operator2 = Mock()
+        example_operator2.norm.return_value = 3
+
+        example_operator3 = Mock()
+        example_operator3.norm.return_value = 0
+
+        d = CompositionOperator(example_operator1, example_operator2, example_operator3)
+
+        out1 = 0
+        out2 = d.norm()
+
+        numpy.testing.assert_almost_equal(out2, out1)

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -1003,14 +1003,14 @@ class TestOperatorCompositionSum(unittest.TestCase):
     def test_CompositionOperator_norm1(self):
 
         example_operator1 = Mock()
-        example_operator1.norm.return_value = 2
+        example_operator1.norm.return_value = 2.6
 
         example_operator2 = Mock()
-        example_operator2.norm.return_value = 3
+        example_operator2.norm.return_value = 3.4
 
         d = CompositionOperator(example_operator1, example_operator2)
 
-        out1 = 6
+        out1 = 8.84
         out2 = d.norm()
 
         numpy.testing.assert_almost_equal(out2, out1)
@@ -1019,17 +1019,17 @@ class TestOperatorCompositionSum(unittest.TestCase):
     def test_CompositionOperator_norm2(self):
 
         example_operator1 = Mock()
-        example_operator1.norm.return_value = 2
+        example_operator1.norm.return_value = 2.6
 
         example_operator2 = Mock()
-        example_operator2.norm.return_value = 3
+        example_operator2.norm.return_value = 3.4
 
         example_operator3 = Mock()
-        example_operator3.norm.return_value = 5
+        example_operator3.norm.return_value = 5.0
 
         d = CompositionOperator(example_operator1, example_operator2, example_operator3)
 
-        out1 = 30
+        out1 = 44.2
         out2 = d.norm()
 
         numpy.testing.assert_almost_equal(out2, out1)


### PR DESCRIPTION
## Describe your changes

- Added function to calculate norm of the CompositonOperator and some tests for it. 
- Added contributor.
- Updated the changelog.

## Describe any testing you have performed

Function has been tested through the tests that are part of this pull request. It has also been used/tested when running the script for motion compensation (SIRF) with PDHG.

## Link relevant issues

Closes #1460 .

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
