### PR TITLE
Changed ISTA and FISTA so that g can be None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Allow show2D to be used with 3D `DataContainer` instances
   - Update documentation for symmetrised gradient 
   - Added documentation for CompositionOperator and SumOperator
+  - Updated FISTA and ISTA algorithms to allow input functions to be None
 
 
 * 23.1.0

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -130,17 +130,17 @@ class ISTA(Algorithm):
         self.x = initial.copy()    
         
         if f is None:
-            f=ZeroFunction()
+            f = ZeroFunction()
             
             if step_size is None:
-                step_size=1   
+                step_size = 1   
                 
             if g is None: 
                 warnings.warn('You set both f and g to be None and thus the iterative method will not update and will remain fixed at the initial value.')
         self.f = f
         
         if g is None:
-            g=ZeroFunction()
+            g = ZeroFunction()
         self.g = g
 
         # set step_size

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -18,6 +18,7 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 from cil.optimisation.algorithms import Algorithm
+from cil.optimisation.functions import ZeroFunction
 import numpy
 import warnings
 import logging
@@ -57,8 +58,8 @@ class ISTA(Algorithm):
               Initial guess of ISTA.
     f : Function
         Differentiable function
-    g : Function
-        Convex function with *simple* proximal operator
+    g : Function or `None`
+        Convex function with *simple* proximal operator. If `None` is passed, the algorithm will use the ZeroFunction.
     step_size : positive :obj:`float`, default = None
                 Step size for the gradient step of ISTA.
                 The default :code:`step_size` is :math:`\frac{0.99 * 2}{L}.`
@@ -123,6 +124,8 @@ class ISTA(Algorithm):
         self.x_old = initial.copy()
         self.x = initial.copy()           
         self.f = f
+        if g is None:
+            g=ZeroFunction()
         self.g = g
 
         # set step_size
@@ -198,8 +201,8 @@ class FISTA(ISTA):
             Starting point of the algorithm
     f : Function
         Differentiable function
-    g : Function
-        Convex function with *simple* proximal operator
+    g : Function or `None`
+        Convex function with *simple* proximal operator. If `None` is passed, the algorithm will use the ZeroFunction.
     step_size : positive :obj:`float`, default = None
                 Step size for the gradient step of FISTA.
                 The default :code:`step_size` is :math:`\frac{1}{L}`.
@@ -245,6 +248,8 @@ class FISTA(ISTA):
 
         self.y = initial.copy()
         self.t = 1
+        if g is None:
+            g=ZeroFunction()
         super(FISTA, self).__init__(initial=initial, f=f, g=g, step_size=step_size, **kwargs)
               
     def update(self):

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -137,10 +137,6 @@ class ISTA(Algorithm):
         
         if f is None:
             f = ZeroFunction()
-            
-            if g is None: 
-                raise ValueError('You set both f and g to be None and thus the iterative method will not update and will remain fixed at the initial value.')
- 
                 
         self.f = f
         
@@ -148,6 +144,9 @@ class ISTA(Algorithm):
             g = ZeroFunction()
             
         self.g = g
+        
+        if isinstance(f, ZeroFunction) and isinstance(g, ZeroFunction):
+            raise ValueError('You set both f and g to be the ZeroFunction and thus the iterative method will not update and will remain fixed at the initial value.')
 
         # set step_size
         self.set_step_size(step_size=step_size)

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -128,11 +128,17 @@ class ISTA(Algorithm):
         self.initial = initial
         self.x_old = initial.copy()
         self.x = initial.copy()    
+        
         if f is None:
             f=ZeroFunction()
+            
             if step_size is None:
                 step_size=1   
+                
+            if g is None: 
+                warnings.warn('You set both f and g to be None and thus the iterative method will not update and will remain fixed at the initial value.')
         self.f = f
+        
         if g is None:
             g=ZeroFunction()
         self.g = g

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -104,11 +104,17 @@ class ISTA(Algorithm):
     def set_step_size(self, step_size):
         """ Set default step size.
         """
+    
         if step_size is None:
-            if isinstance(self.f.L, Number):
+            if isinstance(self.f, ZeroFunction):
+                self._step_size = 1
+                
+            elif isinstance(self.f.L, Number):
                 self._step_size = 0.99*2.0/self.f.L
+                
             else:
                 raise ValueError("Function f is not differentiable")
+            
         else:
             self._step_size = step_size            
         
@@ -132,20 +138,19 @@ class ISTA(Algorithm):
         if f is None:
             f = ZeroFunction()
             
