### PR TITLE
fix 2D origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Add norm for CompositionOperator.
   - Refactor SIRT algorithm to make it more computationally and memory efficient
   - Optimisation in L2NormSquared
+  - Fix for show_geometry bug for 2D data
 
 * 23.0.1
   - Fix bug with NikonReader requiring ROI to be set in constructor.

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -845,12 +845,12 @@ class _ShowGeometry(object):
 
         #mark data origin
         if 'right' in self.acquisition_geometry.config.panel.origin:
-            if 'bottom' in self.acquisition_geometry.config.panel.origin:
+            if self.ndim==2 or 'bottom' in self.acquisition_geometry.config.panel.origin:
                 pix0 = det[0]
             else:
                 pix0 = det[3]
         else:
-            if 'bottom' in self.acquisition_geometry.config.panel.origin:
+            if self.ndim==2 or 'bottom' in self.acquisition_geometry.config.panel.origin:
                 pix0 = det[1]
             else:
                 pix0 = det[2]


### PR DESCRIPTION
## Describe your changes
Fix to `show_geometry` for 2D datasets with panel origin set.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
Checked origin marker for 2D/3D Cone/Parallel geometries.

## Link relevant issues
closes #1491 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
