### PR TITLE
Updated requirements to TIGRE 2.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/checkout@v4
       with: {fetch-depth: 0, submodules: recursive}
     - name: set requirements
-      run: sed -ri -e '/ python=/d' -e 's/(.* numpy=).*/\1${{ matrix.numpy-version }}/' scripts/requirements-test.yml
+      run: sed -ri -e '/ python=/d' -e 's/(.* numpy=).*/\1${{ matrix.numpy-version }}/' -e '/tigre/d' scripts/requirements-test.yml
     - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
@@ -137,7 +137,7 @@ jobs:
       run: |
         cd docs
         conda install -c conda-forge -yq conda-merge
-        conda-merge ../scripts/requirements-test.yml docs_environment.yml > environment.yml
+        conda-merge ../scripts/requirements-test.yml docs_environment.yml | sed '/tigre/d' > environment.yml
         conda env update -n test
         conda list
     - name: build cil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   - New adjoint operator
   - Bug fix for complex matrix adjoint
   - Added the ApproximateGradientSumFunction and SGFunction to allow for stochastic gradient algorithms to be created using functions with an approximate gradient and deterministic algorithms
+  - CIL plugin support for TIGRE version v2.6
 
 
 * 23.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --chown="${NB_USER}" scripts/requirements-test.yml environment.yml
 RUN sed -ri '/tigre|astra-toolbox/d' environment.yml \
   && for pkg in jupyter-server-proxy $CIL_EXTRA_PACKAGES; do echo "  - $pkg" >> environment.yml; done \
   && conda config --env --set channel_priority strict \
-  && for ch in defaults ccpi intel conda-forge; do conda config --env --add channels $ch; done \
+  && for ch in defaults nvidia ccpi intel conda-forge; do conda config --env --add channels $ch; done \
   && mamba env update -n base \
   && mamba clean -a -y -f \
   && rm environment.yml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.source=https://github.com/TomographicImaging/CIL
 LABEL org.opencontainers.image.licenses="Apache-2.0 AND BSD-3-Clause AND GPL-3.0"
 
 # CUDA-specific packages
-ARG CIL_EXTRA_PACKAGES="tigre=2.4 astra-toolbox<2.1"
+ARG CIL_EXTRA_PACKAGES="tigre=2.6 astra-toolbox<2.1"
 # build & runtime dependencies
 # TODO: sync scripts/create_local_env_for_cil_development.sh, scripts/requirements-test.yml, recipe/meta.yaml (e.g. missing libstdcxx-ng _openmp_mutex pip)?
 # vis. https://github.com/TomographicImaging/CIL/pull/1590

--- a/Wrappers/Python/cil/plugins/tigre/FBP.py
+++ b/Wrappers/Python/cil/plugins/tigre/FBP.py
@@ -97,7 +97,9 @@ class FBP(DataProcessor):
             arr_out = np.squeeze(arr_out, axis=0)
         else:
             if self.acquisition_geometry.geom_type == 'cone':
-                arr_out = fdk(self.get_input().as_array(), self.tigre_geom, self.tigre_angles)
+                # suppress print statements from TIGRE https://github.com/CERN/TIGRE/issues/532
+                with contextlib.redirect_stdout(io.StringIO()):
+                    arr_out = fdk(self.get_input().as_array(), self.tigre_geom, self.tigre_angles)
             else:
                 arr_out = fbp(self.get_input().as_array(), self.tigre_geom, self.tigre_angles)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
     - cvxpy                   # [ linux ]
     - scikit-image
     - tomophantom=2.0.0       # [ linux ]
-    - tigre=2.4               # [ not osx ]
+    - tigre=2.6               # [ not osx ]
     - packaging
     - ccpi-regulariser=22.0.0 # [ not osx ]
     - astra-toolbox>=1.9.9.dev5,<2.1
@@ -92,7 +92,7 @@ requirements:
   run_constrained:
     - tomophantom=2.0.0
     - astra-toolbox>=1.9.9.dev5,<2.1
-    - tigre=2.4
+    - tigre=2.6
     - ccpi-regulariser=22.0.0
     - ipywidgets <8
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
     - cvxpy                   # [ linux ]
     - scikit-image
     - tomophantom=2.0.0       # [ linux ]
-    - tigre=2.6               # [ __cuda ]
+    - tigre=2.6
     - packaging
     - ccpi-regulariser=22.0.0 # [ not osx ]
     - astra-toolbox>=1.9.9.dev5,<2.1
@@ -92,7 +92,7 @@ requirements:
   run_constrained:
     - tomophantom=2.0.0
     - astra-toolbox>=1.9.9.dev5,<2.1
-    - tigre=2.6
+    - tigre>=2.4,<=2.6
     - ccpi-regulariser=22.0.0
     - ipywidgets <8
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
     - cvxpy                   # [ linux ]
     - scikit-image
     - tomophantom=2.0.0       # [ linux ]
-    - tigre=2.6               # [ not osx ]
+    - tigre=2.6               # [ __cuda ]
     - packaging
     - ccpi-regulariser=22.0.0 # [ not osx ]
     - astra-toolbox>=1.9.9.dev5,<2.1

--- a/scripts/create_local_env_for_cil_development.sh
+++ b/scripts/create_local_env_for_cil_development.sh
@@ -83,7 +83,7 @@ else
     python-wget
     setuptools
     scikit-image
-    tigre=2.4
+    tigre=2.6
     tomophantom=2.0.0
     -c conda-forge
     -c intel

--- a/scripts/requirements-test.yml
+++ b/scripts/requirements-test.yml
@@ -16,6 +16,7 @@ channels:
   - conda-forge
   - intel
   - ccpi
+  - nvidia
   - defaults
 dependencies:
   # base (vis. recipe/conda_build_config.yaml)

--- a/scripts/requirements-test.yml
+++ b/scripts/requirements-test.yml
@@ -22,7 +22,7 @@ dependencies:
   - python=3.10
   - numpy=1.24
   - cil-data
-  - tigre=2.4
+  - tigre=2.6
   - ccpi-regulariser=22.0.0
   - tomophantom=2.0.0
   - astra-toolbox >=1.9.9.dev5,<2.1


### PR DESCRIPTION
## Changes
Update recipe to use TIGRE 2.6

Note: Windows binaries have been built with 10.2, linux with 10.2 and 11.8. 
So far that gives compatibility to the released astra and numba versions.

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

- [x] Built TIGRE 2.6 on windows and tested with all versions
- [x] Built TIGRE 2.6 on linux and tested with all versions
- [x] Test on versions without CUDA toolkit installed linux
- [ ] Test on versions without CUDA toolkit installed windows **This is still broken ** see https://github.com/TomographicImaging/TIGRE-conda/issues/7

## Related issues/links
closes #1760

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

