### PR TITLE
CI: pass tests in ignore-paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,3 +155,7 @@ jobs:
         push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+  pass:
+    needs: [conda, docs, docker]
+    runs-on: ubuntu-latest
+    steps: [{run: echo success}]

--- a/.github/workflows/skip.yml
+++ b/.github/workflows/skip.yml
@@ -1,0 +1,16 @@
+# https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: skip
+on:
+  pull_request:
+    branches: [master]
+    paths: # same list as build.yml:on.pull_request.paths-ignore
+    - 'CHANGELOG.md'
+    - 'CITATION.cff'
+    - 'LICENSE'
+    - 'scripts/**'
+    - 'NOTICE.txt'
+    - 'README.md'
+jobs:
+  pass:
+    runs-on: ubuntu-latest
+    steps: [{run: echo success}]


### PR DESCRIPTION
## Changes
- Added a dummy required check (`pass`)
- Added a dummy workflow (`skip`) for whitelist (`paths`) complement of blacklist (`paths-ignore`)

### before
- `build.yml`: `on.pull_request.paths-ignore` -> might not run, causing some `Required` (branch-protection) checks to never pass (#1744)
### after
- at least one of the following is guaranteed to run
  - `build.yml`: `on.pull_request.paths-ignore` -> `jobs.{conda,docs,docker}` -> `jobs.pass`
  - `skip.yml`: `on.pull_request.paths` -> `jobs.pass`
- the new `jobs.pass` will be the sole `Required` test

## Testing you performed

## Related issues/links
- fixes #1744
- it's a known GHA limitation https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
- seems better than alternative hacks like [SO#66751567](https://stackoverflow.com/questions/66751567)

## Checklist
- [x] I have performed a self-review of my code
- [x] ~I have added docstrings in line with the guidance in the developer guide~
- [x] ~I have updated the relevant documentation~
- [x] ~I have implemented unit tests that cover any new or modified functionality~
- [x] ~CHANGELOG.md has been updated with any functionality change~
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes
Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.
- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
