### PR TITLE
fix KL njit and gradient numba without mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
   - Add docker image, test & push to [`ghcr.io/tomographicimaging/cil`](https://github.com/TomographicImaging/CIL/pkgs/container/cil)
   - Quality metrics have added mask option
   - Bug fix for norm of CompositionOperator
-  - Functions updated to use sapyb 
+  - Functions updated to use sapyb
+  - Fix KullbackLeibler numba gradient ignoring mask
 
 * 23.1.0
   - Fix bug in IndicatorBox proximal_conjugate

--- a/Wrappers/Python/cil/optimisation/functions/KullbackLeibler.py
+++ b/Wrappers/Python/cil/optimisation/functions/KullbackLeibler.py
@@ -24,7 +24,7 @@ import scipy.special
 import logging
 
 try:
-    from numba import jit, prange
+    from numba import njit, prange
     has_numba = True
 except ImportError as ie:
     has_numba = False
@@ -236,7 +236,7 @@ class KullbackLeibler_numpy(KullbackLeibler):
 
 if has_numba:
     
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_proximal(x,b, tau, out, eta):
         for i in prange(x.size):
             X = x.flat[i]
@@ -247,7 +247,7 @@ if has_numba:
                     (4. * tau * b.flat[i]) 
                 )
             )
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_proximal_arr(x,b, tau, out, eta):
         for i in prange(x.size):
             t = tau.flat[i]
@@ -259,7 +259,7 @@ if has_numba:
                     (4. * t * b.flat[i]) 
                 )
             )
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_proximal_mask(x,b, tau, out, eta, mask):
         for i in prange(x.size):
             if mask.flat[i] > 0:
@@ -271,7 +271,7 @@ if has_numba:
                         (4. * tau * b.flat[i]) 
                     )
                 )
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_proximal_arr_mask(x,b, tau, out, eta, mask):
         for i in prange(x.size):
             if mask.flat[i] > 0:
@@ -285,7 +285,7 @@ if has_numba:
                     )
                 )
     # proximal conjugate
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_proximal_conjugate_arr(x, b, eta, tau, out):
         #z = x + tau * self.bnoise
         #return 0.5*((z + 1) - ((z-1)**2 + 4 * tau * self.b).sqrt())
@@ -296,7 +296,7 @@ if has_numba:
                 (z + 1) - numpy.sqrt((z-1)*(z-1) + 4 * t * b.flat[i])
                 )
         
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_proximal_conjugate(x, b, eta, tau, out):
         #z = x + tau * self.bnoise
         #return 0.5*((z + 1) - ((z-1)**2 + 4 * tau * self.b).sqrt())
@@ -306,7 +306,7 @@ if has_numba:
                 (z + 1) - numpy.sqrt((z-1)*(z-1) + 4 * tau * b.flat[i])
                 )
 
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_proximal_conjugate_arr_mask(x, b, eta, tau, out, mask):
         #z = x + tau * self.bnoise
         #return 0.5*((z + 1) - ((z-1)**2 + 4 * tau * self.b).sqrt())
@@ -318,7 +318,7 @@ if has_numba:
                     (z + 1) - numpy.sqrt((z-1)*(z-1) + 4 * t * b.flat[i])
                     )
         
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_proximal_conjugate_mask(x, b, eta, tau, out, mask):
         #z = x + tau * self.bnoise
         #return 0.5*((z + 1) - ((z-1)**2 + 4 * tau * self.b).sqrt())
@@ -329,18 +329,18 @@ if has_numba:
                     (z + 1) - numpy.sqrt((z-1)*(z-1) + 4 * tau * b.flat[i])
                     )
     # gradient
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_gradient(x, b, out, eta):
         for i in prange(x.size):
             out.flat[i] = 1 - b.flat[i]/(x.flat[i] + eta.flat[i])
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_gradient_mask(x, b, out, eta, mask):
         for i in prange(x.size):
             if mask.flat[i] > 0:
                 out.flat[i] = 1 - b.flat[i]/(x.flat[i] + eta.flat[i])
     
     # KL divergence
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_div(x, y, eta):
         accumulator = 0.
         for i in prange(x.size):
@@ -356,7 +356,7 @@ if has_numba:
                 # out.flat[i] = numpy.inf
                 return numpy.inf
         return accumulator
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_div_mask(x, y, eta, mask):
         accumulator = 0.
         for i in prange(x.size):
@@ -375,7 +375,7 @@ if has_numba:
         return accumulator
 
     # convex conjugate
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_convex_conjugate(x, b, eta):
         accumulator = 0.
         for i in prange(x.size):
@@ -389,7 +389,7 @@ if has_numba:
                 # else xlogy is 0 so it doesn't add to the accumulator
                 accumulator += eta.flat[i] * x_f
         return - accumulator
-    @jit(parallel=True, nopython=True)
+    @njit(parallel=True)
     def kl_convex_conjugate_mask(x, b, eta, mask):
         accumulator = 0.
         j = 0
@@ -455,7 +455,8 @@ class KullbackLeibler_numba(KullbackLeibler):
 
         if self.mask is not None:
             kl_gradient_mask(x.as_array(), self.b.as_array(), out_np, self.eta.as_array(), self.mask)         
-        kl_gradient(x.as_array(), self.b.as_array(), out_np, self.eta.as_array())            
+        else:
+            kl_gradient(x.as_array(), self.b.as_array(), out_np, self.eta.as_array())            
         out.fill(out_np)
 
         if should_return:

--- a/Wrappers/Python/test/test_function_KullbackLeibler.py
+++ b/Wrappers/Python/test/test_function_KullbackLeibler.py
@@ -118,6 +118,7 @@ class TestKullbackLeiblerNumpy(unittest.TestCase):
         res2 = self.f.convex_conjugate(self.u1)
         numpy.testing.assert_equal(res1, res2)
 
+@unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
 class TestKullbackLeiblerNumba(unittest.TestCase):
     def setUp(self):
         #numpy.random.seed(1)
@@ -164,8 +165,6 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         self.f_on_mask = f_on_mask
         self.u1_on_mask = u1_on_mask
 
-
-    @unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
     def test_KullbackLeibler_numba_call(self):
         f = self.f
         f_np = self.f_np
@@ -174,8 +173,6 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
 
         numpy.testing.assert_allclose(f(u1), f_np(u1),  rtol=1e-5)
 
-
-    @unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
     def test_KullbackLeibler_numba_call_mask(self):
         f = self.f
         f_np = self.f_np
@@ -191,8 +188,6 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
 
         numpy.testing.assert_allclose(f_mask(u1) + f_mask_c(u1), f(u1),  rtol=1e-5)
 
-
-    @unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
     def test_KullbackLeibler_numba_proximal(self):
         f = self.f
         f_np = self.f_np
@@ -203,9 +198,7 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
                                       f_np.proximal(u1,tau=tau).as_array(), rtol=7e-3)
         numpy.testing.assert_array_almost_equal(f.proximal(u1,tau=tau).as_array(),
         f_np.proximal(u1,tau=tau).as_array(), decimal=4)
-        
-    
-    @unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
+
     def test_KullbackLeibler_numba_proximal_arr(self):
         f = self.f
         f_np = self.f_np
@@ -219,8 +212,6 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         numpy.testing.assert_array_almost_equal(f.proximal(u1,tau=self.tau).as_array(),
                                                 f.proximal(u1,tau=tau).as_array(), decimal=4)
 
-
-    @unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
     def test_KullbackLeibler_numba_gradient(self):
         f = self.f
         f_np = self.f_np
@@ -230,7 +221,6 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         numpy.testing.assert_allclose(f.gradient(u1).as_array(), f_np.gradient(u1).as_array(), rtol=1e-3)
 
 
-    @unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
     def test_KullbackLeibler_numba_convex_conjugate(self):
         f = self.f
         f_np = self.f_np
@@ -239,8 +229,6 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
 
         numpy.testing.assert_allclose(f.convex_conjugate(u1), f_np.convex_conjugate(u1), rtol=1e-3)
 
-
-    @unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
     def test_KullbackLeibler_numba_proximal_conjugate_arr(self):
         f = self.f
         f_np = self.f_np
@@ -250,8 +238,6 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         numpy.testing.assert_allclose(f.proximal_conjugate(u1,tau=tau).as_array(),
                         f_np.proximal_conjugate(u1,tau=tau).as_array(), rtol=1e-3)
 
-
-    @unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
     def test_KullbackLeibler_numba_convex_conjugate_mask(self):
         f = self.f
         tau = self.tau
@@ -268,8 +254,6 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
             f_mask.convex_conjugate(u1) + f_mask_c.convex_conjugate(u1) ,\
                  rtol=1e-3)
 
-
-    @unittest.skipUnless(has_numba, "Skipping because numba isn't installed")
     def test_KullbackLeibler_numba_proximal_conjugate_mask(self):
         f = self.f
         f_mask = self.f_mask

--- a/Wrappers/Python/test/test_function_KullbackLeibler.py
+++ b/Wrappers/Python/test/test_function_KullbackLeibler.py
@@ -1,22 +1,16 @@
-# -*- coding: utf-8 -*-
 #  Copyright 2022 United Kingdom Research and Innovation
 #  Copyright 2022 The University of Manchester
-#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
-
 import unittest
 from cil.optimisation.functions import KullbackLeibler
 from cil.framework import ImageGeometry
@@ -30,109 +24,108 @@ if has_numba:
     import numba
 
 class TestKullbackLeiblerNumpy(unittest.TestCase):
-    
+
     def setUp(self):
-        
+
         M, N, K =  2, 3, 4
         self.ig = ImageGeometry(N, M, K)
-        
-        self.u1 = self.ig.allocate('random', seed = 500)    
+
+        self.u1 = self.ig.allocate('random', seed = 500)
         self.g1 = self.ig.allocate('random', seed = 100)
         self.b1 = self.ig.allocate('random', seed = 1000)
 
-        self.f = KullbackLeibler(b = self.g1, backend='numpy')  
-        self.f1 = KullbackLeibler(b = self.g1, eta = self.b1,  backend='numpy') 
+        self.f = KullbackLeibler(b = self.g1, backend='numpy')
+        self.f1 = KullbackLeibler(b = self.g1, eta = self.b1,  backend='numpy')
         self.tau = 400.4
 
     def test_signature(self):
 
         # with no data
         with self.assertRaises(TypeError):
-            f = KullbackLeibler()   
-            
-        with self.assertRaises(ValueError):        
+            f = KullbackLeibler()
+
+        with self.assertRaises(ValueError):
             f = KullbackLeibler(b=-1*self.g1)
 
     def test_call_method(self):
 
-        # without eta      
-        numpy.testing.assert_allclose(0.0, self.f(self.g1))  
+        # without eta
+        numpy.testing.assert_allclose(0.0, self.f(self.g1))
 
         # with eta
         tmp_sum = (self.u1 + self.f1.eta).as_array()
         ind = tmp_sum >= 0
-        tmp = scipy.special.kl_div(self.f1.b.as_array()[ind], tmp_sum[ind])                 
-        numpy.testing.assert_allclose(self.f1(self.u1), numpy.sum(tmp) )          
+        tmp = scipy.special.kl_div(self.f1.b.as_array()[ind], tmp_sum[ind])
+        numpy.testing.assert_allclose(self.f1(self.u1), numpy.sum(tmp) )
 
-    def test_gradient_method(self): 
+    def test_gradient_method(self):
 
         # without eta
         res1 = self.f.gradient(self.u1)
         res2 = self.u1.geometry.allocate()
-        self.f.gradient(self.u1, out = res2) 
-        numpy.testing.assert_allclose(res1.as_array(), res2.as_array())  
+        self.f.gradient(self.u1, out = res2)
+        numpy.testing.assert_allclose(res1.as_array(), res2.as_array())
 
         # with eta
         res1 = self.f1.gradient(self.u1)
         res2 = self.u1.geometry.allocate()
-        self.f1.gradient(self.u1, out = res2) 
-        numpy.testing.assert_allclose(res1.as_array(), res2.as_array())   
+        self.f1.gradient(self.u1, out = res2)
+        numpy.testing.assert_allclose(res1.as_array(), res2.as_array())
 
     def test_proximal_method(self):
 
         # without eta
         res1 = self.f.proximal(self.u1, self.tau)
-        res2 = self.u1.geometry.allocate()   
+        res2 = self.u1.geometry.allocate()
         self.f.proximal(self.u1, self.tau, out = res2)
-        numpy.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal=4)  
+        numpy.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal=4)
 
         # with eta
         res1 = self.f1.proximal(self.u1, self.tau)
-        res2 = self.u1.geometry.allocate()   
+        res2 = self.u1.geometry.allocate()
         self.f1.proximal(self.u1, self.tau, out = res2)
-        numpy.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal=4)          
+        numpy.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal=4)
 
     def test_proximal_conjugate_method(self):
 
         # without eta
         res1 = self.f.proximal_conjugate(self.u1, self.tau)
-        res2 = self.u1.geometry.allocate()   
+        res2 = self.u1.geometry.allocate()
         self.f.proximal_conjugate(self.u1, self.tau, out = res2)
-        numpy.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal=4)  
+        numpy.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal=4)
 
         # with eta
         res1 = self.f1.proximal_conjugate(self.u1, self.tau)
-        res2 = self.u1.geometry.allocate()   
+        res2 = self.u1.geometry.allocate()
         self.f1.proximal_conjugate(self.u1, self.tau, out = res2)
-        numpy.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal=4)          
+        numpy.testing.assert_array_almost_equal(res1.as_array(), res2.as_array(), decimal=4)
 
     def test_convex_conjugate_method(self):
 
         # with eta
         tmp = 1 - self.u1.as_array()
         ind = tmp>0
-        xlogy = - scipy.special.xlogy(self.f1.b.as_array()[ind], tmp[ind])          
-        res1 = numpy.sum(xlogy) - self.f1.eta.dot(self.u1)                
-        res2 = self.f1.convex_conjugate(self.u1)  
-        numpy.testing.assert_equal(res1, res2)   
+        xlogy = - scipy.special.xlogy(self.f1.b.as_array()[ind], tmp[ind])
+        res1 = numpy.sum(xlogy) - self.f1.eta.dot(self.u1)
+        res2 = self.f1.convex_conjugate(self.u1)
+        numpy.testing.assert_equal(res1, res2)
 
         # without eta
         tmp = 1 - self.u1.as_array()
         ind = tmp>0
-        xlogy = - scipy.special.xlogy(self.f.b.as_array()[ind], tmp[ind])          
-        res1 = numpy.sum(xlogy) - self.f.eta.dot(self.u1)                
-        res2 = self.f.convex_conjugate(self.u1)  
-        numpy.testing.assert_equal(res1, res2)   
+        xlogy = - scipy.special.xlogy(self.f.b.as_array()[ind], tmp[ind])
+        res1 = numpy.sum(xlogy) - self.f.eta.dot(self.u1)
+        res2 = self.f.convex_conjugate(self.u1)
+        numpy.testing.assert_equal(res1, res2)
 
 class TestKullbackLeiblerNumba(unittest.TestCase):
-
     def setUp(self):
         #numpy.random.seed(1)
         M, N, K =  2, 3, 4
         ig = ImageGeometry(N, M)
-        
+
         u1 = ig.allocate('random', seed = 500)
-        u1 = ig.allocate(0.2)  
+        u1 = ig.allocate(0.2)
         #g1 = ig.allocate('random', seed = 100)
         g1 = ig.allocate(1)
 
@@ -195,7 +188,7 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         f_on_mask = self.f_on_mask
         f_mask = self.f_mask
         f_mask_c = self.f_mask_c
-        
+
         numpy.testing.assert_allclose(f_mask(u1) + f_mask_c(u1), f(u1),  rtol=1e-5)
 
 
@@ -206,9 +199,9 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         tau = self.tau
         u1 = self.u1
 
-        numpy.testing.assert_allclose(f.proximal(u1,tau=tau).as_array(), 
+        numpy.testing.assert_allclose(f.proximal(u1,tau=tau).as_array(),
                                       f_np.proximal(u1,tau=tau).as_array(), rtol=7e-3)
-        numpy.testing.assert_array_almost_equal(f.proximal(u1,tau=tau).as_array(), 
+        numpy.testing.assert_array_almost_equal(f.proximal(u1,tau=tau).as_array(),
         f_np.proximal(u1,tau=tau).as_array(), decimal=4)
         
     
@@ -221,9 +214,9 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         u1 = self.u1
         a = f.proximal(u1,tau=self.tau)
         b = f.proximal(u1,tau=tau)
-        numpy.testing.assert_allclose(f.proximal(u1,tau=self.tau).as_array(), 
+        numpy.testing.assert_allclose(f.proximal(u1,tau=self.tau).as_array(),
                                       f.proximal(u1,tau=tau).as_array(), rtol=7e-3)
-        numpy.testing.assert_array_almost_equal(f.proximal(u1,tau=self.tau).as_array(), 
+        numpy.testing.assert_array_almost_equal(f.proximal(u1,tau=self.tau).as_array(),
                                                 f.proximal(u1,tau=tau).as_array(), decimal=4)
 
 
@@ -254,7 +247,7 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         tau = self.tau
         u1 = self.u1
 
-        numpy.testing.assert_allclose(f.proximal_conjugate(u1,tau=tau).as_array(), 
+        numpy.testing.assert_allclose(f.proximal_conjugate(u1,tau=tau).as_array(),
                         f_np.proximal_conjugate(u1,tau=tau).as_array(), rtol=1e-3)
 
 
@@ -271,7 +264,7 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         u1_on_mask = self.u1_on_mask
 
         numpy.testing.assert_allclose(
-            f.convex_conjugate(u1), 
+            f.convex_conjugate(u1),
             f_mask.convex_conjugate(u1) + f_mask_c.convex_conjugate(u1) ,\
                  rtol=1e-3)
 
@@ -290,18 +283,13 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
         out_c = x * 0
         f_mask_c.proximal_conjugate(x,tau=tau, out=out_c)
         f_mask.proximal_conjugate(x,tau=tau, out=out)
-        numpy.testing.assert_allclose(f.proximal_conjugate(x,tau=tau).as_array(), 
+        numpy.testing.assert_allclose(f.proximal_conjugate(x,tau=tau).as_array(),
                                       (out + out_c).as_array(), rtol=7e-3)
         # print ("f.prox_conj\n"       , f.proximal_conjugate(x,tau=tau).as_array())
         # print ("f_mask.prox_conj\n"  , out.as_array())
         # print ("f_mask_c.prox_conj\n", out_c.as_array())
         b = f_mask_c.proximal_conjugate(x,tau=tau)
         a = f_mask.proximal_conjugate(x,tau=tau)
-        numpy.testing.assert_allclose(f.proximal_conjugate(x,tau=tau).as_array(), 
+        numpy.testing.assert_allclose(f.proximal_conjugate(x,tau=tau).as_array(),
                                       (f_mask.proximal_conjugate(x,tau=tau) +\
                                       f_mask_c.proximal_conjugate(x, tau=tau)) .as_array(), rtol=7e-3)
-
-
-    def tearDown(self):
-        pass                       
-               

--- a/Wrappers/Python/test/test_function_KullbackLeibler.py
+++ b/Wrappers/Python/test/test_function_KullbackLeibler.py
@@ -213,13 +213,18 @@ class TestKullbackLeiblerNumba(unittest.TestCase):
                                                 f.proximal(u1,tau=tau).as_array(), decimal=4)
 
     def test_KullbackLeibler_numba_gradient(self):
-        f = self.f
-        f_np = self.f_np
-        tau = self.tau
-        u1 = self.u1
-
-        numpy.testing.assert_allclose(f.gradient(u1).as_array(), f_np.gradient(u1).as_array(), rtol=1e-3)
-
+        with self.subTest():
+            f = self.f
+            f_np = self.f_np
+            u1 = self.u1
+            grad_np = f_np.gradient(u1).as_array()
+            numpy.testing.assert_allclose(f.gradient(u1).as_array(), grad_np, rtol=1e-3)
+        with self.subTest("mask"):
+            f = self.f_mask
+            mask = self.mask>0
+            grad_mask = f.gradient(u1).as_array()
+            numpy.testing.assert_allclose(grad_mask[mask], grad_np[mask], rtol=1e-3)
+            self.assertFalse(grad_mask[~mask].any())
 
     def test_KullbackLeibler_numba_convex_conjugate(self):
         f = self.f


### PR DESCRIPTION
## Describe your changes

- fix numba KL `gradient` ignoring `mask`
- misc
  + `jit(nopython=True)` -> `njit`
  + DRY skip numba tests logic (move `unittest.skipUnless` to class-level)
  + whitespace fixes

## Describe any testing you have performed

Added regression test.

## Link relevant issues

closes #1541 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] ~I have added docstrings in line with the guidance in the developer guide~
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties