### PR TITLE
Document, typehint, and rearrange `recon` classes

### DIFF
--- a/Wrappers/Python/cil/recon/FBP.py
+++ b/Wrappers/Python/cil/recon/FBP.py
@@ -17,9 +17,12 @@
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
+from abc import ABCMeta
+from typing import Literal, Optional, Union
 from cil.framework import cilacc
-from cil.framework import AcquisitionGeometry
-from cil.recon import Reconstructor
+from cil.framework import AcquisitionGeometry, AcquisitionData
+from cil.framework.framework import ImageData, ImageGeometry
+from cil.recon.Reconstructor import Reconstructor
 from scipy.fft import fftfreq
 
 import numpy as np
@@ -36,7 +39,7 @@ except:
     has_ipp = False
 
 if has_ipp:
-    cilacc.filter_projections_avh.argtypes = [ctypes.POINTER(ctypes.c_float),  # pointer to the data array 
+    cilacc.filter_projections_avh.argtypes = [ctypes.POINTER(ctypes.c_float),  # pointer to the data array
                                     ctypes.POINTER(ctypes.c_float),  # pointer to the filter array
                                     ctypes.POINTER(ctypes.c_float),  # pointer to the weights array
                                     ctypes.c_int16, #order of the fft
@@ -44,7 +47,7 @@ if has_ipp:
                                     ctypes.c_long, #pix_v
                                     ctypes.c_long] #pix_x
 
-    cilacc.filter_projections_vah.argtypes = [ctypes.POINTER(ctypes.c_float),  # pointer to the data array 
+    cilacc.filter_projections_vah.argtypes = [ctypes.POINTER(ctypes.c_float),  # pointer to the data array
                                     ctypes.POINTER(ctypes.c_float),  # pointer to the filter array
                                     ctypes.POINTER(ctypes.c_float),  # pointer to the weights array
                                     ctypes.c_int16, #order of the fft
@@ -52,35 +55,38 @@ if has_ipp:
                                     ctypes.c_long, #num_proj
                                     ctypes.c_long] #pix_x
 
-class GenericFilteredBackProjection(Reconstructor):
+class GenericFilteredBackProjection(Reconstructor, metaclass=ABCMeta):
+    """Abstract Base Class GenericFilteredBackProjection holding common and virtual methods for FBP and FDK.
+
+    Parameters
+    ----------
+    input
+        Input data for reconstruction
+    image_geometry
+        Image geometry of input data, by default None
+    filter
+        Reconstruction filter from a string selecting from the list of pre-set filters, or pass a numpy.ndarray with a custom filter.
+    backend
+        Engine backend used for reconstruction, by default "tigre"
+
+    Raises
+    ------
+    ImportError
+        Raised if IPP libraries cannot be found
+    ValueError
+        Raised if input data is multi-channel
     """
-    Abstract Base Class GenericFilteredBackProjection holding common and virtual methods for FBP and FDK
-    """
 
-    @property
-    def filter(self):
-        return self._filter
-
-    @property
-    def filter_inplace(self):
-        return self._filter_inplace
-
-    @property
-    def fft_order(self):
-        return self._fft_order
-
-    def __init__ (self, input, image_geometry=None, filter='ram-lak', backend='tigre'):
-
+    def __init__(self, input:AcquisitionData, image_geometry:Optional[ImageGeometry]=None, filter:str="ram-lak", backend:Literal["tigre"]="tigre"):
         #call parent initialiser
         super().__init__(input, image_geometry, backend)
-                
+
         if has_ipp == False:
             raise ImportError("IPP libraries not found. Cannot use CIL FBP")
 
         #additional check
-        if 'channel' in input.dimension_labels:
+        if "channel" in input.dimension_labels:
             raise ValueError("Input data cannot be multi-channel")
-
 
         #define defaults
         self._fft_order = self._default_fft_order()
@@ -88,9 +94,53 @@ class GenericFilteredBackProjection(Reconstructor):
         self.set_filter_inplace(False)
         self._weights = None
 
+    @property
+    def filter(self) -> str:
+        """Get the current filter.
 
-    def set_filter_inplace(self, inplace=False):
+        Returns
+        -------
+        str
+            Name of the current filter, if 'custom', ten get_filter_array will return the numpy array used for filtering.
         """
+        return self._filter
+
+    @property
+    def filter_inplace(self) -> bool:
+        """If True, data filtering is done in-place, rather than allocating temporary memory.
+
+        Returns
+        -------
+        bool
+            True if inplace filtering is performed, false otherwise.
+        """
+        return self._filter_inplace
+
+    @property
+    def fft_order(self) -> int:
+        """The width of the fourier transform N=2^order.
+
+        Returns
+        -------
+        int
+            Width of the fourier transform N=2^order.
+        """
+        return self._fft_order
+
+    @property
+    def preset_filters(self) -> list[str]:
+        """Return a list of all filter presets.
+
+        Returns
+        -------
+        str
+            Supported filter presets
+        """
+        return ["ram-lak", "shepp-logan", "cosine", "hamming", "hann"]
+
+    def set_filter_inplace(self, inplace:bool=False) -> None:
+        """Allocate temporary memory for filtered projections.
+
         False (default) will allocate temporary memory for filtered projections.
         True will filter projections in-place.
 
@@ -104,28 +154,16 @@ class GenericFilteredBackProjection(Reconstructor):
         else:
             raise TypeError("set_filter_inplace expected a boolean. Got {}".format(type(inplace)))
 
+    def set_fft_order(self, order:Optional[int]=None) -> None:
+        """Width of the fourier transform N=2^order.
 
-    def _default_fft_order(self):
-        min_order = 0
-
-        while 2**min_order < self.acquisition_geometry.pixel_num_h * 2:
-            min_order+=1
-
-        min_order = max(8, min_order)
-        return min_order
-
-
-    def set_fft_order(self, order=None):
-        """
-        The width of the fourier transform N=2^order. 
-        
         Parameters
         ----------
-        order: int, optional
-            The width of the fft N=2^order 
+        order
+            The width of the fft N=2^order
 
         Notes
-        -----      
+        -----
         If `None` the default used is the power-of-2 greater than 2 * detector width, or 8, whichever is greater
         Higher orders will yield more accurate results but increase computation time.
         """
@@ -138,35 +176,30 @@ class GenericFilteredBackProjection(Reconstructor):
                 fft_order = int(order)
             except TypeError:
                 raise TypeError("fft order expected type `int`. Got{}".format(type(order)))
-        
+
         if fft_order < min_order:
             raise ValueError("Minimum fft width 2^order is order = {0}. Got{1}".format(min_order,order))
 
         if fft_order != self.fft_order:
             self._fft_order = fft_order
 
-            if self.filter=='custom':
+            if self.filter=="custom":
                 print("Filter length changed - please update your custom filter")
             else:
                 #create default filter type of new length
                 self.set_filter(self._filter)
-        
-    @property
-    def preset_filters(self):
-        return ['ram-lak', 'shepp-logan', 'cosine', 'hamming', 'hann']
- 
-    def set_filter(self, filter='ram-lak', cutoff=1.0):
-        """
-        Set the filter used by the reconstruction.
 
-        Pre-set filters are constructed in the frequency domain.        
+    def set_filter(self, filter:Union[str, np.ndarray]="ram-lak", cutoff:float=1.0) -> None:
+        """Set the filter used by the reconstruction.
+
+        Pre-set filters are constructed in the frequency domain.
         Pre-set filters are: 'ram-lak', 'shepp-logan', 'cosine', 'hamming', 'hann'
-        
+
         Parameters
         ----------
-        filter : string, numpy.ndarray, default='ram-lak'
+        filter
             Pass a string selecting from the list of pre-set filters, or pass a numpy.ndarray with a custom filter.
-        cutoff : float, default = 1
+        cutoff
             The cut-off frequency of the filter between 0 - 1 pi rads/pixel. The filter will be 0 outside the range rect(-frequency_cutoff, frequency_cutoff)
 
         Notes
@@ -179,8 +212,6 @@ class GenericFilteredBackProjection(Reconstructor):
         - [1:N/2] positive frequencies
         - [N/2:N-1] negative frequencies
         """
-
-
         if type(filter)==str and filter in self.preset_filters:
             self._filter = filter
             self._filter_cutoff = cutoff
@@ -188,19 +219,17 @@ class GenericFilteredBackProjection(Reconstructor):
 
         elif type(filter)==np.ndarray:
             try:
-                filter_array = np.asarray(filter,dtype=np.float32).reshape(2**self.fft_order) 
+                filter_array = np.asarray(filter,dtype=np.float32).reshape(2**self.fft_order)
                 self._filter_array = filter_array.copy()
-                self._filter = 'custom'
+                self._filter = "custom"
             except ValueError:
                 raise ValueError("Custom filter not compatible with input.")
         else:
             raise ValueError("Filter not recognised")
 
+    def get_filter_array(self) -> np.ndarray:
+        """Return the filter array in the frequency domain.
 
-    def get_filter_array(self):
-        """
-        Returns the filter array in the frequency domain. 
-        
         Returns
         -------
         numpy.ndarray
@@ -211,24 +240,21 @@ class GenericFilteredBackProjection(Reconstructor):
         The filter length N is 2^self.fft_order.
 
         The indices of the array are interpreted as:
-        
+
         - [0] The DC frequency component
         - [1:N/2] positive frequencies
         - [N/2:N-1] negative frequencies
 
         The array can be modified and passed back using set_filter()
 
-
         Notes
         -----
-
         Filter reference in frequency domain:
         Eq. 1.12 - 1.15 T. M. Buzug. Computed Tomography: From Photon Statistics to Modern Cone-Beam CT. Berlin: Springer, 2008.
 
         Plantagie, L. Algebraic filters for filtered backprojection, 2017
         https://hdl.handle.net/1887/48289
         """
-
         if self._filter == 'custom':
             return self._filter_array
 
@@ -253,30 +279,44 @@ class GenericFilteredBackProjection(Reconstructor):
         elif self._filter == 'hann':
             filter_array = ramp * (0.5 + 0.5 * np.cos(freq*np.pi))
 
-        return np.asarray(filter_array,dtype=np.float32).reshape(2**self.fft_order) 
-        
-    def _calculate_weights(self):
-        return NotImplementedError
+        return np.asarray(filter_array,dtype=np.float32).reshape(2**self.fft_order)
 
+    def reset(self) -> None:
+        """Reset all optional configuration parameters to their default values."""
+        self.set_filter()
+        self.set_fft_order()
+        self.set_filter_inplace()
+        self.set_image_geometry()
+        self._weights = None
 
-    def _pre_filtering(self,acquistion_data):
-        """
-        Filters and weights the projections inplace
+    def _default_fft_order(self) -> int:
+        min_order = 0
+
+        while 2**min_order < self.acquisition_geometry.pixel_num_h * 2:
+            min_order+=1
+
+        min_order = max(8, min_order)
+        return min_order
+
+    def _calculate_weights(self, acquisition_geometry:AcquisitionGeometry) -> None:
+        raise NotImplementedError()
+
+    def _pre_filtering(self, acquisition_data:AcquisitionData) -> None:
+        """Filter and weight the projections inplace.
 
         Parameters
         ----------
-        acquistion_data : AcquisitionData
+        acquisition_data
             The projections to be filtered
 
         Notes
         -----
         self.input is not used to allow processing in smaller chunks
-
         """
-        if self._weights is None or self._weights.shape[0] != acquistion_data.geometry.pixel_num_v:
-            self._calculate_weights(acquistion_data.geometry)
+        if self._weights is None or self._weights.shape[0] != acquisition_data.geometry.pixel_num_v:
+            self._calculate_weights(acquisition_data.geometry)
 
-        if self._weights.shape[1] != acquistion_data.shape[-1]: #horizontal
+        if self._weights.shape[1] != acquisition_data.shape[-1]: #horizontal
             raise ValueError("Weights not compatible")
 
         filter_array = self.get_filter_array()
@@ -285,52 +325,35 @@ class GenericFilteredBackProjection(Reconstructor):
                             .format(filter_array.size,self.fft_order))
 
         #call ext function
-        data_ptr = acquistion_data.array.ctypes.data_as(c_float_p)
+        data_ptr = acquisition_data.array.ctypes.data_as(c_float_p)
         filter_ptr = filter_array.ctypes.data_as(c_float_p)
         weights_ptr = self._weights.ctypes.data_as(c_float_p)
 
-        ag = acquistion_data.geometry
-        if ag.dimension_labels == ('angle','vertical','horizontal'):   
-            cilacc.filter_projections_avh(data_ptr, filter_ptr, weights_ptr, self.fft_order, *acquistion_data.shape)
-        elif ag.dimension_labels == ('vertical','angle','horizontal'):   
-            cilacc.filter_projections_vah(data_ptr, filter_ptr, weights_ptr, self.fft_order, *acquistion_data.shape)
-        elif ag.dimension_labels == ('angle','horizontal'): 
-            cilacc.filter_projections_vah(data_ptr, filter_ptr, weights_ptr, self.fft_order, 1, *acquistion_data.shape) 
-        elif ag.dimension_labels == ('vertical','horizontal'): 
-            cilacc.filter_projections_avh(data_ptr, filter_ptr, weights_ptr, self.fft_order, 1, *acquistion_data.shape) 
+        ag = acquisition_data.geometry
+        if ag.dimension_labels == ('angle','vertical','horizontal'):
+            cilacc.filter_projections_avh(data_ptr, filter_ptr, weights_ptr, self.fft_order, *acquisition_data.shape)
+        elif ag.dimension_labels == ('vertical','angle','horizontal'):
+            cilacc.filter_projections_vah(data_ptr, filter_ptr, weights_ptr, self.fft_order, *acquisition_data.shape)
+        elif ag.dimension_labels == ('angle','horizontal'):
+            cilacc.filter_projections_vah(data_ptr, filter_ptr, weights_ptr, self.fft_order, 1, *acquisition_data.shape)
+        elif ag.dimension_labels == ('vertical','horizontal'):
+            cilacc.filter_projections_avh(data_ptr, filter_ptr, weights_ptr, self.fft_order, 1, *acquisition_data.shape)
         else:
             raise ValueError ("Could not determine correct function call from dimension labels")
 
 
-    def reset(self):
-        """
-        Resets all optional configuration parameters to their default values
-        """
-        self.set_filter()
-        self.set_fft_order()
-        self.set_filter_inplace()
-        self.set_image_geometry()
-        self._weights = None
-
-
-    def run(self, out=None):
-        NotImplementedError
-
-
 class FDK(GenericFilteredBackProjection):
-
-    """
-    Creates an FDK reconstructor based on your cone-beam acquisition data using TIGRE as a backend.
+    """Create an FDK reconstructor based on your cone-beam acquisition data using TIGRE as a backend.
 
     Parameters
     ----------
-    input : AcquisitionData
+    input
         The input data to reconstruct. The reconstructor is set-up based on the geometry of the data.
-    
-    image_geometry : ImageGeometry, default used if None
+
+    image_geometry
         A description of the area/volume to reconstruct
-    
-    filter : string, numpy.ndarray, default='ram-lak'
+
+    filter
         The filter to be applied. Can be a string from: {'`ram-lak`', '`shepp-logan`', '`cosine`', '`hamming`', '`hann`'}, or a numpy array.
 
     Example
@@ -343,38 +366,26 @@ class FDK(GenericFilteredBackProjection):
 
     Notes
     -----
-    The reconstructor can be futher customised using additional 'set' methods provided.
+    The reconstructor can be further customised using additional 'set' methods provided.
     """
+
     supported_backends = ['tigre']
 
-    def __init__ (self, input, image_geometry=None, filter='ram-lak'):
+    def __init__(self, input:AcquisitionData, image_geometry:Optional[ImageGeometry]=None, filter:str="ram-lak", backend:Literal["tigre"]="tigre"):
         #call parent initialiser
         super().__init__(input, image_geometry, filter, backend='tigre')
 
         if  input.geometry.geom_type != AcquisitionGeometry.CONE:
             raise TypeError("This reconstructor is for cone-beam data only.")
 
-
-    def _calculate_weights(self, acquisition_geometry):
-        ag = acquisition_geometry
-        xv = np.arange(-(ag.pixel_num_h -1)/2,(ag.pixel_num_h -1)/2 + 1,dtype=np.float32) * ag.pixel_size_h
-        yv = np.arange(-(ag.pixel_num_v -1)/2,(ag.pixel_num_v -1)/2 + 1,dtype=np.float32) * ag.pixel_size_v
-        (yy, xx) = np.meshgrid(xv, yv)
-
-        principal_ray_length = ag.dist_source_center + ag.dist_center_detector
-        scaling = 0.25 * ag.magnification * (2 * np.pi/ ag.num_projections) / ag.pixel_size_h
-        self._weights = scaling * principal_ray_length / np.sqrt((principal_ray_length ** 2 + xx ** 2 + yy ** 2))
-
-
-    def run(self, out=None, verbose=1):
-        """
-        Runs the configured FDK recon and returns the reconstruction.
+    def run(self, out:Optional[ImageData]=None, verbose:int=1) -> Optional[ImageData]:
+        """Run the configured FDK recon and returns the reconstruction.
 
         Parameters
         ----------
-        out : ImageData, optional
+        out
            Fills the referenced ImageData with the reconstructed volume and suppresses the return
-        verbose : int, default=1
+        verbose
            Controls the verbosity of the reconstructor. 0: No output is logged, 1: Full configuration is logged
 
         Returns
@@ -382,7 +393,6 @@ class FDK(GenericFilteredBackProjection):
         ImageData
             The reconstructed volume. Suppressed if `out` is passed
         """
-
         if verbose:
             print(self)
 
@@ -393,42 +403,56 @@ class FDK(GenericFilteredBackProjection):
 
         self._pre_filtering(proj_filtered)
         operator = self._PO_class(self.image_geometry,self.acquisition_geometry,adjoint_weights='FDK')
-        
+
         if out is None:
             return operator.adjoint(proj_filtered)
         else:
             operator.adjoint(proj_filtered, out = out)
 
+    def _calculate_weights(self, acquisition_geometry:AcquisitionGeometry) -> None:
+        ag = acquisition_geometry
+        xv = np.arange(-(ag.pixel_num_h -1)/2,(ag.pixel_num_h -1)/2 + 1,dtype=np.float32) * ag.pixel_size_h
+        yv = np.arange(-(ag.pixel_num_v -1)/2,(ag.pixel_num_v -1)/2 + 1,dtype=np.float32) * ag.pixel_size_v
+        (yy, xx) = np.meshgrid(xv, yv)
 
-    def __str__(self):
-    
+        principal_ray_length = ag.dist_source_center + ag.dist_center_detector
+        scaling = 0.25 * ag.magnification * (2 * np.pi/ ag.num_projections) / ag.pixel_size_h
+        self._weights = scaling * principal_ray_length / np.sqrt((principal_ray_length ** 2 + xx ** 2 + yy ** 2))
+
+    def __str__(self) -> str:
+        """Return a string representation of the FDK reconstructor.
+
+        Returns
+        -------
+        str
+            String representation of the FDK reconstructor
+        """
         repres = "FDK recon\n"
 
         repres += self._str_data_size()
 
-        repres += "\nReconstruction Options:\n"    
-        repres += "\tBackend: {}\n".format(self._backend)        
+        repres += "\nReconstruction Options:\n"
+        repres += "\tBackend: {}\n".format(self._backend)
         repres += "\tFilter: {}\n".format(self._filter)
         if self._filter != 'custom':
             repres += "\tFilter cut-off frequency: {}\n".format(self._filter_cutoff)
-        repres += "\tFFT order: {}\n".format(self._fft_order)        
-        repres += "\tFilter_inplace: {}\n".format(self._filter_inplace) 
+        repres += "\tFFT order: {}\n".format(self._fft_order)
+        repres += "\tFilter_inplace: {}\n".format(self._filter_inplace)
 
-        return repres   
+        return repres
+
 
 class FBP(GenericFilteredBackProjection):
-
-    """
-    Creates an FBP reconstructor based on your parallel-beam acquisition data.
+    """Create an FBP reconstructor based on your parallel-beam acquisition data.
 
     Parameters
     ----------
     input : AcquisitionData
         The input data to reconstruct. The reconstructor is set-up based on the geometry of the data.
-        
+
     image_geometry : ImageGeometry, default used if None
         A description of the area/volume to reconstruct
-        
+
     filter : string, numpy.ndarray, default='ram-lak'
         The filter to be applied. Can be a string from: {'`ram-lak`', '`shepp-logan`', '`cosine`', '`hamming`', '`hann`'}, or a numpy array.
 
@@ -451,22 +475,25 @@ class FBP(GenericFilteredBackProjection):
     supported_backends = ['tigre', 'astra']
 
     @property
-    def slices_per_chunk(self):
+    def slices_per_chunk(self) -> int:
+        """Return the number of slices used to chunk data.
+
+        Returns
+        -------
+        int
+            Number of slices used to chunk data
+        """
         return self._slices_per_chunk
 
-
-    def __init__ (self, input, image_geometry=None, filter='ram-lak', backend='tigre'):
-      
+    def __init__(self, input:AcquisitionData, image_geometry:Optional[ImageGeometry]=None, filter:str="ram-lak", backend:Literal["tigre"]="tigre"):
         super().__init__(input, image_geometry, filter, backend)
         self.set_split_processing(False)
 
         if  input.geometry.geom_type != AcquisitionGeometry.PARALLEL:
             raise TypeError("This reconstructor is for parallel-beam data only.")
 
-
-    def set_split_processing(self, slices_per_chunk=0):
-        """
-        Splits the processing in to chunks. Default, 0 will process the data in a single call.
+    def set_split_processing(self, slices_per_chunk:int=0) -> None:
+        """Split the processing in to chunks. Default, 0 will process the data in a single call.
 
         Parameters
         ----------
@@ -477,10 +504,9 @@ class FBP(GenericFilteredBackProjection):
         -----
         This will reduce memory use but may increase computation time.
         It is recommended to tune it too your hardware requirements using 8, 16 or 32 slices.
-        
+
         This can only be used on simple and offset data-geometries.
         """
-
         try:
             num_slices = int(slices_per_chunk)
         except:
@@ -490,48 +516,16 @@ class FBP(GenericFilteredBackProjection):
             num_slices = self.acquisition_geometry.pixel_num_v
 
         self._slices_per_chunk = num_slices
-        
 
-    def _calculate_weights(self, acquisition_geometry):
-
-        ag = acquisition_geometry
-        scaling = 0.25 * (2 * np.pi/ ag.num_projections) / ag.pixel_size_h
-
-        if self.backend=='astra':
-            scaling /=  ag.pixel_size_v
-        self._weights = np.full((ag.pixel_num_v,ag.pixel_num_h),scaling,dtype=np.float32)
-
-
-    def _setup_PO_for_chunks(self, num_slices):
-        
-        if num_slices > 1:
-            ag_slice = self.acquisition_geometry.copy()
-            ag_slice.pixel_num_v = num_slices
-        else:
-            ag_slice = self.acquisition_geometry.get_slice(vertical=0)
-                
-        ig_slice = ag_slice.get_ImageGeometry()
-        self.data_slice = ag_slice.allocate()
-        self.operator = self._PO_class(ig_slice,ag_slice)
-
-    def _process_chunk(self, i, step):
-        self.data_slice.fill(np.squeeze(self.input.array[:,i:i+step,:]))
-        if not self.filter_inplace:
-            self._pre_filtering(self.data_slice)
-
-        return self.operator.adjoint(self.data_slice).array
-
-
-    def run(self, out=None, verbose=1):
-        """
-        Runs the configured FBP recon and returns the reconstruction
+    def run(self, out:Optional[ImageData]=None, verbose:int=1) -> Optional[ImageData]:
+        """Run the configured FBP recon and returns the reconstruction.
 
         Parameters
         ----------
-        out : ImageData, optional
+        out
            Fills the referenced ImageData with the reconstructed volume and suppresses the return
 
-        verbose : int, default=1
+        verbose
            Controls the verbosity of the reconstructor. 0: No output is logged, 1: Full configuration is logged
 
         Returns
@@ -539,10 +533,9 @@ class FBP(GenericFilteredBackProjection):
         ImageData
             The reconstructed volume. Suppressed if `out` is passed
         """
-
         if verbose:
             print(self)
-        
+
         if self.slices_per_chunk:
 
             if self.acquisition_geometry.dimension == '2D':
@@ -576,7 +569,7 @@ class FBP(GenericFilteredBackProjection):
                     end = i + self.slices_per_chunk
                 else:
                     start = tot_slices -i - self.slices_per_chunk
-                    end = tot_slices - i 
+                    end = tot_slices - i
 
                 ret.array[start:end,:,:] = self._process_chunk(i, self.slices_per_chunk)
 
@@ -593,7 +586,7 @@ class FBP(GenericFilteredBackProjection):
                 else:
                     start = 0
                     end = remainder
-                
+
                 ret.array[start:end,:,:] = self._process_chunk(i, remainder)
 
                 if verbose:
@@ -621,29 +614,57 @@ class FBP(GenericFilteredBackProjection):
             else:
                 operator.adjoint(proj_filtered, out = out)
 
-
-    def reset(self):
-        """
-        Resets all optional configuration parameters to their default values
-        """
+    def reset(self) -> None:
+        """Reset all optional configuration parameters to their default values."""
         super().reset()
         self.set_split_processing(0)
 
+    def _calculate_weights(self, acquisition_geometry:AcquisitionGeometry) -> None:
+        ag = acquisition_geometry
+        scaling = 0.25 * (2 * np.pi/ ag.num_projections) / ag.pixel_size_h
 
-    def __str__(self):
+        if self.backend=='astra':
+            scaling /=  ag.pixel_size_v
+        self._weights = np.full((ag.pixel_num_v,ag.pixel_num_h),scaling,dtype=np.float32)
 
+    def _setup_PO_for_chunks(self, num_slices:int) -> None:
+        if num_slices > 1:
+            ag_slice = self.acquisition_geometry.copy()
+            ag_slice.pixel_num_v = num_slices
+        else:
+            ag_slice = self.acquisition_geometry.get_slice(vertical=0)
+
+        ig_slice = ag_slice.get_ImageGeometry()
+        self.data_slice = ag_slice.allocate()
+        self.operator = self._PO_class(ig_slice,ag_slice)
+
+    def _process_chunk(self, i:int, step:int) -> np.ndarray:
+        self.data_slice.fill(np.squeeze(self.input.array[:,i:i+step,:]))
+        if not self.filter_inplace:
+            self._pre_filtering(self.data_slice)
+
+        return self.operator.adjoint(self.data_slice).array
+
+    def __str__(self) -> str:
+        """Return a string representation of the FBP reconstructor.
+
+        Returns
+        -------
+        str
+            String representation of FBP
+        """
         repres = "FBP recon\n"
 
         repres += self._str_data_size()
 
-        repres += "\nReconstruction Options:\n"    
-        repres += "\tBackend: {}\n".format(self._backend)        
+        repres += "\nReconstruction Options:\n"
+        repres += "\tBackend: {}\n".format(self._backend)
         repres += "\tFilter: {}\n".format(self._filter)
         if self._filter != 'custom':
             repres += "\tFilter cut-off frequency: {}\n".format(self._filter_cutoff)
-        repres += "\tFFT order: {}\n".format(self._fft_order)        
-        repres += "\tFilter_inplace: {}\n".format(self._filter_inplace) 
-        repres += "\tSplit processing: {}\n".format(self._slices_per_chunk) 
+        repres += "\tFFT order: {}\n".format(self._fft_order)
+        repres += "\tFilter_inplace: {}\n".format(self._filter_inplace)
+        repres += "\tSplit processing: {}\n".format(self._slices_per_chunk)
 
         if self._slices_per_chunk:
             num_chunks = int(np.ceil(self.image_geometry.shape[0] / self._slices_per_chunk))
@@ -652,5 +673,4 @@ class FBP(GenericFilteredBackProjection):
 
         repres +="\nReconstructing in {} chunk(s):\n".format(num_chunks)
 
-        return repres   
-
+        return repres

--- a/Wrappers/Python/cil/recon/FBP.py
+++ b/Wrappers/Python/cil/recon/FBP.py
@@ -22,7 +22,7 @@ from typing import Literal, Optional, Union
 from cil.framework import cilacc
 from cil.framework import AcquisitionGeometry, AcquisitionData
 from cil.framework.framework import ImageData, ImageGeometry
-from cil.recon.Reconstructor import Reconstructor
+from .Reconstructor import Reconstructor
 from scipy.fft import fftfreq
 
 import numpy as np

--- a/Wrappers/Python/cil/recon/FBP.py
+++ b/Wrappers/Python/cil/recon/FBP.py
@@ -18,7 +18,7 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 from abc import ABCMeta
-from typing import Literal, Optional, Union
+from typing import List, Literal, Optional, Union
 from cil.framework import cilacc
 from cil.framework import AcquisitionGeometry, AcquisitionData
 from cil.framework.framework import ImageData, ImageGeometry
@@ -128,7 +128,7 @@ class GenericFilteredBackProjection(Reconstructor, metaclass=ABCMeta):
         return self._fft_order
 
     @property
-    def preset_filters(self) -> list[str]:
+    def preset_filters(self) -> List[str]:
         """Return a list of all filter presets.
 
         Returns

--- a/Wrappers/Python/cil/recon/Reconstructor.py
+++ b/Wrappers/Python/cil/recon/Reconstructor.py
@@ -17,44 +17,31 @@
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
-from cil.framework import AcquisitionData, ImageGeometry, DataOrder
 import importlib
+from typing import Literal, Optional
 import weakref
+from cil.framework import AcquisitionData, ImageGeometry, DataOrder, ImageData, AcquisitionGeometry
+from abc import ABCMeta
 
-class Reconstructor(object):
-    
-    """ Abstract class representing a reconstructor 
+class Reconstructor(metaclass=ABCMeta):
+    """Abstract class for a tomographic reconstructor.
+
+    Parameters
+    ----------
+    input
+        Input data for reconstruction
+    image_geometry
+        Image geometry of input data, by default None
+    backend
+        Engine backend used for reconstruction, by default "tigre"
+
+    Raises
+    ------
+    TypeError
+        Raised if input data is not an AcquisitionData class
     """
 
-    supported_backends = ['tigre']
-    
-    #_input is a weakreference object
-    @property
-    def input(self):
-        if self._input() is None:
-            raise ValueError("Input has been deallocated")
-        else:
-            return self._input()
-
-
-    @property
-    def acquisition_geometry(self):
-        return self._acquisition_geometry
-
-
-    @property
-    def image_geometry(self):
-        return self._image_geometry
-
-
-    @property
-    def backend(self):
-        return self._backend
-
-
-    def __init__(self, input, image_geometry=None, backend='tigre'):
-
-
+    def __init__(self, input:AcquisitionData, image_geometry:Optional[ImageGeometry]=None, backend:Literal["tigre"]="tigre"):
         if not issubclass(type(input), AcquisitionData):
             raise TypeError("Input type mismatch: got {0} expecting {1}"
                             .format(type(input), AcquisitionData))
@@ -64,30 +51,81 @@ class Reconstructor(object):
         self.set_image_geometry(image_geometry)
         self.set_input(input)
 
+    supported_backends = ["tigre"]
 
-    def set_input(self, input):
+    @property
+    def input(self) -> AcquisitionData:
+        """Get the input data used for reconstruction.
+
+        Returns
+        -------
+        AcquisitionData
+            Input data used for reconstruction.
+
+        Raises
+        ------
+        ValueError
+            Raised if input has been deallocated.
+        """
+        #_input is a weakreference object
+        if self._input() is None:
+            raise ValueError("Input has been deallocated")
+        else:
+            return self._input()
+
+    @property
+    def acquisition_geometry(self) -> AcquisitionGeometry:
+        """Get the acquisition geometry used for reconstruction.
+
+        Returns
+        -------
+        AcquisitionGeometry
+            The acquisition geometry used for reconstruction
+        """
+        return self._acquisition_geometry
+
+    @property
+    def image_geometry(self) -> ImageGeometry:
+        """Get the image geometry used for reconstruction.
+
+        Returns
+        -------
+        ImageGeometry
+            Image geometry used for reconstruction
+        """
+        return self._image_geometry
+
+    @property
+    def backend(self) -> str:
+        """Get the backend engine used for reconstruction.
+
+        Returns
+        -------
+        str
+            Backend engine used for reconstruction
+        """
+        return self._backend
+
+    def set_input(self, input:AcquisitionData) -> None:
         """
         Update the input data to run the reconstructor on. The geometry of the dataset must be compatible with the reconstructor.
 
         Parameters
         ----------
-        input : AcquisitionData
+        input
             A dataset with a compatible geometry
-
         """
         if input.geometry != self.acquisition_geometry:
             raise ValueError ("Input not compatible with configured reconstructor. Initialise a new reconstructor with this geometry")
         else:
             self._input = weakref.ref(input)
 
-
-    def set_image_geometry(self, image_geometry=None):
-        """
-        Sets a custom image geometry to be used by the reconstructor
+    def set_image_geometry(self, image_geometry:Optional[ImageGeometry]=None):
+        """Set a custom image geometry to be used by the reconstructor.
 
         Parameters
         ----------
-        image_geometry : ImageGeometry, default used if None
+        image_geometry
             A description of the area/volume to reconstruct
         """
         if image_geometry is None:
@@ -96,68 +134,72 @@ class Reconstructor(object):
             self._image_geometry = image_geometry.copy()
         else:
             raise TypeError("ImageGeometry type mismatch: got {0} expecting {1}"\
-                                .format(type(input), ImageGeometry))   
-           
+                                .format(type(input), ImageGeometry))
 
-    def _configure_for_backend(self, backend='tigre'):
-        """
-        Configures the class for the right engine. Checks the dataorder.
-        """        
-        if backend not in self.supported_backends:
-            raise ValueError("Backend unsupported. Supported backends: {}".format(self.supported_backends))
-
-        if not DataOrder.check_order_for_engine(backend, self.acquisition_geometry):
-            raise ValueError("Input data must be reordered for use with selected backend. Use input.reorder{'{0}')".format(backend))
-
-        #set ProjectionOperator class from backend
-        try:
-            module = importlib.import_module('cil.plugins.'+backend)
-        except ImportError:
-            if backend == 'tigre':
-                raise ImportError("Cannot import the {} plugin module. Please install TIGRE or select a different backend".format(self.backend))
-            if backend == 'astra':
-                raise ImportError("Cannot import the {} plugin module. Please install CIL-ASTRA or select a different backend".format(self.backend))
-
-        self._PO_class = module.ProjectionOperator
-        self._backend = backend
-
-
-    def reset(self):
-        """
-        Resets all optional configuration parameters to their default values
-        """
+    def reset(self) -> None:
+        """Reset all optional configuration parameters to their default values."""
         raise NotImplementedError()
 
-
-    def run(self, out=None, verbose=1):
-        """
-        Runs the configured recon and returns the reconstruction
+    def run(self, out:Optional[ImageData]=None, verbose:int=1) -> Optional[ImageData]:
+        """Run. the configured recon and returns the reconstruction.
 
         Parameters
         ----------
         out : ImageData, optional
            Fills the referenced ImageData with the reconstructed volume and suppresses the return
-        
+
         verbose : int, default=1
-           Contols the verbosity of the reconstructor. 0: No output is logged, 1: Full configuration is logged
+           Controls the verbosity of the reconstructor. 0: No output is logged, 1: Full configuration is logged
 
         Returns
         -------
         ImageData
             The reconstructed volume. Suppressed if `out` is passed
         """
-
         raise NotImplementedError()
 
+    def _configure_for_backend(self, backend:Literal["tigre"]="tigre") -> None:
+        """Configure the reconstructor class for the right engine, checking the dataorder.
 
-    def _str_data_size(self):
+        Parameters
+        ----------
+        backend
+            Engine backend, by default "tigre"
 
+        Raises
+        ------
+        ValueError
+            Raised if an unsupported backend is passed.
+        ValueError
+            Raised if the input data must be reordered for the selected backend.
+        ImportError
+            Raised if the selected backend cannot be imported.
+        """
+        if backend not in self.supported_backends:
+            raise ValueError("Backend unsupported. Supported backends: {}".format(self.supported_backends))
+
+        if not DataOrder.check_order_for_engine(backend, self.acquisition_geometry):
+            raise ValueError("Input data must be reordered for use with selected backend. Use input.reorder('{0}')".format(backend))
+
+        #set ProjectionOperator class from backend
+        try:
+            module = importlib.import_module("cil.plugins." + backend)
+        except ImportError:
+            if backend == "tigre":
+                raise ImportError("Cannot import the {} plugin module. Please install TIGRE or select a different backend".format(self.backend))
+            if backend == "astra":
+                raise ImportError("Cannot import the {} plugin module. Please install CIL-ASTRA or select a different backend".format(self.backend))
+
+        self._PO_class = module.ProjectionOperator
+        self._backend = backend
+
+    def _str_data_size(self) -> str:
         repres = "\nInput Data:\n"
-        for dim in  zip(self.acquisition_geometry.dimension_labels,self.acquisition_geometry.shape):
-            repres += "\t" + str(dim[0]) + ': ' + str(dim[1])+'\n'
+        for dim in zip(self.acquisition_geometry.dimension_labels, self.acquisition_geometry.shape):
+            repres += "\t" + str(dim[0]) + ": " + str(dim[1])+"\n"
 
         repres += "\nReconstruction Volume:\n"
-        for dim in zip(self.image_geometry.dimension_labels,self.image_geometry.shape):
-            repres += "\t" + str(dim[0]) + ': ' + str(dim[1]) +'\n'
+        for dim in zip(self.image_geometry.dimension_labels, self.image_geometry.shape):
+            repres += "\t" + str(dim[0]) + ": " + str(dim[1]) +"\n"
 
         return repres


### PR DESCRIPTION
This is part of the software sustainability hackathon, and is part of a larger
project to improve cil's documentation. #1683


## Describe your changes

Since the changes are quite large, this PR is limited to the `cil.recon` folder.

No functional code changes were performed.

- Sorted imports
- Document and typehint functions, following the numpy standard
	- Private functions are not documented.
- Move `__init__` to top of class
- Move private functions to bottom of class
- Standardise using `"` for strings
- Explicitly state classes as abstract classes

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues

- https://github.com/TomographicImaging/CIL/issues/1683

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
