### PR TITLE
docs: Fix jupyter extension load error

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ conda create --name cil -c conda-forge -c intel -c ccpi cil=23.1.0
 To install CIL and the additional packages and plugins needed to run the [CIL demos](https://github.com/TomographicImaging/CIL-Demos) install the environment with:
 
 ```sh
-conda create --name cil -c conda-forge -c intel -c ccpi cil=23.1.0 astra-toolbox tigre ccpi-regulariser tomophantom "ipywidgets<8"
+conda create --name cil -c conda-forge -c intel -c ccpi cil=23.1.0 astra-toolbox tigre ccpi-regulariser tomophantom "ipywidgets<8" "jupyterlab<4"
 ```
 
 where:


### PR DESCRIPTION
## Describe your changes

At the time of writing, the original installation command will install jupyterlab==4.0.9 where jupyter widgets (e.g. islicer) fail to load in [CIL-Demos](https://github.com/TomographicImaging/CIL-Demos).
This PR forces conda to install jupyterlab<4 so that widgets can be properly loaded.

## Describe any testing you have performed

I've confirmed that widgets properly display in the following environment:

```Dockerfile
FROM mambaorg/micromamba:1-alpine

RUN /bin/micromamba create --name cil -c conda-forge -c intel -c ccpi cil=23.1.0 tomophantom "ipywidgets<8" 'jupyterlab<4' && /bin/micromamba clean -a
RUN /bin/micromamba shell init -s bash

ENV ENV_NAME=cil
```

## Checklist when you are ready to request a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
