### PR TITLE
FBP split processing respect panel origin

### DIFF
--- a/Wrappers/Python/test/test_reconstructors.py
+++ b/Wrappers/Python/test/test_reconstructors.py
@@ -652,7 +652,7 @@ class Test_FBP_results(unittest.TestCase):
     def test_results_3D_split(self):
 
         reconstructor = FBP(self.acq_data)
-        reconstructor.set_split_processing(1)
+        reconstructor.set_split_processing(8)
 
         reco = reconstructor.run(verbose=0)
         np.testing.assert_allclose(reco.as_array(), self.img_data.as_array(),atol=1e-3)    
@@ -661,6 +661,27 @@ class Test_FBP_results(unittest.TestCase):
         reco2.fill(0)
         reconstructor.run(out=reco2, verbose=0)
         np.testing.assert_allclose(reco.as_array(), reco2.as_array(), atol=1e-8)   
+
+
+    @unittest.skipUnless(has_tigre and has_nvidia and has_ipp, "TIGRE or IPP not installed")
+    def test_results_3D_split_reverse(self):
+
+        acq_data = self.acq_data.copy()
+        acq_data.geometry.config.panel.origin = 'top-left'
+
+        reconstructor = FBP(acq_data)
+        reconstructor.set_split_processing(8)
+
+        expected_image = np.flip(self.img_data.as_array(),0)
+
+        reco = reconstructor.run(verbose=0)
+        np.testing.assert_allclose(reco.as_array(), expected_image,atol=1e-3)    
+
+        reco2 = reco.copy()
+        reco2.fill(0)
+        reconstructor.run(out=reco2, verbose=0)
+        np.testing.assert_allclose(reco.as_array(), reco2.as_array(), atol=1e-8)   
+
 
 
     @unittest.skipUnless(has_tigre and has_nvidia and has_ipp, "TIGRE or IPP not installed")


### PR DESCRIPTION
## Describe your changes
Using recon FBP to process by chunks filled the image data in the wrong order as it didn't respect the acquisition geometry panel origin attribute.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
Added unit test with panel origin 'top' tested on example from linked issue.

## Link relevant issues
closes #1465

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
