### PR TITLE
Add list of filter names to docstring for recon's FBP and FDK

### DIFF
--- a/Wrappers/Python/cil/recon/FBP.py
+++ b/Wrappers/Python/cil/recon/FBP.py
@@ -331,7 +331,7 @@ class FDK(GenericFilteredBackProjection):
         A description of the area/volume to reconstruct
     
     filter : string, numpy.ndarray, default='ram-lak'
-        The filter to be applied. Can be a string from: 'ram-lak' or a numpy array.
+        The filter to be applied. Can be a string from: {'ram-lak', `shepp-logan`, `cosine`, `hamming`, `hann`}, or a numpy array.
 
     Example
     -------
@@ -430,7 +430,7 @@ class FBP(GenericFilteredBackProjection):
         A description of the area/volume to reconstruct
         
     filter : string, numpy.ndarray, default='ram-lak'
-        The filter to be applied. Can be a string from: 'ram-lak' or a numpy array.
+        The filter to be applied. Can be a string from: {'ram-lak', `shepp-logan`, `cosine`, `hamming`, `hann`}, or a numpy array.
 
     backend : string
         The backend to use, can be 'astra' or 'tigre'. Data must be in the correct order for requested backend.

--- a/Wrappers/Python/cil/recon/FBP.py
+++ b/Wrappers/Python/cil/recon/FBP.py
@@ -331,7 +331,7 @@ class FDK(GenericFilteredBackProjection):
         A description of the area/volume to reconstruct
     
     filter : string, numpy.ndarray, default='ram-lak'
-        The filter to be applied. Can be a string from: {'ram-lak', `shepp-logan`, `cosine`, `hamming`, `hann`}, or a numpy array.
+        The filter to be applied. Can be a string from: {'`ram-lak`', '`shepp-logan`', '`cosine`', '`hamming`', '`hann`'}, or a numpy array.
 
     Example
     -------
@@ -430,7 +430,7 @@ class FBP(GenericFilteredBackProjection):
         A description of the area/volume to reconstruct
         
     filter : string, numpy.ndarray, default='ram-lak'
-        The filter to be applied. Can be a string from: {'ram-lak', `shepp-logan`, `cosine`, `hamming`, `hann`}, or a numpy array.
+        The filter to be applied. Can be a string from: {'`ram-lak`', '`shepp-logan`', '`cosine`', '`hamming`', '`hann`'}, or a numpy array.
 
     backend : string
         The backend to use, can be 'astra' or 'tigre'. Data must be in the correct order for requested backend.


### PR DESCRIPTION
## Describe your changes
I was using the documentation for the FBP filters and noticed they were not all listed in the docstring. This adds the list of filters there for both FBP and FDK.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues


## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