-            if step_size is None:
-                step_size = 1   
-                
             if g is None: 
                 raise ValueError('You set both f and g to be None and thus the iterative method will not update and will remain fixed at the initial value.')
+ 
+                
         self.f = f
         
         if g is None:
             g = ZeroFunction()
+            
         self.g = g
 
         # set step_size
         self.set_step_size(step_size=step_size)
-        
         self.configured = True  
 
         logging.info("{} configured".format(self.__class__.__name__, ))
@@ -253,11 +258,18 @@ class FISTA(ISTA):
 
         """Set the default step size
         """
+
         if step_size is None:
-            if isinstance(self.f.L, Number):
+            
+            if isinstance(self.f, ZeroFunction):
+                self._step_size = 1
+                
+            elif isinstance(self.f.L, Number):
                 self._step_size = 1./self.f.L
+                
             else:
                 raise ValueError("Function f is not differentiable")
+            
         else:
             self._step_size = step_size
 

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -57,15 +57,20 @@ class ISTA(Algorithm):
     initial : DataContainer
               Initial guess of ISTA.
     f : Function
-        Differentiable function
+        Differentiable function. If `None` is passed, the algorithm will use the ZeroFunction.
     g : Function or `None`
         Convex function with *simple* proximal operator. If `None` is passed, the algorithm will use the ZeroFunction.
     step_size : positive :obj:`float`, default = None
                 Step size for the gradient step of ISTA.
-                The default :code:`step_size` is :math:`\frac{0.99 * 2}{L}.`
+                The default :code:`step_size` is :math:`\frac{1}{L}` or 1 if `f=None`.
     kwargs: Keyword arguments
         Arguments from the base class :class:`.Algorithm`.
 
+    Note
+    -----
+    If the function `g` is set to `None` or to the `ZeroFunction` then the ISTA algorithm is equivalent to Gradient Descent. 
+    
+    If the function `f` is set to `None` or to the `ZeroFunction` then the ISTA algorithm is equivalent to a Proximal Point Algorithm. 
 
     Examples
     --------
@@ -122,7 +127,11 @@ class ISTA(Algorithm):
         # set up ISTA      
         self.initial = initial
         self.x_old = initial.copy()
-        self.x = initial.copy()           
+        self.x = initial.copy()    
+        if f is None:
+            f=ZeroFunction()
+            if step_size is None:
+                step_size=1   
         self.f = f
         if g is None:
             g=ZeroFunction()
@@ -200,15 +209,20 @@ class FISTA(ISTA):
     initial : DataContainer
             Starting point of the algorithm
     f : Function
-        Differentiable function
+        Differentiable function.  If `None` is passed, the algorithm will use the ZeroFunction.
     g : Function or `None`
         Convex function with *simple* proximal operator. If `None` is passed, the algorithm will use the ZeroFunction.
     step_size : positive :obj:`float`, default = None
                 Step size for the gradient step of FISTA.
-                The default :code:`step_size` is :math:`\frac{1}{L}`.
+                The default :code:`step_size` is :math:`\frac{1}{L}` or 1 if `f=None`.
     kwargs: Keyword arguments
         Arguments from the base class :class:`.Algorithm`.
 
+    Note
+    -----
+    If the function `g` is set to `None` or to the `ZeroFunction` then the FISTA algorithm is equivalent to Accelerated Gradient Descent by Nesterov (:cite:`nesterov2003introductory` algorithm 2.2.9).
+
+    If the function `f` is set to `None` or to the `ZeroFunction` then the FISTA algorithm is equivalent to Guler's First Accelerated Proximal Point Method  (:cite:`guler1992new` sec 2).
 
     Examples
     --------
@@ -248,8 +262,6 @@ class FISTA(ISTA):
 
         self.y = initial.copy()
         self.t = 1
-        if g is None:
-            g=ZeroFunction()
         super(FISTA, self).__init__(initial=initial, f=f, g=g, step_size=step_size, **kwargs)
               
     def update(self):

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -136,7 +136,7 @@ class ISTA(Algorithm):
                 step_size = 1   
                 
             if g is None: 
-                warnings.warn('You set both f and g to be None and thus the iterative method will not update and will remain fixed at the initial value.')
+                raise ValueError('You set both f and g to be None and thus the iterative method will not update and will remain fixed at the initial value.')
         self.f = f
         
         if g is None:

--- a/Wrappers/Python/cil/recon/FBP.py
+++ b/Wrappers/Python/cil/recon/FBP.py
@@ -331,7 +331,7 @@ class FDK(GenericFilteredBackProjection):
         A description of the area/volume to reconstruct
     
     filter : string, numpy.ndarray, default='ram-lak'
