### PR TITLE
Update regularisation toolkit Function to handle non CIL DataContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 23.x.x
+  - allow CCPi Regulariser functions for not CIL object
+
 * 23.0.1
   - Fix bug with NikonReader requiring ROI to be set in constructor.
 

--- a/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
+++ b/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
@@ -457,8 +457,7 @@ class TNV(RegulariserFunction):
     
     def proximal_numpy(self, in_arr, tau):
         # remove any dimension of size 1
-        new_shape = [ i for i in in_arr.shape if i!=1]
-        in_arr.shape = tuple(new_shape)
+        in_arr = np.squeeze(in_arr)
             
         res = regularisers.TNV(in_arr, 
               self.alpha * tau,
@@ -489,8 +488,7 @@ class TNV(RegulariserFunction):
         else:
             # if it is not a CIL DataContainer we assume that the data is passed in the correct order
             # discard any dimension of size 1
-            new_shape = [ i for i in input.shape if i!=1]
-            if len(new_shape) != 3:
+            if sum(1 for i in input.shape if i!=1) != 3:
                 raise ValueError('TNV requires 3D data (with channel as first axis). Got {}'.format(input.shape))
         
 

--- a/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
+++ b/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
@@ -483,7 +483,7 @@ class TNV(RegulariserFunction):
         '''TNV requires 2D+channel data with the first dimension as the channel dimension'''
         if isinstance(input, DataContainer):
             DataOrder.check_order_for_engine('cil', input.geometry)
-            if ( input.geometry.channels == 1 ) or ( not input.geometry.length == 3) :
+            if ( input.geometry.channels == 1 ) or ( not input.geometry.ndim == 3) :
                 raise ValueError('TNV requires 2D+channel data. Got {}'.format(input.geometry.dimension_labels))
         else:
             # if it is not a CIL DataContainer we assume that the data is passed in the correct order

--- a/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
+++ b/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
@@ -481,7 +481,7 @@ class TNV(RegulariserFunction):
 
     def check_input(self, input):
         '''TNV requires 2D+channel data with the first dimension as the channel dimension'''
-        if issubclass(input, DataContainer):
+        if isinstance(input, DataContainer):
             DataOrder.check_order_for_engine('cil', input.geometry)
             if ( input.geometry.channels == 1 ) or ( not input.geometry.length == 3) :
                 raise ValueError('TNV requires 2D+channel data. Got {}'.format(input.geometry.dimension_labels))

--- a/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
+++ b/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
@@ -456,9 +456,10 @@ class TNV(RegulariserFunction):
         return np.nan
     
     def proximal_numpy(self, in_arr, tau):
-        if in_arr.ndim != 3:
-            # https://github.com/vais-ral/CCPi-Regularisation-Toolkit/blob/413c6001003c6f1272aeb43152654baaf0c8a423/src/Python/src/cpu_regularisers.pyx#L584-L588
-            raise ValueError('Only 3D data is supported. Passed data has {} dimensions'.format(in_arr.ndim))
+        # remove any dimension of size 1
+        new_shape = [ i for i in input.shape if i!=1]
+        in_arr.shape = tuple(new_shape)
+            
         res = regularisers.TNV(in_arr, 
               self.alpha * tau,
               self.max_iteration,
@@ -487,7 +488,8 @@ class TNV(RegulariserFunction):
                 raise ValueError('TNV requires 2D+channel data. Got {}'.format(input.geometry.dimension_labels))
         else:
             # if it is not a CIL DataContainer we assume that the data is passed in the correct order
-            if len(input.shape) != 3 or input.shape[0] > 1 or  1 in input.shape:
+            new_shape = [ i for i in input.shape if i!=1]
+            if len(input.shape) != 3:
                 raise ValueError('TNV requires 3D data (with channel as first axis). Got {}'.format(input.shape))
         
 

--- a/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
+++ b/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
@@ -457,7 +457,7 @@ class TNV(RegulariserFunction):
     
     def proximal_numpy(self, in_arr, tau):
         # remove any dimension of size 1
-        new_shape = [ i for i in input.shape if i!=1]
+        new_shape = [ i for i in in_arr.shape if i!=1]
         in_arr.shape = tuple(new_shape)
             
         res = regularisers.TNV(in_arr, 

--- a/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
+++ b/Wrappers/Python/cil/plugins/ccpi_regularisation/functions/regularisers.py
@@ -488,8 +488,9 @@ class TNV(RegulariserFunction):
                 raise ValueError('TNV requires 2D+channel data. Got {}'.format(input.geometry.dimension_labels))
         else:
             # if it is not a CIL DataContainer we assume that the data is passed in the correct order
+            # discard any dimension of size 1
             new_shape = [ i for i in input.shape if i!=1]
-            if len(input.shape) != 3:
+            if len(new_shape) != 3:
                 raise ValueError('TNV requires 3D data (with channel as first axis). Got {}'.format(input.shape))
         
 

--- a/Wrappers/Python/test/test_SIRF.py
+++ b/Wrappers/Python/test/test_SIRF.py
@@ -40,6 +40,7 @@ initialise_tests()
 try:
     import sirf.STIR as pet
     import sirf.Gadgetron as mr
+    import sirf.Reg as reg
     from sirf.Utilities import examples_data_path
     
     has_sirf = True
@@ -307,7 +308,9 @@ class TestSIRFCILIntegration(CCPiTestClass):
         bdc = BlockDataContainer(image1, image2)
         bdc1 = bdc.divide(1.)
 
-        self.assertBlockDataContainerEqual(bdc , bdc1)
+        # self.assertBlockDataContainerEqual(bdc , bdc1)
+        np.testing.assert_allclose(bdc.get_item(0).as_array(), bdc1.get_item(0).as_array())
+        np.testing.assert_allclose(bdc.get_item(1).as_array(), bdc1.get_item(1).as_array())
 
 
     @unittest.skipUnless(has_sirf, "Has SIRF")
@@ -328,7 +331,9 @@ class TestSIRFCILIntegration(CCPiTestClass):
         bdc = BlockDataContainer(image1, image2)
         bdc1 = bdc.multiply(1.)
 
-        self.assertBlockDataContainerEqual(bdc , bdc1)
+        # self.assertBlockDataContainerEqual(bdc , bdc1)
+        np.testing.assert_allclose(bdc.get_item(0).as_array(), bdc1.get_item(0).as_array())
+        np.testing.assert_allclose(bdc.get_item(1).as_array(), bdc1.get_item(1).as_array())
     
 
     @unittest.skipUnless(has_sirf, "Has SIRF")
@@ -352,7 +357,9 @@ class TestSIRFCILIntegration(CCPiTestClass):
 
         bdc = BlockDataContainer(image1, image2)
 
-        self.assertBlockDataContainerEqual(bdc , bdc1)
+        np.testing.assert_allclose(bdc.get_item(0).as_array(), bdc1.get_item(0).as_array())
+        np.testing.assert_allclose(bdc.get_item(1).as_array(), bdc1.get_item(1).as_array())
+        # self.assertBlockDataContainerEqual(bdc , bdc1)
 
 
     @unittest.skipUnless(has_sirf, "Has SIRF")
@@ -372,7 +379,9 @@ class TestSIRFCILIntegration(CCPiTestClass):
 
         bdc = BlockDataContainer(image1, image2)
 
-        self.assertBlockDataContainerEqual(bdc , bdc1)
+        # self.assertBlockDataContainerEqual(bdc , bdc1)
+        np.testing.assert_allclose(bdc.get_item(0).as_array(), bdc1.get_item(0).as_array())
+        np.testing.assert_allclose(bdc.get_item(1).as_array(), bdc1.get_item(1).as_array())
 
 
 

--- a/Wrappers/Python/test/test_SIRF.py
+++ b/Wrappers/Python/test/test_SIRF.py
@@ -385,7 +385,7 @@ class TestSIRFCILIntegration(CCPiTestClass):
 
 
 
-class CCPiRegularisationWithSIRFTests(CCPiTestClass):
+class CCPiRegularisationWithSIRFTests():
     
     def setUpFGP_TV(self, max_iteration=100, alpha=1.):
         return alpha*FGP_TV(max_iteration=max_iteration)
@@ -453,7 +453,7 @@ class CCPiRegularisationWithSIRFTests(CCPiTestClass):
         solution = regulariser.proximal(x=self.image1, tau=1.)
         self.assertTrue(True)
 
-class TestPETRegularisation(CCPiRegularisationWithSIRFTests):
+class TestPETRegularisation(unittest.TestCase, CCPiRegularisationWithSIRFTests):
     skip_TNV_on_2D = True
     def setUp(self):
         self.image1 = pet.ImageData(os.path.join(
@@ -469,12 +469,12 @@ class TestPETRegularisation(CCPiRegularisationWithSIRFTests):
     def test_TNV_proximal_works(self):
         super().test_TNV_proximal_works()
         
-class TestRegRegularisation(CCPiRegularisationWithSIRFTests):
+class TestRegRegularisation(unittest.TestCase, CCPiRegularisationWithSIRFTests):
     def setUp(self):
         self.image1 = reg.ImageData(os.path.join(examples_data_path('Registration'),'test2.nii.gz'))
         self.image2 = self.image1 * 0.5
 
-class TestMRRegularisation(CCPiRegularisationWithSIRFTests):
+class TestMRRegularisation(unittest.TestCase, CCPiRegularisationWithSIRFTests):
     def setUp(self):
         acq_data = mr.AcquisitionData(os.path.join(examples_data_path('MR'),'simulated_MR_2D_cartesian.h5'))
         preprocessed_data = mr.preprocess_acquisition_data(acq_data)

--- a/Wrappers/Python/test/test_SIRF.py
+++ b/Wrappers/Python/test/test_SIRF.py
@@ -28,7 +28,12 @@ from cil.optimisation.operators import GradientOperator, LinearOperator
 from cil.optimisation.functions import TotalVariation, L2NormSquared, KullbackLeibler
 from cil.optimisation.algorithms import FISTA
 
+import os
+from cil.plugins.ccpi_regularisation.functions import FGP_TV, TGV, TNV, FGP_dTV
+from cil.utilities.display import show2D  
+
 from testclass import CCPiTestClass
+from utils import has_nvidia, has_ccpi_regularisation, initialise_tests
 
 initialise_tests()
 
@@ -36,9 +41,16 @@ try:
     import sirf.STIR as pet
     import sirf.Gadgetron as mr
     from sirf.Utilities import examples_data_path
+    
     has_sirf = True
 except ImportError as ie:
     has_sirf = False
+
+if has_ccpi_regularisation:
+    from ccpi.filters import regularisers
+    from cil.plugins.ccpi_regularisation.functions import FGP_TV, TGV, FGP_dTV, TNV
+
+
 
 class KullbackLeiblerSIRF(object):
 
@@ -364,6 +376,101 @@ class TestSIRFCILIntegration(CCPiTestClass):
 
 
 
+class CCPiRegularisationWithSIRFTests(CCPiTestClass):
+    
+    def setUpFGP_TV(self, max_iteration=100, alpha=1.):
+        return alpha*FGP_TV(max_iteration=max_iteration)
 
+    @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
+    def test_FGP_TV_call_works(self):
+        regulariser = self.setUpFGP_TV()
+        output_number = regulariser(self.image1)
+        self.assertTrue(True)
+        # TODO: test the actual value
+        # expected = 160600016.0
+        # np.testing.assert_allclose(output_number, expected, rtol=1e-5)
+    
+    @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
+    def test_FGP_TV_proximal_works(self):
+        regulariser = self.setUpFGP_TV()
+        solution = regulariser.proximal(x=self.image1, tau=1)
+        self.assertTrue(True)
 
+    # TGV
+    def setUpTGV(self, max_iteration=100, alpha=1.):
+        return alpha * TGV(max_iteration=max_iteration)
 
+    @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
+    def test_TGV_call_works(self):
+        regulariser = self.setUpTGV()
+        output_number = regulariser(self.image1)
+        self.assertTrue(True)
+
+    @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
+    def test_TGV_proximal_works(self):
+        regulariser = self.setUpTGV()
+        solution = regulariser.proximal(x=self.image1, tau=1)
+        self.assertTrue(True)
+        
+    # dTV
+    def setUpdTV(self, max_iteration=100, alpha=1.):
+        return alpha * FGP_dTV(reference=self.image2, max_iteration=max_iteration)
+
+    @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
+    def test_TGV_call_works(self):
+        regulariser = self.setUpTGV()
+        output_number = regulariser(self.image1)
+        self.assertTrue(True)
+
+    @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
+    def test_TGV_proximal_works(self):
+        regulariser = self.setUpTGV()
+        solution = regulariser.proximal(x=self.image1, tau=1)
+        self.assertTrue(True)
+
+    # TNV
+    def setUpTNV(self, max_iteration=100, alpha=1.):
+        return alpha * TNV(max_iteration=max_iteration)
+
+    @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
+    def test_TNV_call_works(self):
+        regulariser = self.setUpTNV()
+        output_number = regulariser(self.image1)
+        self.assertTrue(True)
+
+    @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
+    def test_TGV_proximal_works(self):
+        regulariser = self.setUpTNV()
+        solution = regulariser.proximal(x=self.image1, tau=1.)
+        self.assertTrue(True)
+
+class TestPETRegularisation(CCPiRegularisationWithSIRFTests):
+    skip_TNV_on_2D = True
+    def setUp(self):
+        self.image1 = pet.ImageData(os.path.join(
+            examples_data_path('PET'),'thorax_single_slice','emission.hv'
+            ))
+        self.image2 = self.image1 * 0.5
+
+    @unittest.skipIf(skip_TNV_on_2D, "TNV not implemented for 2D")
+    def test_TNV_call_works(self):
+        super().test_TNV_call_works()
+    
+    @unittest.skipIf(skip_TNV_on_2D, "TNV not implemented for 2D")
+    def test_TNV_proximal_works(self):
+        super().test_TNV_proximal_works()
+        
+class TestRegRegularisation(CCPiRegularisationWithSIRFTests):
+    def setUp(self):
+        self.image1 = = reg.ImageData(os.path.join(examples_data_path('Registration'),'test2.nii.gz'))
+        self.image2 = self.image1 * 0.5
+
+class TestMRRegularisation(CCPiRegularisationWithSIRFTests):
+    def setUp(self):
+        acq_data = mr.AcquisitionData(os.path.join(examples_data_path('MR'),'simulated_MR_2D_cartesian.h5'))
+        preprocessed_data = mr.preprocess_acquisition_data(acq_data)
+        recon = mr.FullySampledReconstructor()
+        recon.set_input(preprocessed_data)
+        recon.process()
+        self.image1 = recon.get_output()
+        self.image2 = self.image1 * 0.5

--- a/Wrappers/Python/test/test_SIRF.py
+++ b/Wrappers/Python/test/test_SIRF.py
@@ -443,15 +443,19 @@ class CCPiRegularisationWithSIRFTests():
 
     @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
     def test_TNV_call_works(self):
-        regulariser = self.setUpTNV()
-        output_number = regulariser(self.image1)
-        self.assertTrue(True)
+        new_shape = [ i for i in self.image1.shape if i!=1]
+        if len(new_shape) == 3:
+            regulariser = self.setUpTNV()
+            output_number = regulariser(self.image1)
+            self.assertTrue(True)
 
     @unittest.skipUnless(has_sirf and has_ccpi_regularisation, "Has SIRF and CCPi Regularisation")
-    def test_TGV_proximal_works(self):
-        regulariser = self.setUpTNV()
-        solution = regulariser.proximal(x=self.image1, tau=1.)
-        self.assertTrue(True)
+    def test_TNV_proximal_works(self):
+        new_shape = [ i for i in self.image1.shape if i!=1]
+        if len(new_shape) == 3:
+            regulariser = self.setUpTNV()
+            solution = regulariser.proximal(x=self.image1, tau=1.)
+            self.assertTrue(True)
 
 class TestPETRegularisation(unittest.TestCase, CCPiRegularisationWithSIRFTests):
     skip_TNV_on_2D = True

--- a/Wrappers/Python/test/test_SIRF.py
+++ b/Wrappers/Python/test/test_SIRF.py
@@ -462,7 +462,7 @@ class TestPETRegularisation(CCPiRegularisationWithSIRFTests):
         
 class TestRegRegularisation(CCPiRegularisationWithSIRFTests):
     def setUp(self):
-        self.image1 = = reg.ImageData(os.path.join(examples_data_path('Registration'),'test2.nii.gz'))
+        self.image1 = reg.ImageData(os.path.join(examples_data_path('Registration'),'test2.nii.gz'))
         self.image2 = self.image1 * 0.5
 
 class TestMRRegularisation(CCPiRegularisationWithSIRFTests):


### PR DESCRIPTION
## Describe your changes

The `check_input` function in the regularisation toolkit plugin relied on data being CIL `DataContainer`, therefore failing for SIRF objects.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*

Added tests for CIL/SIRF integration which run on SIRF SuperBuild https://github.com/SyneRBI/SIRF-SuperBuild/pull/822
Once that works, we can merge this PR in.

## Link relevant issues

closes #1479 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
