### PR TITLE
Skip tests on windows

### DIFF
--- a/Wrappers/Python/test/test_dataexample.py
+++ b/Wrappers/Python/test/test_dataexample.py
@@ -167,7 +167,7 @@ class TestRemoteData(unittest.TestCase):
         mock_response.__enter__.return_value = mock_response
         mock_urlopen.return_value = mock_response
 
-    @unittest.skipIf(os.name == 'nt', "Skip on Windows")   
+    @unittest.skipIf(platform.system() == 'Windows', "Skip on Windows")   
     @patch('cil.utilities.dataexample.urlopen')
     def test_unzip_remote_data(self, mock_urlopen):
         '''
@@ -193,7 +193,7 @@ class TestRemoteData(unittest.TestCase):
         if os.path.exists(os.path.join(tmp_path,tmp_dir)):
             shutil.rmtree(os.path.join(tmp_path,tmp_dir)) 
         
-    @unittest.skipIf(os.name == 'nt', "Skip on Windows")   
+    @unittest.skipIf(platform.system() == 'Windows', "Skip on Windows")   
     @patch('cil.utilities.dataexample.input', return_value='n')    
     @patch('cil.utilities.dataexample.urlopen')
     def test_download_data_input_n(self, mock_urlopen, input):
@@ -228,7 +228,7 @@ class TestRemoteData(unittest.TestCase):
         if os.path.exists(os.path.join(tmp_path,tmp_dir)):
             shutil.rmtree(os.path.join(tmp_path,tmp_dir)) 
 
-    @unittest.skipIf(os.name == 'nt', "Skip on Windows")   
+    @unittest.skipIf(platform.system() == 'Windows', "Skip on Windows")   
     @patch('cil.utilities.dataexample.input', return_value='y')    
     @patch('cil.utilities.dataexample.urlopen')
     def test_download_data_input_y(self, mock_urlopen, input):

--- a/Wrappers/Python/test/test_dataexample.py
+++ b/Wrappers/Python/test/test_dataexample.py
@@ -167,6 +167,7 @@ class TestRemoteData(unittest.TestCase):
         mock_response.__enter__.return_value = mock_response
         mock_urlopen.return_value = mock_response
 
+    @unittest.skipIf(os.name == 'nt', "Skip on Windows")   
     @patch('cil.utilities.dataexample.urlopen')
     def test_unzip_remote_data(self, mock_urlopen):
         '''
@@ -192,7 +193,7 @@ class TestRemoteData(unittest.TestCase):
         if os.path.exists(os.path.join(tmp_path,tmp_dir)):
             shutil.rmtree(os.path.join(tmp_path,tmp_dir)) 
         
-
+    @unittest.skipIf(os.name == 'nt', "Skip on Windows")   
     @patch('cil.utilities.dataexample.input', return_value='n')    
     @patch('cil.utilities.dataexample.urlopen')
     def test_download_data_input_n(self, mock_urlopen, input):
@@ -227,6 +228,7 @@ class TestRemoteData(unittest.TestCase):
         if os.path.exists(os.path.join(tmp_path,tmp_dir)):
             shutil.rmtree(os.path.join(tmp_path,tmp_dir)) 
 
+    @unittest.skipIf(os.name == 'nt', "Skip on Windows")   
     @patch('cil.utilities.dataexample.input', return_value='y')    
     @patch('cil.utilities.dataexample.urlopen')
     def test_download_data_input_y(self, mock_urlopen, input):


### PR DESCRIPTION
## Changes
Skip 3 unittests in dataexample on windows 

## Testing you performed
Built on windows, confirmed skipped tests.

```
test_download_data_input_n (test_dataexample.TestRemoteData)
Test the download_data function, when the user input is 'n' to 'are you sure you want to download data' ... skipped 'Skip on Windows'
test_download_data_input_y (test_dataexample.TestRemoteData)
Test the download_data function, when the user input is 'y' to 'are you sure you want to download data' ... skipped 'Skip on Windows'
test_unzip_remote_data (test_dataexample.TestRemoteData)
Test the _download_and_extract_data_from_url function correctly extracts files from a byte string ... skipped 'Skip on Windows'
```
## Related issues/links
Temporary solution to #1759

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

