### PR TITLE
fix import warning & docs missing GPU deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         cd docs
         conda install -c conda-forge -yq conda-merge
-        conda-merge <(sed -r '/tigre|astra-toolbox/d' ../scripts/requirements-test.yml) docs_environment.yml > environment.yml
+        conda-merge ../scripts/requirements-test.yml docs_environment.yml > environment.yml
         conda env update -n test
         conda list
     - name: build cil

--- a/Wrappers/Python/cil/utilities/jupyter/__init__.py
+++ b/Wrappers/Python/cil/utilities/jupyter/__init__.py
@@ -26,7 +26,7 @@ except ImportError as ie:
 from packaging import version
 from warnings import warn
 if version.parse(widgets.__version__) >= version.parse('8'):
-    warn(ImportWarning, f'requires ipywidgets<8, found {widgets.__version__}')
+    warn(f'requires ipywidgets<8, found {widgets.__version__}', ImportWarning, stacklevel=2)
 
 import matplotlib.pyplot as plt
 from matplotlib import gridspec


### PR DESCRIPTION
## Changes
- [x] Install GPU deps in docs CI build
- [x] Fix import warning syntax

## Testing you performed
Unzipped `DocumentationHTML.zip` art[ei]fact locally, ran `python -m http.server`, opened <http://localhost:8000/CIL/1749_merge/utilities/#islicer-interactive-display-of-2d-slices>

## Related issues/links
- fixes #1746
- fixes bug introduced by #1679
- fixes bug introduced by #1736

## Checklist
- [x] I have performed a self-review of my code
- [x] ~I have added docstrings in line with the guidance in the developer guide~
- [x] ~I have updated the relevant documentation~
- [x] ~I have implemented unit tests that cover any new or modified functionality~
- [x] ~CHANGELOG.md has been updated with any functionality change~
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes
Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.
- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties