### PR TITLE
Wavelet-related tests and corresponding fixes to WaveletOperator and WaveletNorm

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -43,7 +43,6 @@ Laura Murgatroyd (2021 - present) - 1
 Evelina Ametova (2018-2020) - 3, (2020-2021) - 6 
 Margaret Duff (2023 - present) - 1
 Hannah Robarts (2023 - present) - 1 
-Tommi Heikkila (2023 - present) - 11
 
 CIL Contributors:
 Srikanth Nagella (2017-2018) - 1

--- a/Wrappers/Python/cil/optimisation/functions/L1Norm.py
+++ b/Wrappers/Python/cil/optimisation/functions/L1Norm.py
@@ -39,6 +39,12 @@ def soft_shrinkage(x, tau, out=None):
     """
 
     should_return = False
+    # get the sign of the input
+    if x.dtype in [np.csingle, np.cdouble, np.clongdouble]:
+        dsign = np.exp(1j*np.angle(x.as_array()))
+    else:
+        dsign = x.sign()
+ 
     if out is None:
         if x.dtype in [np.csingle, np.cdouble, np.clongdouble]:
             out = x * 0
@@ -58,15 +64,10 @@ def soft_shrinkage(x, tau, out=None):
             x.abs(out = out)
     out -= tau
     out.maximum(0, out = out)
-    if x.dtype in [np.csingle, np.cdouble, np.clongdouble]:
-        out *= np.exp(1j*np.angle(x.as_array()))
-        
-    else:
-        out *= x.sign()
+    out *= dsign
     
-
     if should_return:
-        return out        
+        return out              
 
 class L1Norm(Function):
     r"""L1Norm function

--- a/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
+++ b/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
@@ -20,6 +20,7 @@
 from cil.optimisation.functions import Function, L1Norm, soft_shrinkage
 
 import numpy as np
+import pywt
 ###############################################################################
 ###############################################################################
 ####################### L1-norm of Wavelet Coefficients #######################
