### PR TITLE
Crop reconstructed array if input is odd in RingRemover

### DIFF
--- a/Wrappers/Python/cil/processors/RingRemover.py
+++ b/Wrappers/Python/cil/processors/RingRemover.py
@@ -145,7 +145,9 @@ class RingRemover(Processor):
         Corrected 2D sinogram data (Numpy Array)
         
         '''              
-                            
+
+        original_extent = [slice(s) for s in ima.shape]
+
         # allocate cH, cV, cD
         Ch = [None]*decNum
         Cv = [None]*decNum
@@ -174,5 +176,7 @@ class RingRemover(Processor):
         for i in range(decNum-1,-1,-1):
             nima = nima[0:Ch[i].shape[0],0:Ch[i].shape[1]]
             nima = pywt.idwt2((nima,(Ch[i],Cv[i],Cd[i])),wname)
-            
-        return nima      
+        
+        nima_crop = nima[original_extent[0], original_extent[1]]
+
+        return nima_crop


### PR DESCRIPTION
## Describe your changes
RingRemover uses PyWavelets wavelet transform to filter for rings. After the wavelet decomposition, the reconstructed array is always even in size, even if the input array is odd.
Add a line to crop the reconstructed array.

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues
#1603 

## Checklist when you are ready to request a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties
