### PR TITLE
ZeroOperator no longer relies on the default of allocate 

### DIFF
--- a/Wrappers/Python/cil/optimisation/operators/ZeroOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/ZeroOperator.py
@@ -53,18 +53,18 @@ class ZeroOperator(LinearOperator):
         
         
         if out is None:
-            return self.range_geometry().allocate()
+            return self.range_geometry().allocate(value=0)
         else:
-            out.fill(self.range_geometry().allocate())
+            out.fill(self.range_geometry().allocate(value=0))
     
     def adjoint(self,x, out=None):
         
         '''Returns O^{*}(y)'''        
         
         if out is None:
-            return self.domain_geometry().allocate()
+            return self.domain_geometry().allocate(value=0)
         else:
-            out.fill(self.domain_geometry().allocate())
+            out.fill(self.domain_geometry().allocate(value=0))
         
     def calculate_norm(self, **kwargs):
         

--- a/Wrappers/Python/test/test_Operator.py
+++ b/Wrappers/Python/test/test_Operator.py
@@ -75,6 +75,20 @@ class TestOperator(CCPiTestClass):
         A.adjoint(res1, out = out2)
         self.assertNumpyArrayAlmostEqual(res3.as_array(), out2.as_array(), decimal=4)
     
+    def test_ZeroOperator(self):
+        ig = ImageGeometry(10,20,30)
+        img = ig.allocate(3)
+        out=ig.allocate(0)
+        op1=ZeroOperator(ig)
+        self.assertNumpyArrayEqual(op1.direct(img).array,out.array)
+        self.assertNumpyArrayEqual(op1.adjoint(img).array,out.array)
+        ig2 = ImageGeometry(10,15,30)
+        out2=ig2.allocate(0)
+        img2=ig2.allocate(5)
+        op2=ZeroOperator(ig, ig2)
+        self.assertNumpyArrayEqual(op2.direct(img).array,out2.array)
+        self.assertNumpyArrayEqual(op2.adjoint(img2).array,out.array)
+        self.assertEqual(op2.calculate_norm(),0)
 
     def test_ScaledOperator(self):
         ig = ImageGeometry(10,20,30)


### PR DESCRIPTION
## Describe your changes
ZeroOperator no longer relies on the default of allocate. 
Added unit tests for the ZeroOperator. 

## Link relevant issues
Closes #1602

## Checklist when you are ready to request a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties
