### PR TITLE
CentreOfRotationCorrector xcorrelation find projections over 180 degrees

### DIFF
--- a/Wrappers/Python/cil/processors/CofR_xcorrelation.py
+++ b/Wrappers/Python/cil/processors/CofR_xcorrelation.py
@@ -109,9 +109,19 @@ class CofR_xcorrelation(Processor):
 
             target -= 360     
 
-        ind = np.abs(angles_deg - target).argmin()
-        
-        ang_diff = abs(angles_deg[ind] - angles_deg[0])
+        ind1 = np.abs(angles_deg - target).argmin()
+        ang_diff1 = abs(angles_deg[ind1] - angles_deg[0])
+
+        ind2 = np.abs(angles_deg - target+360).argmin() 
+        ang_diff2 = abs(angles_deg[ind2] - angles_deg[0])
+
+        if abs(ang_diff1-180)>abs(ang_diff2-180):
+            ind = ind2
+            ang_diff = ang_diff2
+        else:
+            ind = ind1
+            ang_diff = ang_diff1
+
         if abs(ang_diff-180) > self.ang_tol:
             raise ValueError('Method requires projections at 180 +/- {0} degrees interval, got {1}.\nPick a different initial projection or increase the angular tolerance `ang_tol`.'.format(self.ang_tol, ang_diff))
 


### PR DESCRIPTION
## Describe your changes
CentreOfRotationCorrector xcorrelation method tries to find the projection closest to 180 degrees away from a specified projection, within specified angular tolerance
If the target projection is >180 degrees, it doesn't find projections less than 180 degrees because all angles are shifted into -180 to 180 and the calculation to find the closest angle doesn't consider projections -180->180 to be close to each other.
Find projection closest to +180 including projections above 180 degrees by also consider -180->180

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues
#1619 

## Checklist when you are ready to request a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties
