### PR TITLE
`WaveletOperator` fixes for odd-sized inputs and 1D (`VectorGeometry`)

### DIFF
--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -104,7 +104,8 @@ class WaveletOperator(LinearOperator):
                 range_geometry.voxel_num_x = range_shape[1]
                 range_geometry.voxel_num_y = range_shape[0]
             elif len(range_shape) == 1:
-                range_geometry.voxel_num_x = range_shape[0]
+                range_geometry.voxel_num_x = range_shape[0] # Not sure if this is needed
+                range_geometry.length = range_shape[0] # This is unique to vector geometry
                 range_geometry.shape = (range_shape[0],)
             else:
                 raise AttributeError(f"Dimension of range_geometry can be at most 3. Now it is {len(range_shape)}!")

--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -93,7 +93,7 @@ class WaveletOperator(LinearOperator):
             if hasattr(range_geometry, 'channels'):
                 if range_geometry.channels > 1:
                     range_geometry.channels = range_shape[0]
-                    range_shape = range_shape[1:]
+                    range_shape = range_shape[1:] # Remove channels temporarily
 
             
             if len(range_shape) == 3:
@@ -106,7 +106,6 @@ class WaveletOperator(LinearOperator):
             elif len(range_shape) == 1:
                 range_geometry.voxel_num_x = range_shape[0] # Not sure if this is needed
                 range_geometry.length = range_shape[0] # This is unique to vector geometry
-                range_geometry.shape = (range_shape[0],)
             else:
                 raise AttributeError(f"Dimension of range_geometry can be at most 3. Now it is {len(range_shape)}!")
                     
@@ -172,7 +171,7 @@ class WaveletOperator(LinearOperator):
         x = pywt.waverecn(coeffs, wavelet=self.wname, axes=self.axes)
 
         # Need to slice the output in case original size is of odd length
-        org_size = [slice(i) for i in self.domain_geometry().shape]
+        org_size = tuple(slice(i) for i in self.domain_geometry().shape)
 
         if out is None:
             ret = self.domain_geometry().allocate()


### PR DESCRIPTION
## Describe changes
- In `adjoint`, after the PyWavelet reconstruction, the array is always cut to correct size in case the `domain_geometry` is of odd size. The tuple of slices `org_size` could be created during initialization as well.
    - Channels should work as is, even if they have odd length
- When initializing the `range_geometry` for 1D (`VectorGeometry`) data, the correct shape parameters are given.
    - Channels most likely will not work but I do not know if that behaviour is supported anyways.
- Cleaned some old comments and added few new ones, nothing major


## Describe any testing you have performed
- No proper testing, just some of my own experiments.
- The `WaveletOperator` should have a proper tests built at some point because there are so many things that can go wrong. For example
    - Check that the dimensions of input and output are correct
    - Check that odd sized arrays behave correctly
    - Check that decomposing different axes works correctly


## Link relevant issues
- All issues related to too big decomposition level are left to PyWavelets to handle. There should be a warning if very long filters are used with too small data / too big decomposition level, because this leads to nonsense coefficients.
- In addition to `axes` for choosing the dimensions the operator acts on, there should be string-based `correlation` parameter which would define the `axes` similar to `GradientOperator`

## Checklist when you are ready to request a review

- [x] I have no idea what I am doing
