### PR TITLE
Padding and correlation options for `WaveletOperator` + check for `range_geometry` size

### DIFF
--- a/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
+++ b/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
@@ -113,5 +113,6 @@ class WaveletNorm(Function):
                             
         """  
         y = self.W.direct(x)
-        return self.l1norm.proximal(y, tau, out)
+        self.l1norm.proximal(y, tau, out=y)
+        return self.W.adjoint(y, out)
 

--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -104,7 +104,8 @@ class WaveletOperator(LinearOperator):
                 range_geometry.voxel_num_x = range_shape[1]
                 range_geometry.voxel_num_y = range_shape[0]
             elif len(range_shape) == 1:
-                range_geometry.voxel_num_x = range_shape[0]
+                range_geometry.voxel_num_x = range_shape[0] # Not sure if this is needed
+                range_geometry.length = range_shape[0] # This is unique to vector geometry
                 range_geometry.shape = (range_shape[0],)
             else:
                 raise AttributeError(f"Dimension of range_geometry can be at most 3. Now it is {len(range_shape)}!")

--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -93,7 +93,7 @@ class WaveletOperator(LinearOperator):
             if hasattr(range_geometry, 'channels'):
                 if range_geometry.channels > 1:
                     range_geometry.channels = range_shape[0]
-                    range_shape = range_shape[1:]
+                    range_shape = range_shape[1:] # Remove channels temporarily
 
             
             if len(range_shape) == 3:
@@ -106,7 +106,6 @@ class WaveletOperator(LinearOperator):
             elif len(range_shape) == 1:
                 range_geometry.voxel_num_x = range_shape[0] # Not sure if this is needed
                 range_geometry.length = range_shape[0] # This is unique to vector geometry
-                range_geometry.shape = (range_shape[0],)
             else:
                 raise AttributeError(f"Dimension of range_geometry can be at most 3. Now it is {len(range_shape)}!")
                     
@@ -172,7 +171,7 @@ class WaveletOperator(LinearOperator):
         x = pywt.waverecn(coeffs, wavelet=self.wname, axes=self.axes)
 
         # Need to slice the output in case original size is of odd length
-        org_size = [slice(i) for i in self.domain_geometry().shape]
+        org_size = tuple(slice(i) for i in self.domain_geometry().shape)
 
         if out is None:
             ret = self.domain_geometry().allocate()


### PR DESCRIPTION
## Describe your changes
- Added option to specify convolution padding mode via the keyword `bnd_cond` similar to `GradientOperator`. This just applies the existing options from pywt.
- Added option to specify `axes` using the `correlation` keyword similar to `GradientOperator`. This sets the `axes` unless `axes` is already specified, which takes priority. It also gives errors and warnings for nonsense choices.
- The size of the `range_geometry` is now checked upon initialization to make sure the wavelet coefficients fit.
- Some small fixes and comments. Mostly for `VectorGeometry` which has so many weird behaviours such as not setting the shape automatically. Also the special option for setting 1D domain geometry has been removed because it was pointless.

## Describe any testing you have performed
- None

## Describe any testing you wish to be implemented :)
- The range_geometry size checking does check for problems but these should be tested for:
    - Use giving wrong size range should give error
    - Not decomposing all dimensions (either via `axes` or `correlation`) should keep those dimensions same size as input
- `correlation` and `axes` are also checked for clashes and overall viability
    - Correlation for `Channels` should not work with data without channels
    - Correlation with 1D data should always give error
    - What happens if user labels 1D data to `channel` or one of the dimensions in 2D data?

## Link relevant issues
- `correlation` keyword due to [this comment](https://github.com/TomographicImaging/CIL/pull/1615#discussion_r1420267923) in #1615
- Similar reason for `bnd_cond`, in particular the funny name
- Problems where user give incompatible range size and only notice when the operator is applied.