-        The filter to be applied. Can be a string from: 'ram-lak' or a numpy array.
+        The filter to be applied. Can be a string from: {'`ram-lak`', '`shepp-logan`', '`cosine`', '`hamming`', '`hann`'}, or a numpy array.
 
     Example
     -------
@@ -430,7 +430,7 @@ class FBP(GenericFilteredBackProjection):
         A description of the area/volume to reconstruct
         
     filter : string, numpy.ndarray, default='ram-lak'
-        The filter to be applied. Can be a string from: 'ram-lak' or a numpy array.
+        The filter to be applied. Can be a string from: {'`ram-lak`', '`shepp-logan`', '`cosine`', '`hamming`', '`hann`'}, or a numpy array.
 
     backend : string
         The backend to use, can be 'astra' or 'tigre'. Data must be in the correct order for requested backend.

--- a/Wrappers/Python/test/test_ISTA_algorithm.py
+++ b/Wrappers/Python/test/test_ISTA_algorithm.py
@@ -48,7 +48,7 @@ class TestISTA(unittest.TestCase):
 
         self.f = LeastSquares(self.Aop, b=self.bop, c=0.5)
         self.g = ZeroFunction()
-        self.h=L1Norm()
+        self.h = L1Norm()
 
         self.ig = self.Aop.domain
 

--- a/Wrappers/Python/test/test_ISTA_algorithm.py
+++ b/Wrappers/Python/test/test_ISTA_algorithm.py
@@ -101,6 +101,28 @@ class TestISTA(unittest.TestCase):
         res1 = ista.objective[-1]
         res2 = self.f(x) + self.g(x)
         self.assertTrue( res1==res2) 
+        
+    def test_update_g_none(self):
+
+        # ista run 10 iteration
+        tmp_initial = self.ig.allocate()
+        ista = ISTA(initial = tmp_initial, f = self.f, g = None,  max_iteration=1)  
+        ista.run()
+
+        x = tmp_initial.copy()
+        x_old = tmp_initial.copy()
+
+        for _ in range(1):         
+            x = ista.g.proximal(x_old - (0.99*2/ista.f.L) * ista.f.gradient(x_old), (1./ista.f.L))
+            x_old.fill(x)
+
+        np.testing.assert_allclose(ista.solution.array, x.array, atol=1e-2)      
+    
+        # check objective
+        res1 = ista.objective[-1]
+        res2 = self.f(x) + self.g(x)
+        self.assertTrue( res1==res2) 
+        
 
     def test_provable_condition(self):
 

--- a/Wrappers/Python/test/test_ISTA_algorithm.py
+++ b/Wrappers/Python/test/test_ISTA_algorithm.py
@@ -21,7 +21,7 @@
 from cil.optimisation.algorithms import ISTA
 from cil.optimisation.operators import MatrixOperator
 from cil.framework import VectorData
-from cil.optimisation.functions import LeastSquares, ZeroFunction
+from cil.optimisation.functions import LeastSquares, ZeroFunction, L1Norm
 
 import numpy as np
 
@@ -48,6 +48,7 @@ class TestISTA(unittest.TestCase):
 
         self.f = LeastSquares(self.Aop, b=self.bop, c=0.5)
         self.g = ZeroFunction()
+        self.h=L1Norm()
 
         self.ig = self.Aop.domain
 
@@ -123,6 +124,27 @@ class TestISTA(unittest.TestCase):
         res2 = self.f(x) + self.g(x)
         self.assertTrue( res1==res2) 
         
+    def test_update_f_none(self):
+
+        # ista run 1 iteration
+        tmp_initial = self.ig.allocate()
+        ista = ISTA(initial = tmp_initial, f = None, g = self.h,  max_iteration=1)  
+        ista.run()
+
+        x = tmp_initial.copy()
+        x_old = tmp_initial.copy()
+
+        for _ in range(1):         
+            x = ista.g.proximal(x_old,ista.step_size)
+            x_old.fill(x)
+
+        np.testing.assert_allclose(ista.solution.array, x.array, atol=1e-2)      
+    
+        # check objective
+        res1 = ista.objective[-1]
+        res2 = self.h(x)
+        self.assertTrue( res1==res2) 
+
 
     def test_provable_condition(self):
 

--- a/Wrappers/Python/test/test_ISTA_algorithm.py
+++ b/Wrappers/Python/test/test_ISTA_algorithm.py
@@ -113,9 +113,9 @@ class TestISTA(unittest.TestCase):
         x = tmp_initial.copy()
         x_old = tmp_initial.copy()
 
-        for _ in range(1):         
-            x = ista.g.proximal(x_old - (0.99*2/ista.f.L) * ista.f.gradient(x_old), (1./ista.f.L))
-            x_old.fill(x)
+              
+        x = ista.g.proximal(x_old - (0.99*2/ista.f.L) * ista.f.gradient(x_old), (1./ista.f.L))
+        x_old.fill(x)
 
         np.testing.assert_allclose(ista.solution.array, x.array, atol=1e-2)      
     
@@ -145,6 +145,12 @@ class TestISTA(unittest.TestCase):
         res2 = self.h(x)
         self.assertTrue( res1==res2) 
 
+    def test_f_and_g_none(self):
+        tmp_initial = self.ig.allocate()
+        with self.assertRaises(ValueError):
+            ista = ISTA(initial = tmp_initial, f = None, g = None,  max_iteration=1)  
+        
+        
 
     def test_provable_condition(self):
 

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -235,11 +235,9 @@ class TestAlgorithms(CCPiTestClass):
         self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
         
         #Testing f and g is None 
-        with warnings.catch_warnings(record=True) as wa:
-            alg = FISTA(initial=initial, f=None, g=None, max_iteration=2, update_objective_interval=2)
-            assert "f and g to be None" in str(wa[0].message)         
-        alg.run(20, verbose=0)
-        self.assertNumpyArrayAlmostEqual(alg.x.as_array(), initial.as_array())
+        with self.assertRaises(ValueError):
+            alg = FISTA(initial=initial, f=None, g=None, max_iteration=2, update_objective_interval=2)         
+        
 
     def test_FISTA_update(self):
 

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -238,7 +238,8 @@ class TestAlgorithms(CCPiTestClass):
         with warnings.catch_warnings(record=True) as wa:
             alg = FISTA(initial=initial, f=None, g=None, max_iteration=2, update_objective_interval=2)
             assert "f and g to be None" in str(wa[0].message)         
-        
+        alg.run(20, verbose=0)
+        self.assertNumpyArrayAlmostEqual(alg.x.as_array(), initial.as_array())
 
     def test_FISTA_update(self):
 

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -219,6 +219,15 @@ class TestAlgorithms(CCPiTestClass):
 
         alg.run(20, verbose=0)
         self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
+        
+        #Testing g=None
+        alg = FISTA(initial=initial, f=norm2sq, g=None, max_iteration=2, update_objective_interval=2)
+        self.assertTrue(alg.max_iteration == 2)
+        self.assertTrue(alg.update_objective_interval==2)
+        alg.run(20, verbose=0)
+        self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
+        
+        
 
     def test_FISTA_update(self):
 

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -234,6 +234,11 @@ class TestAlgorithms(CCPiTestClass):
         alg.run(20, verbose=0)
         self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
         
+        #Testing f and g is None 
+        with warnings.catch_warnings(record=True) as wa:
+            alg = FISTA(initial=initial, f=None, g=None, max_iteration=2, update_objective_interval=2)
+            assert "f and g to be None" in str(wa[0].message)         
+        
 
     def test_FISTA_update(self):
 

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -227,6 +227,12 @@ class TestAlgorithms(CCPiTestClass):
         alg.run(20, verbose=0)
         self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
         
+        #Testing f=None
+        alg = FISTA(initial=initial, f=None, g=L1Norm(b=b), max_iteration=2, update_objective_interval=2)
+        self.assertTrue(alg.max_iteration == 2)
+        self.assertTrue(alg.update_objective_interval==2)
+        alg.run(20, verbose=0)
+        self.assertNumpyArrayAlmostEqual(alg.x.as_array(), b.as_array())
         
 
     def test_FISTA_update(self):

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -17,6 +17,30 @@
      Authors:
      CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
+
+
+@article{guler1992new,
+  title={New proximal point algorithms for convex minimization},
+  author={G{\"u}ler, Osman},
+  journal={SIAM Journal on Optimization},
+  volume={2},
+  number={4},
+  pages={649--664},
+  year={1992},
+  publisher={SIAM}
+}
+
+
+@book{nesterov2003introductory,
+  title={Introductory lectures on convex optimization: A basic course},
+  author={Nesterov, Yurii},
+  volume={87},
+  year={2003},
+  publisher={Springer Science \& Business Media}
+}
+
+
+
 @Article{CP2011,
 author={Chambolle, Antonin
 and Pock, Thomas},


### PR DESCRIPTION
## Describe your changes
Changed ISTA and FISTA so that g can be:
" g : Function or `None`
        Convex function with *simple* proximal operator. If `None` is passed, the algorithm will use the ZeroFunction."
   

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues
Closes  #1567

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
