### PR TITLE
docs: callback examples, fix some cross-refs

### DIFF
--- a/docs/source/framework.rst
+++ b/docs/source/framework.rst
@@ -161,14 +161,14 @@ VectorData
 BlockDataContainer
 ------------------
 
-A :code:`BlockDataContainer` can be instantiated from a number of :code:`DataContainer` and subclasses
-represents a column vector of :code:`DataContainer`s.
+A :code:`BlockDataContainer` can be instantiated from a number of `DataContainer`_ and subclasses
+represents a column vector of :code:`DataContainer` s.
 
 .. code:: python
 
   bdc = BlockDataContainer(DataContainer0, DataContainer1)
 
-This provide a base class that will behave as normal ``DataContainer``.
+This provide a base class that will behave as normal :code:`DataContainer`.
 
 .. autoclass:: cil.framework.BlockDataContainer
    :members:

--- a/docs/source/optimisation.rst
+++ b/docs/source/optimisation.rst
@@ -128,24 +128,24 @@ SPDHG
 Callbacks
 ---------
 
-A list of :code:`Callback`s to be executed each iteration can be passed to :code:`Algorithm`'s :code:`run` method.
+A list of :code:`Callback` s to be executed each iteration can be passed to :code:`Algorithm` 's :code:`run` method.
 
 .. code-block :: python
 
-   from cil.utilities.callbacks import LogfileCallback
+   from cil.optimisation.utilities.callbacks import LogfileCallback
    ...
    algorithm.run(..., callbacks=[LogfileCallback("log.txt")])
 
-.. autoclass:: cil.utilities.callbacks.Callback
+.. autoclass:: cil.optimisation.utilities.callbacks.Callback
    :members:
 
-.. autoclass:: cil.utilities.callbacks.ProgressCallback
+.. autoclass:: cil.optimisation.utilities.callbacks.ProgressCallback
    :members:
 
-.. autoclass:: cil.utilities.callbacks.TextProgressCallback
+.. autoclass:: cil.optimisation.utilities.callbacks.TextProgressCallback
    :members:
 
-.. autoclass:: cil.utilities.callbacks.LogfileCallback
+.. autoclass:: cil.optimisation.utilities.callbacks.LogfileCallback
    :members:
 
 Operators
@@ -396,7 +396,7 @@ Contains utilities for the CIL optimisation framework.
 Samplers
 --------
 Here, we define samplers that select from a list of indices {0, 1, …, N-1} either randomly or by some deterministic pattern.
-The `cil.optimisation.utilities.sampler` class defines a function next() which gives the next sample. It also has utility to `get_samples` to access which samples have or will be drawn.
+The :code:`cil.optimisation.utilities.sampler` class defines a function :code:`next()` which gives the next sample. It also has utility to :code:`get_samples` to access which samples have or will be drawn.
 
 For ease of use we provide the following static methods in `cil.optimisation.utilities.sampler` that allow you to configure your sampler object rather than initialising the classes directly:
 
@@ -447,7 +447,7 @@ The block framework consists of:
 
 
 
-The block framework allows writing more advanced `optimisation problems`_. Consider the typical
+The block framework allows writing more advanced optimisation problems. Consider the typical
 `Tikhonov regularisation <https://en.wikipedia.org/wiki/Tikhonov_regularization>`_:
 
 .. math::
@@ -622,9 +622,10 @@ Which in Python would be like
 
 :ref:`Return Home <mastertoc>`
 
-.. _BlockDataContainer: framework.html#cil.framework.BlockDataContainer
-.. _BlockFunction: optimisation.html#cil.optimisation.functions.BlockFunction
-.. _BlockOperator: optimisation.html#cil.optimisation.operators.BlockOperators
+.. _BlockDataContainer: #blockdatacontainer
+.. _DataContainer: ../framework/#datacontainer
+.. _BlockFunction: #block-function
+.. _BlockOperator: #block-operator
 
 
 

--- a/docs/source/optimisation.rst
+++ b/docs/source/optimisation.rst
@@ -125,28 +125,6 @@ SPDHG
    :members:
    :inherited-members: run, update_objective_interval, max_iteration
 
-Callbacks
----------
-
-A list of :code:`Callback` s to be executed each iteration can be passed to :code:`Algorithm` 's :code:`run` method.
-
-.. code-block :: python
-
-   from cil.optimisation.utilities.callbacks import LogfileCallback
-   ...
-   algorithm.run(..., callbacks=[LogfileCallback("log.txt")])
-
-.. autoclass:: cil.optimisation.utilities.callbacks.Callback
-   :members:
-
-.. autoclass:: cil.optimisation.utilities.callbacks.ProgressCallback
-   :members:
-
-.. autoclass:: cil.optimisation.utilities.callbacks.TextProgressCallback
-   :members:
-
-.. autoclass:: cil.optimisation.utilities.callbacks.LogfileCallback
-   :members:
 
 Operators
 =========
@@ -390,11 +368,13 @@ Total variation
 
 
 Utilities
-=======
+=========
+
 Contains utilities for the CIL optimisation framework.
 
 Samplers
 --------
+
 Here, we define samplers that select from a list of indices {0, 1, …, N-1} either randomly or by some deterministic pattern.
 The :code:`cil.optimisation.utilities.sampler` class defines a function :code:`next()` which gives the next sample. It also has utility to :code:`get_samples` to access which samples have or will be drawn.
 
@@ -424,9 +404,66 @@ In addition, we provide a random sampling class which is a child class of  `cil.
 .. autoclass:: cil.optimisation.utilities.SamplerRandom
    :members:
 
+Callbacks
+---------
+
+A list of :code:`Callback` s to be executed each iteration can be passed to `Algorithms`_ :code:`run` method.
+
+.. code-block :: python
+
+   from cil.optimisation.utilities.callbacks import LogfileCallback
+   ...
+   algorithm.run(..., callbacks=[LogfileCallback("log.txt")])
+
+.. autoclass:: cil.optimisation.utilities.callbacks.Callback
+   :members:
+
+Built-in callbacks include:
+
+.. autoclass:: cil.optimisation.utilities.callbacks.ProgressCallback
+   :members:
+
+.. autoclass:: cil.optimisation.utilities.callbacks.TextProgressCallback
+   :members:
+
+.. autoclass:: cil.optimisation.utilities.callbacks.LogfileCallback
+   :members:
+
+Users can also write custom callbacks.
+
+Below is an example of a custom callback implementing early stopping.
+In each iteration of the :code:`TestAlgo`, the objective :math:`x` is reduced by :math:`5`. The :code:`EarlyStopping` callback terminates the algorithm when :math:`x \le -15`. The algorithm thus terminates after :math:`3` iterations.
+
+.. code:: python
+
+   from cil.optimisation.algorithms import Algorithm
+   from cil.optimisation.utilities import callbacks
+
+   class TestAlgo(Algorithm):
+       def __init__(self, *args, **kwargs):
+           self.x = 0
+           super().__init__(*args, **kwargs)
+           self.configured = True
+
+       def update(self):
+           self.x -= 5
+
+       def update_objective(self):
+           self.loss.append(2 ** self.x)
+
+   class EarlyStopping(callbacks.Callback):
+       def __call__(self, algorithm: Algorithm):
+           if algorithm.x <= -15:  # arbitrary stopping criterion
+               raise StopIteration
+
+   algo = TestAlgo()
+   algo.run(20, callbacks=[callbacks.ProgressCallback(), EarlyStopping()])
 
 
+.. code:: raw
 
+   Output:
+    15%|███                 | 3/20 [00:00<00:00, 11770.73it/s, objective=3.05e-5]
 
 Block Framework
 ***************


### PR DESCRIPTION
## Changes
- add `EarlyStopping(Callback)` example
- fix some cross-refs

## Testing you performed
```sh
make -C docs
python -m http.server -d docs/build/dirhtml
open http://localhost:8000/optimisation/#callbacks
```

![image](https://github.com/TomographicImaging/CIL/assets/10780059/04f12006-7036-46da-b37f-fc47070857e2)

## Related issues/links
- fixes #1705

## Checklist
- [x] I have performed a self-review of my code
- [x] I have updated the relevant documentation
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'
