### PR TITLE
fix missing ipps.h by pinning ipp

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,9 +69,9 @@ requirements:
     - vc 14         # [win]
     - cil-data
     - ripgrep
-    - ipp-include
-    - ipp-devel
-    - ipp
+    - ipp-include <2021.10
+    - ipp-devel <2021.10
+    - ipp <2021.10
 
   run:
     - python
@@ -89,7 +89,7 @@ requirements:
     - olefile >=0.46
     - pywavelets
     - cil-data >=21.3.0
-    - ipp
+    - ipp <2021.10
     - tqdm
     - numba
 

--- a/scripts/create_local_env_for_cil_development.sh
+++ b/scripts/create_local_env_for_cil_development.sh
@@ -44,4 +44,4 @@ set -x
 
 conda create --name $name cmake python=$python numpy=$numpy scipy matplotlib \
   h5py pillow libgcc-ng dxchange olefile pywavelets python-wget scikit-image \
-  packaging  numba ipp ipp-devel ipp-include tqdm -c conda-forge -c intel  -c defaults --override-channels
+  packaging  numba ipp'<2021.10' ipp-devel'<2021.10' ipp-include'<2021.10' tqdm -c conda-forge -c intel  -c defaults --override-channels

--- a/scripts/create_local_env_for_cil_development_tests.sh
+++ b/scripts/create_local_env_for_cil_development_tests.sh
@@ -45,7 +45,7 @@ ${conda_cmd} python=$python numpy=$numpy \
         cil-data tigre=2.4 ccpi-regulariser=22.0.0 tomophantom=2.0.0  astra-toolbox'>=1.9.9.dev5,<2.1' \
         cvxpy python-wget scikit-image packaging \
         cmake'>=3.16' setuptools  \
-        ipp-include ipp-devel ipp \
+        ipp-include'<2021.10' ipp-devel'<2021.10' ipp'<2021.10' \
         ipywidgets scipy matplotlib \
         h5py pillow libgcc-ng dxchange olefile pywavelets numba tqdm \
         -c conda-forge -c intel  -c ccpi/label/dev -c ccpi -c astra-toolbox -c astra-toolbox/label/dev \


### PR DESCRIPTION
## Describe your changes

In the last few days tests started failing due to `ipp=2021.10.0` (re)moving the `ipps.h` header.

Possible solutions:

- pin to `ipp=2021.9.0` (previous version, working)
- drop `ipps.h`?

## Describe any testing you have performed

Haven't fully tested, should check upstream (`ipp`) changelog in detail first. According to https://www.intel.com/content/www/us/en/docs/ipp/developer-guide-reference/2021-10/fftinit-r-fftinit-c.html, `ipps.h` should still exist in `2021.10`. Maybe it's a bug in their latest release?

## Link relevant issues


## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] ~I have added docstrings in line with the guidance in the developer guide~
- [x] ~I have implemented unit tests that cover any new or modified functionality~
- [ ] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties