### PR TITLE
Missing wavelet adjoint in the `proximal` of `WaveletNorm` 

### DIFF
--- a/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
+++ b/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
@@ -113,5 +113,6 @@ class WaveletNorm(Function):
                             
         """  
         y = self.W.direct(x)
-        return self.l1norm.proximal(y, tau, out)
+        self.l1norm.proximal(y, tau, out=y)
+        return self.W.adjoint(y, out)
 

--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -104,7 +104,8 @@ class WaveletOperator(LinearOperator):
                 range_geometry.voxel_num_x = range_shape[1]
                 range_geometry.voxel_num_y = range_shape[0]
             elif len(range_shape) == 1:
-                range_geometry.voxel_num_x = range_shape[0]
+                range_geometry.voxel_num_x = range_shape[0] # Not sure if this is needed
+                range_geometry.length = range_shape[0] # This is unique to vector geometry
                 range_geometry.shape = (range_shape[0],)
             else:
                 raise AttributeError(f"Dimension of range_geometry can be at most 3. Now it is {len(range_shape)}!")

--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -93,7 +93,7 @@ class WaveletOperator(LinearOperator):
             if hasattr(range_geometry, 'channels'):
                 if range_geometry.channels > 1:
                     range_geometry.channels = range_shape[0]
-                    range_shape = range_shape[1:]
+                    range_shape = range_shape[1:] # Remove channels temporarily
 
             
             if len(range_shape) == 3:
@@ -106,7 +106,6 @@ class WaveletOperator(LinearOperator):
             elif len(range_shape) == 1:
                 range_geometry.voxel_num_x = range_shape[0] # Not sure if this is needed
                 range_geometry.length = range_shape[0] # This is unique to vector geometry
-                range_geometry.shape = (range_shape[0],)
             else:
                 raise AttributeError(f"Dimension of range_geometry can be at most 3. Now it is {len(range_shape)}!")
                     
@@ -172,7 +171,7 @@ class WaveletOperator(LinearOperator):
         x = pywt.waverecn(coeffs, wavelet=self.wname, axes=self.axes)
 
         # Need to slice the output in case original size is of odd length
-        org_size = [slice(i) for i in self.domain_geometry().shape]
+        org_size = tuple(slice(i) for i in self.domain_geometry().shape)
 
         if out is None:
             ret = self.domain_geometry().allocate()


### PR DESCRIPTION
## Describe your changes
Added missing `W.adjoint(y)` to the `proximal` of `WaveletOperator`

## Describe any testing you have performed
- None, but I think it very interesting that this passed the existing tests. I think it might be due to the fact that the tests were done using `IdentityOperator`. With most `WaveletOperator`s this would have caused an error as the array sizes would not match.