@@ -49,6 +50,9 @@ class WaveletNorm(Function):
         [OPTIONAL PARAMETERS]
         :param weight: weight array matching the size of the wavelet coefficients
         '''
+        if not pywt.Wavelet(W.wname).orthogonal:
+            raise AttributeError(f"Invalid wavelet: `{W.wname}`. WaveletNorm is only defined for orthogonal wavelets!")
+
         super(WaveletNorm, self).__init__()
         self.W = W
         

--- a/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
+++ b/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
@@ -117,9 +117,6 @@ class WaveletNorm(Function):
                             
         """  
         y = self.W.direct(x)
-        y = self.l1norm.proximal(y, tau)
-        if out is None:
-            return self.W.adjoint(y)
-        else:
-            self.W.adjoint(y, out=out)
+        self.l1norm.proximal(y, tau, out=y)
+        self.W.adjoint(y, out)
 

--- a/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
+++ b/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
@@ -117,6 +117,9 @@ class WaveletNorm(Function):
                             
         """  
         y = self.W.direct(x)
-        self.l1norm.proximal(y, tau, out=y)
-        return self.W.adjoint(y, out)
+        y = self.l1norm.proximal(y, tau)
+        if out is None:
+            return self.W.adjoint(y)
+        else:
+            self.W.adjoint(y, out=out)
 

--- a/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
+++ b/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
@@ -113,5 +113,6 @@ class WaveletNorm(Function):
                             
         """  
         y = self.W.direct(x)
-        return self.l1norm.proximal(y, tau, out)
+        self.l1norm.proximal(y, tau, out=y)
+        return self.W.adjoint(y, out)
 

--- a/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
+++ b/Wrappers/Python/cil/optimisation/functions/WaveletNorm.py
@@ -118,5 +118,5 @@ class WaveletNorm(Function):
         """  
         y = self.W.direct(x)
         self.l1norm.proximal(y, tau, out=y)
-        self.W.adjoint(y, out)
+        return self.W.adjoint(y, out)
 

--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -104,7 +104,8 @@ class WaveletOperator(LinearOperator):
                 range_geometry.voxel_num_x = range_shape[1]
                 range_geometry.voxel_num_y = range_shape[0]
             elif len(range_shape) == 1:
-                range_geometry.voxel_num_x = range_shape[0]
+                range_geometry.voxel_num_x = range_shape[0] # Not sure if this is needed
+                range_geometry.length = range_shape[0] # This is unique to vector geometry
                 range_geometry.shape = (range_shape[0],)
             else:
                 raise AttributeError(f"Dimension of range_geometry can be at most 3. Now it is {len(range_shape)}!")

--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -93,7 +93,7 @@ class WaveletOperator(LinearOperator):
             if hasattr(range_geometry, 'channels'):
                 if range_geometry.channels > 1:
                     range_geometry.channels = range_shape[0]
-                    range_shape = range_shape[1:]
+                    range_shape = range_shape[1:] # Remove channels temporarily
 
             
             if len(range_shape) == 3:
@@ -106,7 +106,6 @@ class WaveletOperator(LinearOperator):
             elif len(range_shape) == 1:
                 range_geometry.voxel_num_x = range_shape[0] # Not sure if this is needed
                 range_geometry.length = range_shape[0] # This is unique to vector geometry
-                range_geometry.shape = (range_shape[0],)
             else:
                 raise AttributeError(f"Dimension of range_geometry can be at most 3. Now it is {len(range_shape)}!")
                     
@@ -172,7 +171,7 @@ class WaveletOperator(LinearOperator):
         x = pywt.waverecn(coeffs, wavelet=self.wname, axes=self.axes)
 
         # Need to slice the output in case original size is of odd length
-        org_size = [slice(i) for i in self.domain_geometry().shape]
+        org_size = tuple(slice(i) for i in self.domain_geometry().shape)
 
         if out is None:
             ret = self.domain_geometry().allocate()

--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -80,9 +80,9 @@ class WaveletOperator(LinearOperator):
         if axes is None and len(domain_geometry.shape) > 1:
             if self.correlation in [None, 'All']:
                 axes = None
-            elif self.correlation in ["Space", "Spatial"]:
+            elif self.correlation.lower() in ["space", "spatial"]:
                 axes = [i for i,l in enumerate(domain_geometry.dimension_labels) if l != 'channel']
-            elif self.correlation in ["Channels", "Channel"]:
+            elif self.correlation.lower() in ["channels", "channel"]:
                 axes = [i for i,l in enumerate(domain_geometry.dimension_labels) if l == 'channel']
             else:
                 raise AttributeError(f"Unknown correlation type: '{self.correlation}'")
@@ -140,7 +140,7 @@ class WaveletOperator(LinearOperator):
             else:
                 raise AttributeError(f"Spatial dimension of range_geometry can be at most 3. Now it is {len(range_shape)}!")
             
-        elif range_geometry.shape != range_shape:
+        elif (range_geometry.shape != range_shape).any():
             raise AttributeError(f"Size of the range geometry is {range_geometry.shape} but the size of the wavelet coefficient array must be {tuple(range_shape)}.")
                     
         super().__init__(domain_geometry=domain_geometry, range_geometry=range_geometry)

--- a/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/WaveletOperator.py
@@ -215,9 +215,9 @@ class WaveletOperator(LinearOperator):
             out.fill(x[org_size])
         
     def calculate_norm(self):
-        orthWavelets = pywt.wavelist(family=None, kind="discrete")
-        if self.wname in orthWavelets:
+        wavelet = pywt.Wavelet(self.wname)
+        if wavelet.orthogonal:
             norm = 1.0
         else:
-            raise AttributeError(f"Unkown wavelet: {self.wname}! Norm not known.")
+            norm = LinearOperator.calculate_norm(self)
         return norm

--- a/Wrappers/Python/test/test_wavelets.py
+++ b/Wrappers/Python/test/test_wavelets.py
@@ -1,0 +1,158 @@
+import unittest
+import numpy as np
+import warnings
+import pywt
+
+from cil.framework import ImageGeometry, VectorGeometry
+from cil.optimisation.functions import L1Norm, WaveletNorm
+from cil.optimisation.operators import WaveletOperator
+
+from testclass import CCPiTestClass
+
+def setUp(self):
+    np.random.seed(1)
+    print("Seed set")
+
+class TestWavelets(CCPiTestClass):
+
+    def test_WaveletOperator_dimensions(self):
+        m, n = 20, 21
+        wname = "haar"
+        level = 3
+        for dg in [ImageGeometry(voxel_num_x=m, voxel_num_y=n), VectorGeometry(m), VectorGeometry(n)]:
+            with self.subTest(msg=f"Failed for {dg.__class__.__name__} of size {dg.shape}", dg=dg):
+                x = dg.allocate('random')
+
+                W = WaveletOperator(dg, wname=wname, level=level)
+                rg = W.range_geometry() # Range
+                Wx = W.direct(x)
+                y = W.adjoint(Wx)
+
+                self.assertEqual(Wx.shape, rg.shape, msg="Coefficient array shape should match range_geometry")
+                self.assertEqual(y.shape, dg.shape, msg="Adjoint array shape should match domain_geometry")
+
+                # Reconstruction should be (almost) the original input
+                self.assertNumpyArrayAlmostEqual(x.as_array(), y.as_array())
+
+                self.assertRaises(AttributeError, WaveletOperator, dg, range_geometry=dg, wname='db2', msg="Geometry shape mismatch should raise error")
+
+    def test_wavelet_axes(self):
+        m, n = 20, 21
+        dg = ImageGeometry(voxel_num_x=m, voxel_num_y=n) # Domain
+        dg.channels = 32
+
+        # Give axes as range
+        W = WaveletOperator(dg, wname='db2', level=2, axes=range(1,3))
+        rg = W.range_geometry()
+
+        self.assertEqual(dg.shape[0], rg.shape[0], msg="Size of channels should remain unchanged")
+        self.assertLess(dg.shape[1:], rg.shape[1:], msg="Decomposed dimensions should get extended")
+
+        # Try each individual axis
+        for ax in range(3):
+            with self.subTest(msg=f"Failed for axis {ax}", ax=ax):
+                W = WaveletOperator(dg, wname='db2', level=2, axes=[ax])
+                rg = W.range_geometry()
+
+                self.assertEqual(dg.shape[not ax], rg.shape[not ax], msg="Size of other dimensions should remain unchanged")
+                self.assertEqual(dg.shape[ax] + 5, rg.shape[ax], msg="Decomposed dimension should get extended by 5 (when level=2)")
+
+    def test_wavelet_correlation(self):
+        m, n = 20, 21
+        dg = ImageGeometry(voxel_num_x=m, voxel_num_y=n) # Domain
+        
+        self.assertRaises(AttributeError, WaveletOperator, dg, wname='haar', correlation='channel', msg="Missing channels should raise error")
+
+        dg.channels = 32
+        self.assertRaises(AttributeError, WaveletOperator, dg, wname='haar', correlation='SPACEchannel', msg="Invalid correlation keyword should raise error")
+
+        W = WaveletOperator(dg, wname='db2', level=2, correlation='Space')
+        rg = W.range_geometry()
+        self.assertEqual(dg.shape[0], rg.shape[0], msg="Size of channels should remain unchanged")
+        self.assertLess(dg.shape[1:], rg.shape[1:], msg="Correlated dimensions should get extended")
+
+        self.assertWarns(UserWarning, WaveletOperator, dg, axes=[0], correlation='channel', msg="Defining both axes and correlation should give warning")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            W = WaveletOperator(dg, wname='db2', level=2, axes=[1], correlation='channel')
+        rg = W.range_geometry()
+
+        self.assertEqual(dg.shape[0], rg.shape[0], msg="Axes should be prioritized over correlation")
+
+    def test_wavelet_bnd_cond(self):
+        m, n = 20, 24
+        dg = ImageGeometry(voxel_num_x=m, voxel_num_y=n) # Domain
+        W = WaveletOperator(dg, wname='db2', level=2, bnd_cond='periodization') # Note: this is different from bnd_cond='periodic'
+        rg = W.range_geometry()
+
+        self.assertEqual(dg.shape, rg.shape, msg="Periodization convolution should require no padding")
+
+        x = dg.allocate('random')
+        c = rg.allocate('random')
+
+        ip1 = c.dot(W.direct(x))
+        ip2 = x.dot(W.adjoint(c))
+        M = x.norm() # Normalization
+        self.assertAlmostEqual(ip1/M, ip2/M, places=5, msg="Periodic convolution should be closest to true adjoint")
+
+    def test_wavelet_adjoint(self):
+        m, n = 48, 64
+        dg = ImageGeometry(voxel_num_x=m, voxel_num_y=n) # Domain
+        x = dg.allocate('random')
+        for wname in ['haar', 'db3', 'sym4', 'coif1', 'bior3.5', 'rbio3.5']:
+            with self.subTest(msg=f"Failed for wavelet {wname}", wname=wname):
+                if (not pywt.Wavelet(wname).orthogonal) and pywt.Wavelet(wname).biorthogonal:
+                    self.skipTest(f"Biorthogonal {wname} wavelet adjoint not implemented (yet)")
+
+                W = WaveletOperator(dg, wname=wname, level=2, bnd_cond='periodization') # Note: this is different from bnd_cond='periodic'
+                rg = W.range_geometry()
+                c = rg.allocate('random')
+
+                ip1 = c.dot(W.direct(x))
+                ip2 = x.dot(W.adjoint(c))
+                M = x.norm() # Normalization
+                self.assertAlmostEqual(ip1/M, ip2/M, places=5, msg="Periodic convolution should be closest to true adjoint")
+    
+    def test_WaveletNorm(self):
+        n = 20
+        wname = 'db2'
+        level = 2
+
+        dg = VectorGeometry(n)
+        W = WaveletOperator(dg, wname=wname, level=level)
+        WN = WaveletNorm(W)
+
+        x = dg.allocate('random')
+        Wx = W.direct(x)
+
+        self.assertAlmostEqual(WN(x), np.sum(Wx.abs().as_array()), msg="WaveletNorm should be the sum of absolute values of the wavelet coefficients")
+
+        y = W.adjoint(Wx)
+        tau = 0.0
+        prox = WN.proximal(x, tau=tau)
+
+        self.assertAlmostEqual(0, (prox - y).norm(), msg="Prox_{tau=0}(  ) should be (almost) the identity")
+        self.assertNumpyArrayAlmostEqual(y.as_array(), prox.as_array())
+
+        tau = 1.1
+        Wx /= Wx.abs().max() # Bound Wx to [-1, 1]
+        W.adjoint(Wx, out=y)
+        WN.proximal(y, tau=tau, out=prox)
+        self.assertNumpyArrayAlmostEqual(np.zeros(x.shape), prox.as_array())
+
+        # Test for sign problems in prox
+        prox = x.copy()
+        WN.proximal(prox, tau=tau, out=prox)
+        proxNeg = WN.proximal(-x, tau=tau)
+        self.assertNumpyArrayAlmostEqual(np.zeros(x.shape), (prox + proxNeg).as_array())
+
+        convConj = WN.convex_conjugate(1.2*y)
+        self.assertEqual(np.inf, convConj, msg="Some coefficient should be > 1")
+
+        convConj = WN.convex_conjugate(0.9*y)
+        self.assertEqual(0, convConj, msg="All coefficient should be < 1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Describe your changes
- `WaveletOperator`
  - Fixed some geometry checks
  - Correlation keywords are no longer case specific
  - Computes the norm for non-orthogonal wavelets as well (although this will be incorrect due to incorrect adjoint)
- `WaveletNorm`
  - Avoids proximal bug due to `out=in` (see: https://github.com/TomographicImaging/CIL/issues/1662#issue-2105775104)
  - Will raise error for non-orthogonal wavelets
- `test_wavelets.py`
  - Created a starting point for wavelet related tests, probably does not work in CIL straight away

## Describe any testing you have performed
- [x] Tests for variety of domain and range geometry sizes
  - [x] With different correlations (some 1D geometry + correlation tests missing but low priority)
  - [x] With different axes
  - [x] Odd and even sizes
  - [ ] Exhausting checks for different amount of padding when using different wavelets
- [x] Test for perfect reconstruction
  - [ ] Exhausting checks for different wavelets
  - [ ] Test some known signals
  - [ ] Test for some well known behaviour with different `bnd_cond`
- [x] Tests for adjoint (with `bnd_cond='periodization'` since it gives the most faithful adjoint
  - [x] Exhausting checks for different orthogonal wavelets (non-orthogonal wavelets skipped for now) 
  - [ ] Exhausting checks for non-orthogonal wavelets (skipped since adjoint is not properly implemented)
- [x] WaveletNorm value
- [x] Proximal values for different tau
  - [x] Extra checks for silly sign errors/bugs
- [x] Convex conjugate for different inputs


## TODO
- Implement non-orthogonal wavelet adjoint (I have an idea for this, should be relatively easy). For example PDHG should then work with those wavelets too
- Anything complex valued
- More testing?
