### PR TITLE
Document, typehint, and rearrange `plugins/astra` classes

### DIFF
--- a/Wrappers/Python/cil/plugins/astra/operators/AstraProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/AstraProjector2D.py
@@ -23,7 +23,6 @@ from typing import Literal, Optional
 from cil.framework.framework import (
     AcquisitionData,
     AcquisitionGeometry,
-    DataContainer,
     ImageData,
     ImageGeometry,
 )
@@ -32,8 +31,7 @@ from cil.plugins.astra.processors import AstraBackProjector2D, AstraForwardProje
 
 
 class AstraProjector2D(LinearOperator):
-    """
-    AstraProjector2D configures and calls the ASTRA 2D Projectors for CPU and GPU.
+    """AstraProjector2D configures and calls the ASTRA 2D Projectors for CPU and GPU.
 
     It is recommended to use this via the ProjectionOperator Class.
 
@@ -70,39 +68,39 @@ class AstraProjector2D(LinearOperator):
                                         proj_id = None,
                                         device = device)
 
-    def direct(self, x:ImageData, out:Optional[ImageData]=None) -> Optional[ImageData]:
+    def direct(self, x:ImageData, out:Optional[AcquisitionData]=None) -> Optional[AcquisitionData]:
         """Apply the direct of the operator i.e. the forward projection.
 
         Parameters
         ----------
-        x : ImageData
+        x
             The image/volume to be projected.
 
-        out : ImageData, optional
+        out
            Fills the referenced ImageData with the processed data and suppresses the return
 
         Returns
         -------
-        ImageData
+        AcquisitionData
             The processed data. Suppressed if `out` is passed
         """
         self.fp.set_input(x)
         return self.fp.get_output(out = out)
 
-    def adjoint(self, x:AcquisitionData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+    def adjoint(self, x:AcquisitionData, out:Optional[ImageData]=None) -> Optional[ImageData]:
         """Apply the adjoint of the operator, i.e. the backward projection.
 
         Parameters
         ----------
-        x : AcquisitionData
+        x
             The projections/sinograms to be projected.
 
-        out : DataContainer, optional
+        out
            Fills the referenced DataContainer with the processed data and suppresses the return
 
         Returns
         -------
-        DataContainer
+        ImageData
             The processed data. Suppressed if `out` is passed
         """
         self.bp.set_input(x)

--- a/Wrappers/Python/cil/plugins/astra/operators/AstraProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/AstraProjector2D.py
@@ -27,7 +27,8 @@ from cil.framework.framework import (
     ImageGeometry,
 )
 from cil.optimisation.operators import LinearOperator
-from cil.plugins.astra.processors import AstraBackProjector2D, AstraForwardProjector2D
+
+from ..processors import AstraBackProjector2D, AstraForwardProjector2D
 
 
 class AstraProjector2D(LinearOperator):

--- a/Wrappers/Python/cil/plugins/astra/operators/AstraProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/AstraProjector2D.py
@@ -18,26 +18,34 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 
-from cil.optimisation.operators import LinearOperator
-from cil.plugins.astra.processors import AstraForwardProjector2D, AstraBackProjector2D
+from typing import Literal, Optional
 
+from cil.framework.framework import (
+    AcquisitionData,
+    AcquisitionGeometry,
+    DataContainer,
+    ImageData,
+    ImageGeometry,
+)
+from cil.optimisation.operators import LinearOperator
+from cil.plugins.astra.processors import AstraBackProjector2D, AstraForwardProjector2D
 
 
 class AstraProjector2D(LinearOperator):
     """
     AstraProjector2D configures and calls the ASTRA 2D Projectors for CPU and GPU.
+
     It is recommended to use this via the ProjectionOperator Class.
 
     Parameters
     ----------
-
-    image_geometry : ImageGeometry
+    image_geometry
         A description of the area/volume to reconstruct
 
-    acquisition_geometry : AcquisitionGeometry
+    acquisition_geometry
         A description of the acquisition data
 
-    device : string, default='gpu'
+    device
         The device to run on 'gpu' or 'cpu'
 
     Example
@@ -46,44 +54,43 @@ class AstraProjector2D(LinearOperator):
     >>> PO = AstraProjector2D(image.geometry, data.geometry)
     >>> forward_projection = PO.direct(image)
     >>> backward_projection = PO.adjoint(data)
+    """
 
-    """    
-    def __init__(self, image_geometry, acquisition_geometry, device):
+    def __init__(self, image_geometry:ImageGeometry, acquisition_geometry:AcquisitionGeometry, device:Literal["cpu", "gpu"]):
 
         super(AstraProjector2D, self).__init__(image_geometry, range_geometry=acquisition_geometry)
-        
+
         self.fp = AstraForwardProjector2D(volume_geometry=image_geometry,
                                         sinogram_geometry=acquisition_geometry,
                                         proj_id = None,
                                         device=device)
-        
+
         self.bp = AstraBackProjector2D(volume_geometry = image_geometry,
                                         sinogram_geometry = acquisition_geometry,
                                         proj_id = None,
                                         device = device)
-                           
-        
-    def direct(self, x, out=None):
-        '''Applies the direct of the operator i.e. the forward projection.
-        
+
+    def direct(self, x:ImageData, out:Optional[ImageData]=None) -> Optional[ImageData]:
+        """Apply the direct of the operator i.e. the forward projection.
+
         Parameters
         ----------
         x : ImageData
             The image/volume to be projected.
 
-        out : DataContainer, optional
-           Fills the referenced DataContainer with the processed data and suppresses the return
-        
+        out : ImageData, optional
+           Fills the referenced ImageData with the processed data and suppresses the return
+
         Returns
         -------
-        DataContainer
+        ImageData
             The processed data. Suppressed if `out` is passed
-        '''
+        """
         self.fp.set_input(x)
         return self.fp.get_output(out = out)
 
-    def adjoint(self, x, out=None):
-        '''Applies the adjoint of the operator, i.e. the backward projection.
+    def adjoint(self, x:AcquisitionData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+        """Apply the adjoint of the operator, i.e. the backward projection.
 
         Parameters
         ----------
@@ -92,12 +99,11 @@ class AstraProjector2D(LinearOperator):
 
         out : DataContainer, optional
            Fills the referenced DataContainer with the processed data and suppresses the return
-        
+
         Returns
         -------
         DataContainer
             The processed data. Suppressed if `out` is passed
-        '''
-
+        """
         self.bp.set_input(x)
         return self.bp.get_output(out = out)

--- a/Wrappers/Python/cil/plugins/astra/operators/AstraProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/AstraProjector3D.py
@@ -28,7 +28,8 @@ from cil.framework.framework import (
     ImageGeometry,
 )
 from cil.optimisation.operators import LinearOperator
-from cil.plugins.astra.processors import AstraBackProjector3D, AstraForwardProjector3D
+
+from ..processors import AstraBackProjector3D, AstraForwardProjector3D
 
 
 class AstraProjector3D(LinearOperator):

--- a/Wrappers/Python/cil/plugins/astra/operators/AstraProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/AstraProjector3D.py
@@ -18,21 +18,31 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 
+from typing import Optional
+
+from cil.framework.framework import (
+    AcquisitionData,
+    AcquisitionGeometry,
+    DataContainer,
+    ImageData,
+    ImageGeometry,
+)
 from cil.optimisation.operators import LinearOperator
-from cil.plugins.astra.processors import AstraForwardProjector3D, AstraBackProjector3D
+from cil.plugins.astra.processors import AstraBackProjector3D, AstraForwardProjector3D
+
 
 class AstraProjector3D(LinearOperator):
     """
     AstraProjector3D configures and calls the ASTRA 3D Projectors for GPU. This works with 2D or 3D datasets.
+
     It is recommended to use this via the ProjectionOperator Class.
 
     Parameters
     ----------
-
-    image_geometry : ImageGeometry
+    image_geometry
         A description of the area/volume to reconstruct
 
-    acquisition_geometry : AcquisitionGeometry
+    acquisition_geometry
         A description of the acquisition data
 
     Example
@@ -43,56 +53,54 @@ class AstraProjector3D(LinearOperator):
     >>> backward_projection = PO.adjoint(data)
     """
 
-    def __init__(self, image_geometry, acquisition_geometry):
-       
+    def __init__(self, image_geometry:ImageGeometry, acquisition_geometry:AcquisitionGeometry):
+
         super(AstraProjector3D, self).__init__(domain_geometry=image_geometry, range_geometry=acquisition_geometry)
-                    
-        self.sinogram_geometry = acquisition_geometry 
-        self.volume_geometry = image_geometry         
-        
-        self.fp = AstraForwardProjector3D(volume_geometry=image_geometry, sinogram_geometry=acquisition_geometry)       
+
+        self.sinogram_geometry = acquisition_geometry
+        self.volume_geometry = image_geometry
+
+        self.fp = AstraForwardProjector3D(volume_geometry=image_geometry, sinogram_geometry=acquisition_geometry)
         self.bp = AstraBackProjector3D(volume_geometry=image_geometry, sinogram_geometry=acquisition_geometry)
-                      
-    def direct(self, x, out=None):
-        '''Applies the direct of the operator i.e. the forward projection.
-        
+
+    def direct(self, x:ImageData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+        """Apply the direct of the operator i.e. the forward projection.
+
         Parameters
         ----------
-        x : ImageData
+        x
             The image/volume to be projected.
 
-        out : DataContainer, optional
+        out
            Fills the referenced DataContainer with the processed data and suppresses the return
-        
+
         Returns
         -------
         DataContainer
             The processed data. Suppressed if `out` is passed
-        '''
-
+        """
         self.fp.set_input(x)
-        temp= self.fp.get_output(out = out)
+        temp = self.fp.get_output(out = out)
         self.fp.__dict__['input']= None
         return temp
-    
-    def adjoint(self, x, out=None):
-        '''Applies the adjoint of the operator, i.e. the backward projection.
+
+    def adjoint(self, x:AcquisitionData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+        """Apply the adjoint of the operator, i.e. the backward projection.
 
         Parameters
         ----------
-        x : AcquisitionData
+        x
             The projections/sinograms to be projected.
 
-        out : DataContainer, optional
+        out
            Fills the referenced DataContainer with the processed data and suppresses the return
-        
+
         Returns
         -------
         DataContainer
             The processed data. Suppressed if `out` is passed
-        '''
-
-        self.bp.set_input(x)  
-        temp= self.bp.get_output(out = out)
+        """
+        self.bp.set_input(x)
+        temp = self.bp.get_output(out = out)
         self.bp.__dict__['input']= None
         return temp

--- a/Wrappers/Python/cil/plugins/astra/operators/AstraProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/AstraProjector3D.py
@@ -32,8 +32,7 @@ from cil.plugins.astra.processors import AstraBackProjector3D, AstraForwardProje
 
 
 class AstraProjector3D(LinearOperator):
-    """
-    AstraProjector3D configures and calls the ASTRA 3D Projectors for GPU. This works with 2D or 3D datasets.
+    """AstraProjector3D configures and calls the ASTRA 3D Projectors for GPU. This works with 2D or 3D datasets.
 
     It is recommended to use this via the ProjectionOperator Class.
 
@@ -63,7 +62,7 @@ class AstraProjector3D(LinearOperator):
         self.fp = AstraForwardProjector3D(volume_geometry=image_geometry, sinogram_geometry=acquisition_geometry)
         self.bp = AstraBackProjector3D(volume_geometry=image_geometry, sinogram_geometry=acquisition_geometry)
 
-    def direct(self, x:ImageData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+    def direct(self, x:ImageData, out:Optional[AcquisitionData]=None) -> Optional[AcquisitionData]:
         """Apply the direct of the operator i.e. the forward projection.
 
         Parameters
@@ -72,11 +71,11 @@ class AstraProjector3D(LinearOperator):
             The image/volume to be projected.
 
         out
-           Fills the referenced DataContainer with the processed data and suppresses the return
+           Fills the referenced AcquisitionData with the processed data and suppresses the return
 
         Returns
         -------
-        DataContainer
+        AcquisitionData
             The processed data. Suppressed if `out` is passed
         """
         self.fp.set_input(x)
@@ -84,7 +83,7 @@ class AstraProjector3D(LinearOperator):
         self.fp.__dict__['input']= None
         return temp
 
-    def adjoint(self, x:AcquisitionData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+    def adjoint(self, x:AcquisitionData, out:Optional[ImageData]=None) -> Optional[ImageData]:
         """Apply the adjoint of the operator, i.e. the backward projection.
 
         Parameters
@@ -93,11 +92,11 @@ class AstraProjector3D(LinearOperator):
             The projections/sinograms to be projected.
 
         out
-           Fills the referenced DataContainer with the processed data and suppresses the return
+           Fills the referenced ImageData with the processed data and suppresses the return
 
         Returns
         -------
-        DataContainer
+        ImageData
             The processed data. Suppressed if `out` is passed
         """
         self.bp.set_input(x)

--- a/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
@@ -25,7 +25,6 @@ from cil.framework.BlockGeometry import BlockGeometry
 from cil.framework.framework import (
     AcquisitionData,
     AcquisitionGeometry,
-    DataContainer,
     ImageData,
     ImageGeometry,
 )
@@ -34,7 +33,8 @@ from cil.optimisation.operators import (
     ChannelwiseOperator,
     LinearOperator,
 )
-from cil.plugins.astra.operators import AstraProjector2D, AstraProjector3D
+
+from ..operators import AstraProjector2D, AstraProjector3D
 
 
 class ProjectionOperator(LinearOperator):

--- a/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
@@ -17,29 +17,38 @@
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
-from cil.framework import DataOrder
-from cil.optimisation.operators import LinearOperator, ChannelwiseOperator
-from cil.framework.BlockGeometry import BlockGeometry
-from cil.optimisation.operators import BlockOperator
-from cil.plugins.astra.operators import AstraProjector3D
-from cil.plugins.astra.operators import AstraProjector2D
 import logging
+from typing import Literal, Optional, Union
+
+from cil.framework import DataOrder
+from cil.framework.BlockGeometry import BlockGeometry
+from cil.framework.framework import (
+    AcquisitionData,
+    AcquisitionGeometry,
+    DataContainer,
+    ImageData,
+    ImageGeometry,
+)
+from cil.optimisation.operators import (
+    BlockOperator,
+    ChannelwiseOperator,
+    LinearOperator,
+)
+from cil.plugins.astra.operators import AstraProjector2D, AstraProjector3D
 
 
 class ProjectionOperator(LinearOperator):
-    """
-    ProjectionOperator configures and calls appropriate ASTRA Projectors for your dataset.
+    """ProjectionOperator configures and calls appropriate ASTRA Projectors for your dataset.
 
     Parameters
     ----------
-
-    image_geometry : ``ImageGeometry``, default used if None
+    image_geometry
         A description of the area/volume to reconstruct
 
-    acquisition_geometry : ``AcquisitionGeometry``, ``BlockGeometry``
+    acquisition_geometry
         A description of the acquisition data. If passed a BlockGeometry it will return a BlockOperator.
 
-    device : string, default='gpu'
+    device
         'gpu' will run on a compatible CUDA capable device using the ASTRA 3D CUDA Projectors, 'cpu' will run on CPU using the ASTRA 2D CPU Projectors
 
     Example
@@ -53,22 +62,19 @@ class ProjectionOperator(LinearOperator):
     -----
     For multichannel data the ProjectionOperator will broadcast across all channels.
     """
-    def __new__(cls, image_geometry=None, acquisition_geometry=None, \
-        device='gpu', **kwargs):
+
+    def __new__(cls, image_geometry:Optional[ImageGeometry]=None, acquisition_geometry:Optional[Union[AcquisitionGeometry, BlockGeometry]]=None, device:Literal["gpu", "cpu"]="gpu", **kwargs):
         if isinstance(acquisition_geometry, BlockGeometry):
             logging.info("BlockOperator is returned.")
 
             K = []
             for ag in acquisition_geometry:
-                K.append(
-                    ProjectionOperator_ag(image_geometry=image_geometry, acquisition_geometry=ag, \
-                        device=device, **kwargs)
-                )
+                K.append(ProjectionOperator_ag(image_geometry=image_geometry, acquisition_geometry=ag, device=device, **kwargs))
+
             return BlockOperator(*K)
         else:
             logging.info("Standard Operator is returned.")
-            return super(ProjectionOperator,
-                         cls).__new__(ProjectionOperator_ag)
+            return super(ProjectionOperator, cls).__new__(ProjectionOperator_ag)
 
 
 class ProjectionOperator_ag(ProjectionOperator):
@@ -77,14 +83,13 @@ class ProjectionOperator_ag(ProjectionOperator):
 
     Parameters
     ----------
-
-    image_geometry : ImageGeometry, default used if None
+    image_geometry
         A description of the area/volume to reconstruct
 
-    acquisition_geometry : AcquisitionGeometry
+    acquisition_geometry
         A description of the acquisition data
 
-    device : string, default='gpu'
+    device
         'gpu' will run on a compatible CUDA capable device using the ASTRA 3D CUDA Projectors, 'cpu' will run on CPU using the ASTRA 2D CPU Projectors
 
     Example
@@ -99,22 +104,15 @@ class ProjectionOperator_ag(ProjectionOperator):
     For multichannel data the ProjectionOperator will broadcast across all channels.
     """
 
-    def __init__(self,
-                 image_geometry=None,
-                 acquisition_geometry=None,
-                 device='gpu'):
+    def __init__(self, image_geometry:Optional[ImageGeometry]=None, acquisition_geometry:Optional[AcquisitionGeometry]=None, device:Literal["gpu", "cpu"]='gpu'):
 
         if acquisition_geometry is None:
-            raise TypeError(
-                "Please specify an acquisition_geometry to configure this operator"
-            )
+            raise TypeError("Please specify an acquisition_geometry to configure this operator")
 
         if image_geometry is None:
             image_geometry = acquisition_geometry.get_ImageGeometry()
 
-        super(ProjectionOperator_ag,
-              self).__init__(domain_geometry=image_geometry,
-                             range_geometry=acquisition_geometry)
+        super(ProjectionOperator_ag, self).__init__(domain_geometry=image_geometry, range_geometry=acquisition_geometry)
 
         DataOrder.check_order_for_engine('astra', image_geometry)
         DataOrder.check_order_for_engine('astra', acquisition_geometry)
@@ -126,64 +124,84 @@ class ProjectionOperator_ag(ProjectionOperator):
         volume_geometry_sc = image_geometry.get_slice(channel=0)
 
         if device == 'gpu':
-            operator = AstraProjector3D(volume_geometry_sc,
-                                        sinogram_geometry_sc)
+            operator = AstraProjector3D(volume_geometry_sc, sinogram_geometry_sc)
+
         elif self.sinogram_geometry.dimension == '2D':
-            operator = AstraProjector2D(volume_geometry_sc,
-                                        sinogram_geometry_sc,
-                                        device=device)
+            operator = AstraProjector2D(volume_geometry_sc, sinogram_geometry_sc, device=device)
         else:
             raise NotImplementedError("Cannot process 3D data without a GPU")
 
         if acquisition_geometry.channels > 1:
-            operator_full = ChannelwiseOperator(
-                operator, self.sinogram_geometry.channels, dimension='prepend')
+            operator_full = ChannelwiseOperator(operator, self.sinogram_geometry.channels, dimension='prepend')
             self.operator = operator_full
         else:
             self.operator = operator
 
-    def direct(self, IM, out=None):
-        '''Applies the direct of the operator i.e. the forward projection.
-        
+    def direct(self, IM:ImageData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+        """Apply the direct of the operator i.e. the forward projection.
+
         Parameters
         ----------
-        IM : ImageData
+        IM
             The image/volume to be projected.
 
-        out : DataContainer, optional
+        out
            Fills the referenced DataContainer with the processed data and suppresses the return
-        
+
         Returns
         -------
         DataContainer
             The processed data. Suppressed if `out` is passed
-        '''
-
+        """
         return self.operator.direct(IM, out=out)
 
-    def adjoint(self, DATA, out=None):
-        '''Applies the adjoint of the operator, i.e. the backward projection.
+    def adjoint(self, DATA:AcquisitionData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+        """Apply the adjoint of the operator, i.e. the backward projection.
 
         Parameters
         ----------
-        DATA : AcquisitionData
+        DATA
             The projections/sinograms to be projected.
 
-        out : DataContainer, optional
+        out
            Fills the referenced DataContainer with the processed data and suppresses the return
-        
+
         Returns
         -------
         DataContainer
             The processed data. Suppressed if `out` is passed
-        '''
+        """
         return self.operator.adjoint(DATA, out=out)
 
-    def calculate_norm(self):
+    def calculate_norm(self) -> float:
+        """Return the norm of the Operator.
+
+        On first call the norm will be calculated using the operator's calculate_norm method.
+        Subsequent calls will return the cached norm.
+
+        Returns
+        -------
+        float
+            Norm of the LinearOperator
+        """
         return self.operator.norm()
 
-    def domain_geometry(self):
+    def domain_geometry(self) -> ImageGeometry:
+        """Return the image geometry of the volume.
+
+        Returns
+        -------
+        ImageGeometry
+            Domain geometry of the reconstruction volume
+        """
         return self.volume_geometry
 
-    def range_geometry(self):
+    def range_geometry(self) -> AcquisitionGeometry:
+        """Return the acquisition geometry of the volume.
+
+        Returns
+        -------
+        AcquisitionGeometry
+            Range geometry of the reconstruction volume
+        """
         return self.sinogram_geometry

--- a/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
@@ -78,8 +78,7 @@ class ProjectionOperator(LinearOperator):
 
 
 class ProjectionOperator_ag(ProjectionOperator):
-    """
-    ProjectionOperator configures and calls appropriate ASTRA Projectors for your dataset.
+    """ProjectionOperator configures and calls appropriate ASTRA Projectors for your dataset.
 
     Parameters
     ----------
@@ -137,7 +136,7 @@ class ProjectionOperator_ag(ProjectionOperator):
         else:
             self.operator = operator
 
-    def direct(self, IM:ImageData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+    def direct(self, IM:ImageData, out:Optional[AcquisitionData]=None) -> Optional[AcquisitionData]:
         """Apply the direct of the operator i.e. the forward projection.
 
         Parameters
@@ -155,7 +154,7 @@ class ProjectionOperator_ag(ProjectionOperator):
         """
         return self.operator.direct(IM, out=out)
 
-    def adjoint(self, DATA:AcquisitionData, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+    def adjoint(self, DATA:AcquisitionData, out:Optional[ImageData]=None) -> Optional[ImageData]:
         """Apply the adjoint of the operator, i.e. the backward projection.
 
         Parameters
@@ -168,7 +167,7 @@ class ProjectionOperator_ag(ProjectionOperator):
 
         Returns
         -------
-        DataContainer
+        ImageData
             The processed data. Suppressed if `out` is passed
         """
         return self.operator.adjoint(DATA, out=out)

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
@@ -24,7 +24,7 @@ import astra
 import numpy as np
 
 from cil.framework import DataProcessor, ImageData
-from cil.framework.framework import AcquisitionGeometry, DataContainer, ImageGeometry
+from cil.framework.framework import AcquisitionData, AcquisitionGeometry, ImageGeometry
 from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_2D
 
 
@@ -80,7 +80,7 @@ class AstraBackProjector2D(DataProcessor):
         else:
             raise NotImplementedError()
 
-    def check_input(self, dataset:DataContainer) -> bool:
+    def check_input(self, dataset:AcquisitionData) -> Literal[True]:
         """Check the dimension comparability of the passed dataset.
 
         Parameters
@@ -139,7 +139,7 @@ class AstraBackProjector2D(DataProcessor):
         Parameters
         ----------
         out
-           Fills the referenced DataContainer with the processed data and suppresses the return
+           Fills the referenced ImageData with the processed data and suppresses the return
 
         Returns
         -------

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
@@ -18,10 +18,14 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 
-from cil.framework import DataProcessor, ImageData
-from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_2D
+from typing import Literal, Optional
+
 import astra
 import numpy as np
+
+from cil.framework import DataProcessor, ImageData
+from cil.framework.framework import AcquisitionGeometry, DataContainer, ImageGeometry
+from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_2D
 
 
 class AstraBackProjector2D(DataProcessor):
@@ -30,73 +34,118 @@ class AstraBackProjector2D(DataProcessor):
 
     Parameters
     ----------
-
-    volume_geometry : ImageGeometry
+    volume_geometry
         A description of the area/volume to reconstruct
 
-    sinogram_geometry : AcquisitionGeometry
+    sinogram_geometry
         A description of the acquisition data
 
-    proj_id : the ASTRA projector ID
+    proj_id
         For advances ASTRA users only. The astra_mex_projector ID of the projector, use `astra.astra_create_projector()`
-        
-    device : string, default='gpu'
-        The device to run on 'gpu' or 'cpu'
 
-    """  
-        
-    def __init__(self,
-                 volume_geometry=None,
-                 sinogram_geometry=None,
-                 proj_id=None,
-                 device='cpu'):
+    device
+        The device to run on "gpu" or "cpu"
+    """
+
+    def __init__(self, volume_geometry:Optional[ImageGeometry]=None,
+                 sinogram_geometry:Optional[AcquisitionGeometry]=None,
+                 proj_id:Optional[int]=None,
+                 device:Literal["cpu", "gpu"]="gpu"):
         kwargs = {
-                  'volume_geometry'  : volume_geometry,
-                  'sinogram_geometry'  : sinogram_geometry,
-                  'proj_id'  : proj_id,
-                  'device'  : device
+                  "volume_geometry"  : volume_geometry,
+                  "sinogram_geometry"  : sinogram_geometry,
+                  "proj_id"  : proj_id,
+                  "device"  : device
                   }
-        
+
         #DataProcessor.__init__(self, **kwargs)
         super(AstraBackProjector2D, self).__init__(**kwargs)
-        
+
         self.set_ImageGeometry(volume_geometry)
         self.set_AcquisitionGeometry(sinogram_geometry)
-        
+
         vol_geom, proj_geom = convert_geometry_to_astra_vec_2D(self.volume_geometry, self.sinogram_geometry)
-        
+
         # ASTRA projector, to be stored
-        if device == 'cpu':
+        if device == "cpu":
             # Note that 'line' only one option
-            if self.sinogram_geometry.geom_type == 'parallel':
-                self.set_projector(astra.create_projector('line', proj_geom, vol_geom) )
-            elif self.sinogram_geometry.geom_type == 'cone':
-                self.set_projector(astra.create_projector('line_fanflat', proj_geom, vol_geom) )
+            if self.sinogram_geometry.geom_type == "parallel":
+                self.set_projector(astra.create_projector("line", proj_geom, vol_geom) )
+            elif self.sinogram_geometry.geom_type == "cone":
+                self.set_projector(astra.create_projector("line_fanflat", proj_geom, vol_geom) )
             else:
-                NotImplemented 
-        elif device == 'gpu':
-            self.set_projector(astra.create_projector('cuda', proj_geom, vol_geom) )
+                raise NotImplementedError()
+        elif device == "gpu":
+            self.set_projector(astra.create_projector("cuda", proj_geom, vol_geom) )
         else:
-            NotImplemented
-    
-    def check_input(self, dataset):
+            raise NotImplementedError()
+
+    def check_input(self, dataset:DataContainer) -> bool:
+        """Check the dimension comparability of the passed dataset.
+
+        Parameters
+        ----------
+        dataset
+            Dataset to be checked
+
+        Returns
+        -------
+        bool
+            True if input checks are passed
+
+        Raises
+        ------
+        ValueError
+            Raised if input fails the dimension check
+        """
         if dataset.number_of_dimensions == 1 or dataset.number_of_dimensions == 2:
                return True
         else:
-            raise ValueError("Expected input dimensions is 1 or 2, got {0}"\
-                             .format(dataset.number_of_dimensions))
-    
-    def set_projector(self, proj_id):
-        self.proj_id = proj_id
-        
-    def set_ImageGeometry(self, volume_geometry):
-        self.volume_geometry = volume_geometry
-        
-    def set_AcquisitionGeometry(self, sinogram_geometry):
-        self.sinogram_geometry = sinogram_geometry
-    
-    def process(self, out=None):
+            raise ValueError("Expected input dimensions is 1 or 2, got {0}".format(dataset.number_of_dimensions))
 
+    def set_projector(self, proj_id:int) -> None:
+        """For advanced users, set the astra_mex_projector ID of the projector, use `astra.astra_create_projector()`.
+
+        Parameters
+        ----------
+        proj_id : int
+            astra_mex_projector ID of the projector
+        """
+        self.proj_id = proj_id
+
+    def set_ImageGeometry(self, volume_geometry:ImageGeometry) -> None:
+        """Set the area/volume geometry to reconstruct.
+
+        Parameters
+        ----------
+        volume_geometry
+            Area/volume geometry
+        """
+        self.volume_geometry = volume_geometry
+
+    def set_AcquisitionGeometry(self, sinogram_geometry:AcquisitionGeometry) -> None:
+        """Set the acquisition geometry of the data.
+
+        Parameters
+        ----------
+        sinogram_geometry
+            Acquisition geometry of the reconstructed data.
+        """
+        self.sinogram_geometry = sinogram_geometry
+
+    def process(self, out:Optional[ImageData]=None) -> Optional[ImageData]:
+        """Reconstruct the volume using ASTRA.
+
+        Parameters
+        ----------
+        out
+           Fills the referenced DataContainer with the processed data and suppresses the return
+
+        Returns
+        -------
+        Optional[ImageData]
+            Reconstructed data
+        """
         DATA = self.get_input()
 
         #ASTRA expects a 3D array with shape 1, CIL removes dimensions of len 1

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
@@ -25,7 +25,8 @@ import numpy as np
 
 from cil.framework import DataProcessor, ImageData
 from cil.framework.framework import AcquisitionData, AcquisitionGeometry, ImageGeometry
-from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_2D
+
+from ..utilities import convert_geometry_to_astra_vec_2D
 
 
 class AstraBackProjector2D(DataProcessor):

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
@@ -18,14 +18,19 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import astra
 import numpy as np
 from astra import algorithm, astra_dict, data3d
 
 from cil.framework import DataOrder, DataProcessor, ImageData
-from cil.framework.framework import AcquisitionGeometry, DataContainer, ImageGeometry
+from cil.framework.framework import (
+    AcquisitionData,
+    AcquisitionGeometry,
+    DataContainer,
+    ImageGeometry,
+)
 from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_3D
 
 
@@ -39,7 +44,6 @@ class AstraBackProjector3D(DataProcessor):
 
     sinogram_geometry
         A description of the acquisition data
-
     """
 
     def __init__(self,
@@ -59,7 +63,7 @@ class AstraBackProjector3D(DataProcessor):
 
         self.vol_geom, self.proj_geom = convert_geometry_to_astra_vec_3D(self.volume_geometry, self.sinogram_geometry)
 
-    def check_input(self, dataset:DataContainer):
+    def check_input(self, dataset:AcquisitionData) -> Literal[True]:
         """Check the dimension comparability of the passed dataset.
 
         Parameters
@@ -81,7 +85,7 @@ class AstraBackProjector3D(DataProcessor):
             raise ValueError("Dataset not compatible with geometry used to create the projector")
         return True
 
-    def set_ImageGeometry(self, volume_geometry:ImageGeometry):
+    def set_ImageGeometry(self, volume_geometry:ImageGeometry) -> None:
         """Set the area/volume geometry to reconstruct.
 
         Parameters
@@ -96,7 +100,7 @@ class AstraBackProjector3D(DataProcessor):
 
         self.volume_geometry = volume_geometry.copy()
 
-    def set_AcquisitionGeometry(self, sinogram_geometry:AcquisitionGeometry):
+    def set_AcquisitionGeometry(self, sinogram_geometry:AcquisitionGeometry) -> None:
         """Set the acquisition geometry of the data.
 
         Parameters
@@ -111,7 +115,7 @@ class AstraBackProjector3D(DataProcessor):
 
         self.sinogram_geometry = sinogram_geometry.copy()
 
-    def process(self, out:Optional[DataContainer]=None):
+    def process(self, out:Optional[ImageData]=None) -> Optional[ImageData]:
         """Reconstruct the volume using ASTRA.
 
         Parameters

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
@@ -28,10 +28,10 @@ from cil.framework import DataOrder, DataProcessor, ImageData
 from cil.framework.framework import (
     AcquisitionData,
     AcquisitionGeometry,
-    DataContainer,
     ImageGeometry,
 )
-from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_3D
+
+from ..utilities import convert_geometry_to_astra_vec_3D
 
 
 class AstraBackProjector3D(DataProcessor):

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
@@ -18,73 +18,112 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 
-from cil.framework import DataProcessor, ImageData, DataOrder
-from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_3D
+from typing import Optional, Union
+
 import astra
-from astra import astra_dict, algorithm, data3d
 import numpy as np
+from astra import algorithm, astra_dict, data3d
+
+from cil.framework import DataOrder, DataProcessor, ImageData
+from cil.framework.framework import AcquisitionGeometry, DataContainer, ImageGeometry
+from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_3D
 
 
 class AstraBackProjector3D(DataProcessor):
-
-    """
-    AstraBackProjector3D configures an ASTRA 3D back projector for GPU.
+    """AstraBackProjector3D configures an ASTRA 3D back projector for GPU.
 
     Parameters
     ----------
-
-    volume_geometry : ImageGeometry
+    volume_geometry
         A description of the area/volume to reconstruct
 
-    sinogram_geometry : AcquisitionGeometry
+    sinogram_geometry
         A description of the acquisition data
 
-    """  
+    """
+
     def __init__(self,
-                 volume_geometry=None,
-                 sinogram_geometry=None):
+                 volume_geometry:Optional[ImageGeometry]=None,
+                 sinogram_geometry:Optional[AcquisitionGeometry]=None):
         kwargs = {
                   'volume_geometry'  : volume_geometry,
                   'sinogram_geometry'  : sinogram_geometry,
                   'proj_geom'  : None,
                   'vol_geom'  : None}
-        
+
         #DataProcessor.__init__(self, **kwargs)
         super(AstraBackProjector3D, self).__init__(**kwargs)
-        
+
         self.set_ImageGeometry(volume_geometry)
         self.set_AcquisitionGeometry(sinogram_geometry)
-        
+
         self.vol_geom, self.proj_geom = convert_geometry_to_astra_vec_3D(self.volume_geometry, self.sinogram_geometry)
-        
-    
-    def check_input(self, dataset):
 
+    def check_input(self, dataset:DataContainer):
+        """Check the dimension comparability of the passed dataset.
+
+        Parameters
+        ----------
+        dataset
+            Dataset to be checked
+
+        Returns
+        -------
+        bool
+            True if input checks are passed
+
+        Raises
+        ------
+        ValueError
+            Raised if input fails the dimension check
+        """
         if self.sinogram_geometry.shape != dataset.geometry.shape:
-            raise ValueError("Dataset not compatible with geometry used to create the projector")  
-    
+            raise ValueError("Dataset not compatible with geometry used to create the projector")
         return True
-    
-    def set_ImageGeometry(self, volume_geometry):
 
+    def set_ImageGeometry(self, volume_geometry:ImageGeometry):
+        """Set the area/volume geometry to reconstruct.
+
+        Parameters
+        ----------
+        volume_geometry
+            Area/volume geometry
+        """
         DataOrder.check_order_for_engine('astra', volume_geometry)
 
         if len(volume_geometry.dimension_labels) > 3:
-            raise ValueError("Supports 2D and 3D data only, got {0}".format(volume_geometry.number_of_dimensions))  
+            raise ValueError("Supports 2D and 3D data only, got {0}".format(volume_geometry.number_of_dimensions))
 
         self.volume_geometry = volume_geometry.copy()
 
-    def set_AcquisitionGeometry(self, sinogram_geometry):
+    def set_AcquisitionGeometry(self, sinogram_geometry:AcquisitionGeometry):
+        """Set the acquisition geometry of the data.
 
+        Parameters
+        ----------
+        sinogram_geometry
+            Acquisition geometry of the reconstructed data.
+        """
         DataOrder.check_order_for_engine('astra', sinogram_geometry)
 
         if len(sinogram_geometry.dimension_labels) > 3:
-            raise ValueError("Supports 2D and 3D data only, got {0}".format(sinogram_geometry.number_of_dimensions))  
+            raise ValueError("Supports 2D and 3D data only, got {0}".format(sinogram_geometry.number_of_dimensions))
 
         self.sinogram_geometry = sinogram_geometry.copy()
 
-    def process(self, out=None):
+    def process(self, out:Optional[DataContainer]=None):
+        """Reconstruct the volume using ASTRA.
 
+        Parameters
+        ----------
+        out
+           Fills the referenced DataContainer with the processed data and suppresses the return
+
+        Returns
+        -------
+        Optional[ImageData]
+            Reconstructed data
+        """
         DATA = self.get_input()
 
         #ASTRA expects a 3D array with shape 1, CIL removes dimensions of len 1
@@ -105,7 +144,7 @@ class AstraBackProjector3D(DataProcessor):
 
         # delete the GPU copy
         astra.data3d.delete(rec_id)
-        
+
         arr_out = np.squeeze(arr_out)
 
         if out is None:
@@ -114,36 +153,31 @@ class AstraBackProjector3D(DataProcessor):
         else:
             out.fill(arr_out)
 
-    def create_backprojection3d_gpu(self, data, proj_geom, vol_geom, returnData=True, vol_id=None):
-
-        """
-        Call to ASTRA to create a backward projection of an image (3D)
+    def create_backprojection3d_gpu(self, data:Union[np.ndarray, int], proj_geom:dict, vol_geom:dict, returnData:bool=True, vol_id:Optional[int]=None) -> Union[int, Union[int, np.ndarray]]:
+        """Call to ASTRA to create a backward projection of an image (3D).
 
         Parameters
         ----------
-
-        data : numpy.ndarray or int
+        data
             Image data or ID.
 
-        proj_geom : dict
+        proj_geom
             Projection geometry.
 
-        vol_geom : dict
+        vol_geom
             Volume geometry.
 
-        returnData : bool
+        returnData
             If False, only return the ID of the forward projection.
 
-        vol_id : int, default None
+        vol_id
             ID of the np array linked with astra.
 
         Returns
         -------
-
-        proj_geom : int or (int, numpy.ndarray)
+        proj_geom
             If ``returnData=False``, returns the ID of the back projection. Otherwise returns a tuple containing the ID of the back projection and the back projection itself.
         """
-
         if isinstance(data, np.ndarray):
             sino_id = data3d.create('-sino', proj_geom, data)
         else:

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
@@ -26,11 +26,11 @@ import numpy as np
 from cil.framework import AcquisitionData, DataProcessor
 from cil.framework.framework import (
     AcquisitionGeometry,
-    DataContainer,
     ImageData,
     ImageGeometry,
 )
-from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_2D
+
+from ..utilities import convert_geometry_to_astra_vec_2D
 
 
 class AstraForwardProjector2D(DataProcessor):

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
@@ -18,19 +18,22 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 
-from cil.framework import DataProcessor, AcquisitionData
-from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_2D
+from typing import Literal, Optional
+
 import astra
 import numpy as np
 
-class AstraForwardProjector2D(DataProcessor):
+from cil.framework import AcquisitionData, DataProcessor
+from cil.framework.framework import AcquisitionGeometry, DataContainer, ImageData, ImageGeometry
+from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_2D
 
+
+class AstraForwardProjector2D(DataProcessor):
     """
     AstraForwardProjector2D configures an ASTRA 2D forward projector for CPU and GPU.
 
     Parameters
     ----------
-
     volume_geometry : ImageGeometry
         A description of the area/volume to reconstruct
 
@@ -39,65 +42,114 @@ class AstraForwardProjector2D(DataProcessor):
 
     proj_id : the ASTRA projector ID
         For advances ASTRA users only. The astra_mex_projector ID of the projector, use `astra.astra_create_projector()`
-        
-    device : string, default='gpu'
-        The device to run on 'gpu' or 'cpu'
 
-    """  
-    
+    device : string, default="gpu"
+        The device to run on "gpu" or "cpu"
+
+    """
+
     def __init__(self,
-                 volume_geometry=None,
-                 sinogram_geometry=None,
-                 proj_id=None,
-                 device='cpu'):
+                 volume_geometry:Optional[ImageGeometry]=None,
+                 sinogram_geometry:Optional[AcquisitionGeometry]=None,
+                 proj_id:Optional[int]=None,
+                 device:Literal["cpu", "gpu"]="cpu"):
         kwargs = {
-                  'volume_geometry'  : volume_geometry,
-                  'sinogram_geometry'  : sinogram_geometry,
-                  'proj_id'  : proj_id,
-                  'device'  : device
+                  "volume_geometry"  : volume_geometry,
+                  "sinogram_geometry"  : sinogram_geometry,
+                  "proj_id"  : proj_id,
+                  "device"  : device
                   }
-        
+
         #DataProcessor.__init__(self, **kwargs)
         super(AstraForwardProjector2D, self).__init__(**kwargs)
-        
+
         self.set_ImageGeometry(volume_geometry)
         self.set_AcquisitionGeometry(sinogram_geometry)
-        
+
         vol_geom, proj_geom = convert_geometry_to_astra_vec_2D(self.volume_geometry, self.sinogram_geometry)
-        
+
         # ASTRA projector, to be stored
-        if device == 'cpu':
+        if device == "cpu":
             # Note that 'line' only one option
-            if self.sinogram_geometry.geom_type == 'parallel':
-                self.set_projector(astra.create_projector('line', proj_geom, vol_geom) )
-            elif self.sinogram_geometry.geom_type == 'cone':
-                self.set_projector(astra.create_projector('line_fanflat', proj_geom, vol_geom) )
+            if self.sinogram_geometry.geom_type == "parallel":
+                self.set_projector(astra.create_projector("line", proj_geom, vol_geom) )
+            elif self.sinogram_geometry.geom_type == "cone":
+                self.set_projector(astra.create_projector("line_fanflat", proj_geom, vol_geom) )
             else:
-                NotImplemented    
-        elif device == 'gpu':
-            self.set_projector(astra.create_projector('cuda', proj_geom, vol_geom) )
+                raise NotImplementedError()
+        elif device == "gpu":
+            self.set_projector(astra.create_projector("cuda", proj_geom, vol_geom) )
         else:
-            NotImplemented
-    
-    def check_input(self, dataset):
+            raise NotImplementedError()
+
+    def check_input(self, dataset:DataContainer) -> bool:
+        """Check the dimension comparability of the passed dataset.
+
+        Parameters
+        ----------
+        dataset
+            Dataset to be checked
+
+        Returns
+        -------
+        bool
+            True if input checks are passed
+
+        Raises
+        ------
+        ValueError
+            Raised if input fails the dimension check
+        """
         if dataset.number_of_dimensions == 1 or\
            dataset.number_of_dimensions == 2:
                return True
         else:
             raise ValueError("Expected input dimensions is 1 or 2, got {0}"\
                              .format(dataset.number_of_dimensions))
-    
-    def set_projector(self, proj_id):
-        self.proj_id = proj_id
-    
-    def set_ImageGeometry(self, volume_geometry):
-        self.volume_geometry = volume_geometry
-    
-    def set_AcquisitionGeometry(self, sinogram_geometry):
-        self.sinogram_geometry = sinogram_geometry
-        
-    def process(self, out=None):
 
+    def set_projector(self, proj_id:int) -> None:
+        """For advanced users, set the astra_mex_projector ID of the projector, use `astra.astra_create_projector()`.
+
+        Parameters
+        ----------
+        proj_id : int
+            astra_mex_projector ID of the projector
+        """
+        self.proj_id = proj_id
+
+    def set_ImageGeometry(self, volume_geometry:ImageGeometry) -> None:
+        """Set the area/volume geometry to reconstruct.
+
+        Parameters
+        ----------
+        volume_geometry
+            Area/volume geometry
+        """
+        self.volume_geometry = volume_geometry
+
+    def set_AcquisitionGeometry(self, sinogram_geometry:AcquisitionGeometry) -> None:
+        """Set the acquisition geometry of the data.
+
+        Parameters
+        ----------
+        sinogram_geometry
+            Acquisition geometry of the reconstructed data.
+        """
+        self.sinogram_geometry = sinogram_geometry
+
+    def process(self, out:Optional[AcquisitionData]=None) -> Optional[AcquisitionData]:
+        """Reconstruct the volume using ASTRA.
+
+        Parameters
+        ----------
+        out
+           Fills the referenced DataContainer with the processed data and suppresses the return
+
+        Returns
+        -------
+        Optional[AcquisitionData]
+            Reconstructed data
+        """
         IM = self.get_input()
 
         #ASTRA expects a 2D array with shape 1, CIL removes dimensions of len 1
@@ -108,7 +160,7 @@ class AstraForwardProjector2D(DataProcessor):
 
         sinogram_id, arr_out = astra.create_sino(IM_data_temp, self.proj_id)
         astra.data2d.delete(sinogram_id)
-        
+
         arr_out = np.squeeze(arr_out)
         if out is None:
             out = AcquisitionData(arr_out, deep_copy=False, geometry=self.sinogram_geometry.copy(), suppress_warning=True)

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
@@ -24,35 +24,34 @@ import astra
 import numpy as np
 
 from cil.framework import AcquisitionData, DataProcessor
-from cil.framework.framework import AcquisitionGeometry, DataContainer, ImageData, ImageGeometry
+from cil.framework.framework import (
+    AcquisitionGeometry,
+    DataContainer,
+    ImageData,
+    ImageGeometry,
+)
 from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_2D
 
 
 class AstraForwardProjector2D(DataProcessor):
-    """
-    AstraForwardProjector2D configures an ASTRA 2D forward projector for CPU and GPU.
+    """AstraForwardProjector2D configures an ASTRA 2D forward projector for CPU and GPU.
 
     Parameters
     ----------
-    volume_geometry : ImageGeometry
+    volume_geometry
         A description of the area/volume to reconstruct
 
-    sinogram_geometry : AcquisitionGeometry
+    sinogram_geometry
         A description of the acquisition data
 
-    proj_id : the ASTRA projector ID
+    proj_id
         For advances ASTRA users only. The astra_mex_projector ID of the projector, use `astra.astra_create_projector()`
 
-    device : string, default="gpu"
+    device
         The device to run on "gpu" or "cpu"
-
     """
 
-    def __init__(self,
-                 volume_geometry:Optional[ImageGeometry]=None,
-                 sinogram_geometry:Optional[AcquisitionGeometry]=None,
-                 proj_id:Optional[int]=None,
-                 device:Literal["cpu", "gpu"]="cpu"):
+    def __init__(self, volume_geometry:Optional[ImageGeometry]=None, sinogram_geometry:Optional[AcquisitionGeometry]=None, proj_id:Optional[int]=None, device:Literal["cpu", "gpu"]="cpu"):
         kwargs = {
                   "volume_geometry"  : volume_geometry,
                   "sinogram_geometry"  : sinogram_geometry,
@@ -82,7 +81,7 @@ class AstraForwardProjector2D(DataProcessor):
         else:
             raise NotImplementedError()
 
-    def check_input(self, dataset:DataContainer) -> bool:
+    def check_input(self, dataset:ImageData) -> Literal[True]:
         """Check the dimension comparability of the passed dataset.
 
         Parameters
@@ -137,13 +136,13 @@ class AstraForwardProjector2D(DataProcessor):
         """
         self.sinogram_geometry = sinogram_geometry
 
-    def process(self, out:Optional[AcquisitionData]=None) -> Optional[AcquisitionData]:
+    def process(self, out:Optional[ImageData]=None) -> Optional[AcquisitionData]:
         """Reconstruct the volume using ASTRA.
 
         Parameters
         ----------
         out
-           Fills the referenced DataContainer with the processed data and suppresses the return
+           Fills the referenced ImageData with the processed data and suppresses the return
 
         Returns
         -------

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector3D.py
@@ -27,11 +27,11 @@ from astra import algorithm, astra_dict, data3d
 from cil.framework import AcquisitionData, DataOrder, DataProcessor
 from cil.framework.framework import (
     AcquisitionGeometry,
-    DataContainer,
     ImageData,
     ImageGeometry,
 )
-from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_3D
+
+from ..utilities import convert_geometry_to_astra_vec_3D
 
 
 class AstraForwardProjector3D(DataProcessor):

--- a/Wrappers/Python/cil/plugins/astra/processors/FBP.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FBP.py
@@ -27,8 +27,9 @@ from cil.framework.framework import (
     ImageData,
     ImageGeometry,
 )
-from cil.plugins.astra.processors.FBP_Flexible import FBP_CPU, FBP_Flexible
-from cil.plugins.astra.processors.FDK_Flexible import FDK_Flexible
+
+from .FBP_Flexible import FBP_CPU, FBP_Flexible
+from .FDK_Flexible import FDK_Flexible
 
 
 class FBP(DataProcessor):

--- a/Wrappers/Python/cil/plugins/astra/processors/FBP.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FBP.py
@@ -17,14 +17,19 @@
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
-from typing import Literal, Optional
-from cil.framework import DataProcessor
-from cil.framework import DataOrder
-from cil.framework.framework import AcquisitionGeometry, DataContainer, ImageGeometry
-from cil.plugins.astra.processors.FBP_Flexible import FBP_Flexible
-from cil.plugins.astra.processors.FDK_Flexible import FDK_Flexible
-from cil.plugins.astra.processors.FBP_Flexible import FBP_CPU
 import logging
+from typing import Literal, Optional
+
+from cil.framework import DataOrder, DataProcessor
+from cil.framework.framework import (
+    AcquisitionGeometry,
+    DataContainer,
+    ImageData,
+    ImageGeometry,
+)
+from cil.plugins.astra.processors.FBP_Flexible import FBP_CPU, FBP_Flexible
+from cil.plugins.astra.processors.FDK_Flexible import FDK_Flexible
+
 
 class FBP(DataProcessor):
     """FBP configures and calls an appropriate ASTRA FBP or FDK algorithm for your dataset.
@@ -49,7 +54,6 @@ class FBP(DataProcessor):
     >>> fbp = FBP(image_geometry, data.geometry)
     >>> fbp.set_input(data)
     >>> reconstruction = fbp.get_output()
-
 
     Notes
     -----
@@ -111,7 +115,7 @@ class FBP(DataProcessor):
 
         Parameters
         ----------
-        dataset : DataContainer
+        dataset
             Input DataContainer for reconstruction
         """
         return self.processor.set_input(dataset)
@@ -131,7 +135,7 @@ class FBP(DataProcessor):
 
         Parameters
         ----------
-        out :
+        out
             Fills the referenced DataContainer with the processed data, and suppresses the return
 
         Returns
@@ -153,17 +157,17 @@ class FBP(DataProcessor):
         """
         return self.processor.check_input(dataset)
 
-    def process(self, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+    def process(self, out:Optional[ImageData]=None) -> Optional[ImageData]:
         """Reconstruct data and return the result.
 
         Parameters
         ----------
         out
-            Fills the reference DataContainer with the processed data, and suppresses the return
+            Fills the reference ImageData with the processed data, and suppresses the return
 
         Returns
         -------
-        Optional[DataContainer]
+        Optional[ImageData]
             Reconstructed data, None if out is set.
         """
         return self.processor.process(out=out)

--- a/Wrappers/Python/cil/plugins/astra/processors/FBP.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FBP.py
@@ -17,17 +17,17 @@
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
+from typing import Literal, Optional
 from cil.framework import DataProcessor
 from cil.framework import DataOrder
+from cil.framework.framework import AcquisitionGeometry, DataContainer, ImageGeometry
 from cil.plugins.astra.processors.FBP_Flexible import FBP_Flexible
 from cil.plugins.astra.processors.FDK_Flexible import FDK_Flexible
 from cil.plugins.astra.processors.FBP_Flexible import FBP_CPU
 import logging
 
 class FBP(DataProcessor):
-
-    """
-    FBP configures and calls an appropriate ASTRA FBP or FDK algorithm for your dataset.
+    """FBP configures and calls an appropriate ASTRA FBP or FDK algorithm for your dataset.
 
     The best results will be on data with circular trajectories of a 2PI angular range and equally spaced small angular steps.
 
@@ -43,13 +43,12 @@ class FBP(DataProcessor):
         'gpu' will run on a compatible CUDA capable device using the ASTRA FDK_CUDA algorithm
         'cpu' will run on CPU using the ASTRA FBP algorithm - see Notes for limitations
 
-
     Example
     -------
     >>> from cil.plugins.astra import FBP
     >>> fbp = FBP(image_geometry, data.geometry)
     >>> fbp.set_input(data)
-    >>> reconstruction = fbp.get_ouput()
+    >>> reconstruction = fbp.get_output()
 
 
     Notes
@@ -57,15 +56,14 @@ class FBP(DataProcessor):
     A CPU version is provided for simple 2D parallel-beam geometries only, any offsets and rotations in the acquisition geometry will be ignored.
 
     This uses the ram-lak filter only.
-
     """
 
-    
-    def __init__(self, image_geometry=None, acquisition_geometry=None, device='gpu', **kwargs): 
-        
+    processor:DataProcessor
 
-        sinogram_geometry = kwargs.get('sinogram_geometry', None)
-        volume_geometry = kwargs.get('volume_geometry', None)
+    def __init__(self, image_geometry:Optional[ImageGeometry]=None, acquisition_geometry:Optional[AcquisitionGeometry]=None, device:Literal["gpu","cpu"]="gpu", **kwargs):
+
+        sinogram_geometry = kwargs.get("sinogram_geometry", None)
+        volume_geometry = kwargs.get("volume_geometry", None)
 
         if sinogram_geometry is not None:
             acquisition_geometry = sinogram_geometry
@@ -73,7 +71,7 @@ class FBP(DataProcessor):
 
         if acquisition_geometry is None:
             raise TypeError("Please specify an acquisition_geometry to configure this processor")
-            
+
         if volume_geometry is not None:
             image_geometry = volume_geometry
             logging.warning("volume_geometry has been deprecated. Please use image_geometry instead.")
@@ -81,44 +79,91 @@ class FBP(DataProcessor):
         if image_geometry is None:
             image_geometry = acquisition_geometry.get_ImageGeometry()
 
-        DataOrder.check_order_for_engine('astra', image_geometry)
-        DataOrder.check_order_for_engine('astra', acquisition_geometry) 
+        DataOrder.check_order_for_engine("astra", image_geometry)
+        DataOrder.check_order_for_engine("astra", acquisition_geometry)
 
-        if device == 'gpu':
-            if acquisition_geometry.geom_type == 'parallel':
+        if device == "gpu":
+            if acquisition_geometry.geom_type == "parallel":
                 processor = FBP_Flexible(image_geometry, acquisition_geometry)
             else:
                 processor = FDK_Flexible(image_geometry, acquisition_geometry)
-            
+
         else:
             UserWarning("ASTRA back-projector running on CPU will not make use of enhanced geometry parameters")
 
-            if acquisition_geometry.geom_type == 'cone':
+            if acquisition_geometry.geom_type == "cone":
                 raise NotImplementedError("Cannot process cone-beam data without a GPU")
 
-            if acquisition_geometry.dimension == '2D':
-                processor = FBP_CPU(image_geometry, acquisition_geometry) 
+            if acquisition_geometry.dimension == "2D":
+                processor = FBP_CPU(image_geometry, acquisition_geometry)
             else:
                 raise NotImplementedError("Cannot process 3D data without a GPU")
 
-        if acquisition_geometry.channels > 1: 
+        if acquisition_geometry.channels > 1:
             raise NotImplementedError("Cannot process multi-channel data")
             #processor_full = ChannelwiseProcessor(processor, self.acquisition_geometry.channels, dimension='prepend')
             #self.processor = operator_full
-        
-        super(FBP, self).__init__( image_geometry=image_geometry, acquisition_geometry=acquisition_geometry, device=device, processor=processor)  
 
-    def set_input(self, dataset):       
+        super(FBP, self).__init__(image_geometry=image_geometry, acquisition_geometry=acquisition_geometry, device=device, processor=processor)
+
+    def set_input(self, dataset:DataContainer) -> None:
+        """Set the input data for reconstruction.
+
+        Parameters
+        ----------
+        dataset : DataContainer
+            Input DataContainer for reconstruction
+        """
         return self.processor.set_input(dataset)
 
-    def get_input(self):       
+    def get_input(self) -> DataContainer:
+        """Get input data used for reconstruction.
+
+        Returns
+        -------
+        DataContainer
+            Input data
+        """
         return self.processor.get_input()
 
-    def get_output(self, out=None):
+    def get_output(self, out:Optional[DataContainer]=None) -> DataContainer:
+        """Get the result of reconstruction.
+
+        Parameters
+        ----------
+        out :
+            Fills the referenced DataContainer with the processed data, and suppresses the return
+
+        Returns
+        -------
+        DataContainer
+            Reconstructed data. Suppressed if `out` is passed.
+        """
         return self.processor.get_output(out=out)
 
-    def check_input(self, dataset):       
+    def check_input(self, dataset:DataContainer) -> Literal[True]:
+        """Check the parameters of the input dataset.
+
+        Should raise an error if the DataContainer does not match expectation, e.g incorrect dimensions.
+
+        Parameters
+        ----------
+        dataset
+            Input DataContainer to check
+        """
         return self.processor.check_input(dataset)
-        
-    def process(self, out=None):
+
+    def process(self, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+        """Reconstruct data and return the result.
+
+        Parameters
+        ----------
+        out
+            Fills the reference DataContainer with the processed data, and suppresses the return
+
+        Returns
+        -------
+        Optional[DataContainer]
+            Reconstructed data, None if out is set.
+        """
         return self.processor.process(out=out)

--- a/Wrappers/Python/cil/plugins/astra/processors/FBP_Flexible.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FBP_Flexible.py
@@ -26,11 +26,12 @@ import numpy as np
 
 from cil.framework import AcquisitionGeometry, ImageData, Processor
 from cil.framework.framework import AcquisitionData, ImageGeometry
-from cil.plugins.astra.processors.FDK_Flexible import FDK_Flexible
-from cil.plugins.astra.utilities import (
+
+from ..utilities import (
     convert_geometry_to_astra,
     convert_geometry_to_astra_vec_3D,
 )
+from .FDK_Flexible import FDK_Flexible
 
 
 class FBP_Flexible(FDK_Flexible):

--- a/Wrappers/Python/cil/plugins/astra/processors/FDK_Flexible.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FDK_Flexible.py
@@ -19,11 +19,18 @@
 
 
 from typing import Literal, Optional
-from cil.framework import DataProcessor, ImageData
-from cil.framework.framework import AcquisitionData, AcquisitionGeometry, DataContainer, ImageGeometry
-from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_3D
+
 import astra
 import numpy as np
+
+from cil.framework import DataProcessor, ImageData
+from cil.framework.framework import (
+    AcquisitionData,
+    AcquisitionGeometry,
+    DataContainer,
+    ImageGeometry,
+)
+from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_3D
 
 
 class FDK_Flexible(DataProcessor):
@@ -47,8 +54,7 @@ class FDK_Flexible(DataProcessor):
     >>> from cil.plugins.astra import FDK_Flexible
     >>> fbp = FDK_Flexible(image_geometry, data.geometry)
     >>> fbp.set_input(data)
-    >>> reconstruction = fbp.get_ouput()
-
+    >>> reconstruction = fbp.get_output()
     """
 
     def __init__(self, volume_geometry:ImageGeometry, sinogram_geometry:AcquisitionGeometry):
@@ -63,8 +69,16 @@ class FDK_Flexible(DataProcessor):
 
 
 
-    def check_input(self, dataset:DataContainer) -> Literal[True]:
+    def check_input(self, dataset:AcquisitionData) -> Literal[True]:
+        """Check the parameters of the input dataset.
 
+        Should raise an error if the AcquisitionData does not match expectation, e.g incorrect dimensions.
+
+        Parameters
+        ----------
+        dataset
+            Input AcquisitionData to check
+        """
         if self.sinogram_geometry.channels != 1:
             raise ValueError("Expected input data to be single channel, got {0}"\
                  .format(self.sinogram_geometry.channels))
@@ -76,8 +90,19 @@ class FDK_Flexible(DataProcessor):
         return True
 
 
-    def process(self, out:Optional[DataContainer]=None) -> Optional[DataContainer]:
+    def process(self, out:Optional[ImageData]=None) -> Optional[ImageData]:
+        """Reconstruct data and return the result.
 
+        Parameters
+        ----------
+        out
+            Fills the reference ImageData with the processed data, and suppresses the return
+
+        Returns
+        -------
+        Optional[ImageData]
+            Reconstructed data, None if out is set.
+        """
         # Get DATA
         DATA = self.get_input()
 

--- a/Wrappers/Python/cil/plugins/astra/processors/FDK_Flexible.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FDK_Flexible.py
@@ -27,10 +27,10 @@ from cil.framework import DataProcessor, ImageData
 from cil.framework.framework import (
     AcquisitionData,
     AcquisitionGeometry,
-    DataContainer,
     ImageGeometry,
 )
-from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_3D
+
+from ..utilities import convert_geometry_to_astra_vec_3D
 
 
 class FDK_Flexible(DataProcessor):

--- a/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra.py
+++ b/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra.py
@@ -19,20 +19,22 @@
 
 
 from typing import Tuple
+
 import astra
 import numpy as np
 
 from cil.framework.framework import AcquisitionGeometry, ImageGeometry
+
 
 def convert_geometry_to_astra(volume_geometry:ImageGeometry, sinogram_geometry:AcquisitionGeometry) -> Tuple[dict, dict]:
     """Convert CIL geometries to simple ASTRA Geometries. Any offsets/rotations will be ignored.
 
     Parameters
     ----------
-    volume_geometry : ImageGeometry
+    volume_geometry
         A description of the area/volume to reconstruct
 
-    sinogram_geometry : AcquisitionGeometry
+    sinogram_geometry
         A description of the acquisition data
 
     Returns

--- a/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra.py
+++ b/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra.py
@@ -18,12 +18,14 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 
+from typing import Tuple
 import astra
 import numpy as np
 
-def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
-    """
-    Converts CIL geometries to simple ASTRA Geometries. Any offsets/rotations will be ignored.
+from cil.framework.framework import AcquisitionGeometry, ImageGeometry
+
+def convert_geometry_to_astra(volume_geometry:ImageGeometry, sinogram_geometry:AcquisitionGeometry) -> Tuple[dict, dict]:
+    """Convert CIL geometries to simple ASTRA Geometries. Any offsets/rotations will be ignored.
 
     Parameters
     ----------
@@ -39,7 +41,6 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
         The ASTRA vol_geom and proj_geom
 
     """
-
     # determine if the geometry is 2D or 3D
 
     if sinogram_geometry.pixel_num_v > 1:
@@ -55,13 +56,13 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
         angles_rad = sinogram_geometry.config.angles.angle_data
 
     if dimension == '2D':
-        vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_y, 
-                                         volume_geometry.voxel_num_x, 
-                                         volume_geometry.get_min_x(), 
-                                         volume_geometry.get_max_x(), 
-                                         volume_geometry.get_min_y(), 
+        vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_y,
+                                         volume_geometry.voxel_num_x,
+                                         volume_geometry.get_min_x(),
+                                         volume_geometry.get_max_x(),
+                                         volume_geometry.get_min_y(),
                                          volume_geometry.get_max_y())
-        
+
         if sinogram_geometry.geom_type == 'parallel':
             proj_geom = astra.create_proj_geom('parallel',
                                                sinogram_geometry.pixel_size_h,
@@ -75,19 +76,19 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
                                                np.abs(sinogram_geometry.dist_source_center),
                                                np.abs(sinogram_geometry.dist_center_detector))
         else:
-            NotImplemented
-            
+            raise NotImplementedError()
+
     elif dimension == '3D':
-        vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_y, 
-                                         volume_geometry.voxel_num_x, 
-                                         volume_geometry.voxel_num_z, 
-                                         volume_geometry.get_min_x(), 
-                                         volume_geometry.get_max_x(), 
-                                         volume_geometry.get_min_y(), 
-                                         volume_geometry.get_max_y(), 
-                                         volume_geometry.get_min_z(), 
+        vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_y,
+                                         volume_geometry.voxel_num_x,
+                                         volume_geometry.voxel_num_z,
+                                         volume_geometry.get_min_x(),
+                                         volume_geometry.get_max_x(),
+                                         volume_geometry.get_min_y(),
+                                         volume_geometry.get_max_y(),
+                                         volume_geometry.get_min_z(),
                                          volume_geometry.get_max_z())
-        
+
         if sinogram_geometry.geom_type == 'parallel':
             proj_geom = astra.create_proj_geom('parallel3d',
                                                sinogram_geometry.pixel_size_h,
@@ -105,9 +106,9 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
                                                np.abs(sinogram_geometry.dist_source_center),
                                                np.abs(sinogram_geometry.dist_center_detector))
         else:
-            NotImplemented
-            
+            raise NotImplementedError()
+
     else:
-        NotImplemented
-    
+        raise NotImplementedError()
+
     return vol_geom, proj_geom

--- a/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_2D.py
+++ b/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_2D.py
@@ -18,31 +18,31 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 
+from typing import Tuple
 import astra
 import numpy as np
 
-def convert_geometry_to_astra_vec_2D(volume_geometry, sinogram_geometry_in):
+from cil.framework.framework import AcquisitionGeometry, ImageGeometry
 
-    """
-    Converts CIL 2D geometries to ASTRA 2D vector Geometries.
+def convert_geometry_to_astra_vec_2D(volume_geometry:ImageGeometry, sinogram_geometry_in:AcquisitionGeometry) -> Tuple[dict, dict]:
+    """Convert CIL 2D geometries to ASTRA 2D vector Geometries.
 
     Parameters
     ----------
-    volume_geometry : ImageGeometry
+    volume_geometry
         A description of the area/volume to reconstruct
 
-    sinogram_geometry : AcquisitionGeometry
+    sinogram_geometry
         A description of the acquisition data
 
     Returns
     -------
     astra_volume_geom, astra_projection_geom
         The ASTRA vol_geom and proj_geom
-
     """
     sinogram_geometry = sinogram_geometry_in.copy()
-    
-    #this catches behaviour modified after CIL 21.3.1 
+
+    #this catches behaviour modified after CIL 21.3.1
     try:
         sinogram_geometry.config.system.align_reference_frame('cil')
     except:
@@ -54,7 +54,7 @@ def convert_geometry_to_astra_vec_2D(volume_geometry, sinogram_geometry_in):
 
     #get units
     degrees = angles.angle_unit == sinogram_geometry.DEGREE
-    
+
     #create a 2D astra geom from 2D CIL geometry, 2D astra geometry has axis flipped compared to 3D
     volume_geometry_temp = volume_geometry.copy()
 
@@ -90,8 +90,8 @@ def convert_geometry_to_astra_vec_2D(volume_geometry, sinogram_geometry_in):
         vectors[i, 2:4] = rotation_matrix.dot(det).reshape(2)
         vectors[i, 4:6] = rotation_matrix.dot(row).reshape(2)
 
-    
-    proj_geom = astra.creators.create_proj_geom(projector, panel.num_pixels[0], vectors)    
+
+    proj_geom = astra.creators.create_proj_geom(projector, panel.num_pixels[0], vectors)
     vol_geom = astra.create_vol_geom(volume_geometry_temp.voxel_num_y,
                                     volume_geometry_temp.voxel_num_x,
                                     volume_geometry_temp.get_min_x(),
@@ -102,16 +102,15 @@ def convert_geometry_to_astra_vec_2D(volume_geometry, sinogram_geometry_in):
 
     return vol_geom, proj_geom
 
-def rotation_matrix_z_from_euler(angle, degrees):
-    """
-    Returns 2D rotation matrix for z axis using direction cosine
+def rotation_matrix_z_from_euler(angle:float, degrees:bool) -> np.ndarray:
+    """Return 2D rotation matrix for z axis using direction cosine.
 
     Parameters
     ----------
-    angle : float
+    angle
         angle or rotation around z axis
 
-    degrees : bool
+    degrees
         if radian or degrees
     """
     if degrees:
@@ -124,5 +123,5 @@ def rotation_matrix_z_from_euler(angle, degrees):
     rot_matrix[0][1] = -np.sin(alpha)
     rot_matrix[1][0] = np.sin(alpha)
     rot_matrix[1][1] = np.cos(alpha)
-    
+
     return rot_matrix

--- a/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_2D.py
+++ b/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_2D.py
@@ -19,10 +19,12 @@
 
 
 from typing import Tuple
+
 import astra
 import numpy as np
 
 from cil.framework.framework import AcquisitionGeometry, ImageGeometry
+
 
 def convert_geometry_to_astra_vec_2D(volume_geometry:ImageGeometry, sinogram_geometry_in:AcquisitionGeometry) -> Tuple[dict, dict]:
     """Convert CIL 2D geometries to ASTRA 2D vector Geometries.

--- a/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_3D.py
+++ b/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_3D.py
@@ -19,20 +19,22 @@
 
 
 from typing import Tuple
+
 import astra
 import numpy as np
 
 from cil.framework.framework import AcquisitionGeometry, ImageGeometry
+
 
 def convert_geometry_to_astra_vec_3D(volume_geometry:ImageGeometry, sinogram_geometry_in:AcquisitionGeometry) -> Tuple[dict, dict]:
     """Convert CIL 2D and 3D geometries to ASTRA 3D vector Geometries.
 
     Parameters
     ----------
-    volume_geometry : ImageGeometry
+    volume_geometry
         A description of the area/volume to reconstruct
 
-    sinogram_geometry : AcquisitionGeometry
+    sinogram_geometry
         A description of the acquisition data
 
     Returns
@@ -136,19 +138,16 @@ def convert_geometry_to_astra_vec_3D(volume_geometry:ImageGeometry, sinogram_geo
     return vol_geom, proj_geom
 
 def rotation_matrix_z_from_euler(angle:float, degrees:bool) -> np.ndarray:
-
-    """
-    Returns 3D rotation matrix for z axis using direction cosine
+    """Return 3D rotation matrix for z axis using direction cosine.
 
     Parameters
     ----------
-    angle : float
+    angle
         angle or rotation around z axis
 
-    degrees : bool
-        if radian or degrees
+    degrees
+        If True, angle is in degrees. If False, use radians
     """
-
     if degrees:
         alpha = angle / 180. * np.pi
     else:


### PR DESCRIPTION
This is part of the software sustainability hackathon, and is part of a larger
project to improve cil's documentation. #1683

## Describe your changes

Since the changes are quite large, this PR is limited to the `cil.plugins.astra` folder.

No functional code changes were performed.

- Sorted imports
- Document and typehint functions, following the numpy standard
	- Private functions are not documented.
- Move `__init__` to top of class
- Move private functions to bottom of class
- Standardise using `"` for strings
- Explicitly state classes as abstract classes

## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues

- https://github.com/TomographicImaging/CIL/issues/1683

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
