### PR TITLE
Fix bug with show2D and 3D DataContainers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-
+* x.x.x
+  - Fix show2D bug for 3D DataContainers
+  
 * 23.1.0
   - Fix bug in IndicatorBox proximal_conjugate
   - Allow CCPi Regulariser functions for non CIL object

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2771,9 +2771,9 @@ class DataContainer(object):
         return self.array
 
 
-    def get_slice(self,**kw):
+    def get_slice(self, **kw):
         '''
-        Returns a new DataContainer containing a single slice of in the requested direction. \
+        Returns a new DataContainer containing a single slice in the requested direction. \
         Pass keyword arguments <dimension label>=index
         '''
         new_array = None

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2776,6 +2776,9 @@ class DataContainer(object):
         Returns a new DataContainer containing a single slice in the requested direction. \
         Pass keyword arguments <dimension label>=index
         '''
+        # Force is not relevant for a DataContainer:
+        kw.pop('force', None)
+
         new_array = None
 
         #get ordered list of current dimensions

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -497,10 +497,7 @@ class show2D(show_base):
                             cut_axis[1] = data.dimension_labels[cut_axis[1]]
 
                         temp_dict = {cut_axis[0]:cut_slices[0], cut_axis[1]:cut_slices[1]}
-                        if type(data) == DataContainer:
-                            plot_data = data.get_slice(**temp_dict)
-                        else:
-                            plot_data = data.get_slice(**temp_dict, force=True)
+                        plot_data = data.get_slice(**temp_dict, force=True)
                     elif hasattr(data,'as_array'):
                         plot_data = data.as_array().take(indices=cut_slices[1], axis=cut_axis[1])
                         plot_data = plot_data.take(indices=cut_slices[0], axis=cut_axis[0])
@@ -538,10 +535,7 @@ class show2D(show_base):
                         if type(cut_axis) is int:
                             cut_axis = data.dimension_labels[cut_axis]
                         temp_dict = {cut_axis:cut_slice}
-                        if type(data) == DataContainer:
-                            plot_data = data.get_slice(**temp_dict)
-                        else:
-                            plot_data = data.get_slice(**temp_dict, force=True)
+                        plot_data = data.get_slice(**temp_dict, force=True)
                     elif hasattr(data,'as_array'):
                         plot_data = data.as_array().take(indices=cut_slice, axis=cut_axis)
                     else:

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -380,7 +380,7 @@ class show2D(show_base):
 
     Plots 1 or more 2D plots in an (n x num_cols) matrix.
     Can plot multiple slices from one 3D dataset, or compare multiple datasets
-    Inputs can be single arguments or list of arguments that will be sequentally applied to subplots
+    Inputs can be single arguments or list of arguments that will be sequentially applied to subplots
     If no slice_list is passed a 3D dataset will display the centre slice of the outer dimension, a 4D dataset will show the centre slices of the two outer dimension.
 
 
@@ -392,7 +392,7 @@ class show2D(show_base):
         The title for each figure
     slice_list: tuple, int, list of tuples, list of ints, optional
         The slices to show. A list of integers will show slices for the outer dimension. For 3D datacontainers single slice: (direction, index). For 4D datacontainers two slices: [(direction0, index),(direction1, index)].
-    fix_range: boolian, tuple, list of tuples
+    fix_range: boolean, tuple, list of tuples
         Sets the display range of the data. `True` sets all plots to the global (min, max). 
     axis_labels: tuple, list of tuples, optional
         The axis labels for each figure e.g. ('x','y')
@@ -497,7 +497,10 @@ class show2D(show_base):
                             cut_axis[1] = data.dimension_labels[cut_axis[1]]
 
                         temp_dict = {cut_axis[0]:cut_slices[0], cut_axis[1]:cut_slices[1]}
-                        plot_data = data.get_slice(**temp_dict, force=True)
+                        if type(data) == DataContainer:
+                            plot_data = data.get_slice(**temp_dict)
+                        else:
+                            plot_data = data.get_slice(**temp_dict, force=True)
                     elif hasattr(data,'as_array'):
                         plot_data = data.as_array().take(indices=cut_slices[1], axis=cut_axis[1])
                         plot_data = plot_data.take(indices=cut_slices[0], axis=cut_axis[0])
@@ -535,7 +538,10 @@ class show2D(show_base):
                         if type(cut_axis) is int:
                             cut_axis = data.dimension_labels[cut_axis]
                         temp_dict = {cut_axis:cut_slice}
-                        plot_data = data.get_slice(**temp_dict, force=True)
+                        if type(data) == DataContainer:
+                            plot_data = data.get_slice(**temp_dict)
+                        else:
+                            plot_data = data.get_slice(**temp_dict, force=True)
                     elif hasattr(data,'as_array'):
                         plot_data = data.as_array().take(indices=cut_slice, axis=cut_axis)
                     else:

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -751,6 +751,37 @@ class TestDataContainer(CCPiTestClass):
         ss3 = vol.get_slice(channel=0)
         self.assertListEqual([ImageGeometry.HORIZONTAL_Y, ImageGeometry.HORIZONTAL_X], list(ss3.geometry.dimension_labels))
 
+    def test_DataContainerSubset(self):
+        dc = DataContainer(numpy.ones((2,3,4,5)))
+        print(dc)
+
+        dc.dimension_labels =[AcquisitionGeometry.CHANNEL ,
+                 AcquisitionGeometry.ANGLE , AcquisitionGeometry.VERTICAL ,
+                 AcquisitionGeometry.HORIZONTAL]
+
+        # test reshape
+        new_order = [AcquisitionGeometry.HORIZONTAL ,
+                 AcquisitionGeometry.CHANNEL , AcquisitionGeometry.VERTICAL ,
+                 AcquisitionGeometry.ANGLE]
+        dc.reorder(new_order)
+
+        self.assertListEqual(new_order, list(dc.dimension_labels))
+
+        ss1 = dc.get_slice(vertical = 0)
+
+        self.assertListEqual([AcquisitionGeometry.HORIZONTAL ,
+                 AcquisitionGeometry.CHANNEL  ,
+                 AcquisitionGeometry.ANGLE], list(ss1.dimension_labels))
+        
+        ss2 = dc.get_slice(vertical = 0, channel=0)
+        self.assertListEqual([AcquisitionGeometry.HORIZONTAL ,
+                 AcquisitionGeometry.ANGLE], list(ss2.dimension_labels))
+        
+        # Check we can get slice still even if force parameter is passed:
+        ss3 = dc.get_slice(vertical = 0, channel=0, force=True)
+        self.assertListEqual([AcquisitionGeometry.HORIZONTAL ,
+                    AcquisitionGeometry.ANGLE], list(ss3.dimension_labels))
+        
 
     def test_DataContainerChaining(self):
         dc = self.create_DataContainer(256,256,256,1)
@@ -1135,4 +1166,3 @@ class TestDataContainer(CCPiTestClass):
         numpy.testing.assert_array_equal(u.get_slice(channel=1, vertical=1).as_array(), 3 * a)
 
 
- 

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -753,7 +753,6 @@ class TestDataContainer(CCPiTestClass):
 
     def test_DataContainerSubset(self):
         dc = DataContainer(numpy.ones((2,3,4,5)))
-        print(dc)
 
         dc.dimension_labels =[AcquisitionGeometry.CHANNEL ,
                  AcquisitionGeometry.ANGLE , AcquisitionGeometry.VERTICAL ,
@@ -767,18 +766,18 @@ class TestDataContainer(CCPiTestClass):
 
         self.assertListEqual(new_order, list(dc.dimension_labels))
 
-        ss1 = dc.get_slice(vertical = 0)
+        ss1 = dc.get_slice(vertical=0)
 
         self.assertListEqual([AcquisitionGeometry.HORIZONTAL ,
                  AcquisitionGeometry.CHANNEL  ,
                  AcquisitionGeometry.ANGLE], list(ss1.dimension_labels))
         
-        ss2 = dc.get_slice(vertical = 0, channel=0)
+        ss2 = dc.get_slice(vertical=0, channel=0)
         self.assertListEqual([AcquisitionGeometry.HORIZONTAL ,
                  AcquisitionGeometry.ANGLE], list(ss2.dimension_labels))
         
         # Check we can get slice still even if force parameter is passed:
-        ss3 = dc.get_slice(vertical = 0, channel=0, force=True)
+        ss3 = dc.get_slice(vertical=0, channel=0, force=True)
         self.assertListEqual([AcquisitionGeometry.HORIZONTAL ,
                     AcquisitionGeometry.ANGLE], list(ss3.dimension_labels))
         


### PR DESCRIPTION
## Describe your changes
Fixes bug which wouldn't allow 3D DataContainers to be viewed with show2D. 
Note, this was just a bug with DataContainers, not with ImageData or AcquisitionData

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*
Tested with a 3D datacontainer
I could not see that there are any unit tests for show2D?
Added unit tests checking `get_slice` with a DataContainer.

## Link relevant issues
Fixes #1536 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
