### PR TITLE
CI: fix concurrent CUDA runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,21 +55,24 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: scripts/requirements-test.yml
-        activate-environment: ${{ steps.reqs.outputs.envname}}
+        activate-environment: ${{ steps.reqs.outputs.envname }}
         run-post: false
     - id: build
       name: build
       run: |
+        conda activate "${{ steps.reqs.outputs.envname }}"
         cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"
         cmake --build ./build --target install
     - name: test
-      run: TESTS_FORCE_GPU=1 python -m unittest discover -v -k tigre -k TIGRE -k astra -k ASTRA -k gpu -k GPU ./Wrappers/Python/test
+      run: |
+        conda activate "${{ steps.reqs.outputs.envname }}"
+        TESTS_FORCE_GPU=1 python -m unittest discover -v -k tigre -k TIGRE -k astra -k ASTRA -k gpu -k GPU ./Wrappers/Python/test
     - if: always()
       name: Post Run conda-incubator/setup-miniconda@v3
       run: |
         conda deactivate
-        conda env remove -n "${{ steps.reqs.outputs.envname }}"
         sed -i '/${{ steps.reqs.outputs.envname }}/d' ~/.profile
+        conda env remove -n "${{ steps.reqs.outputs.envname }}"
   test:
     defaults: {run: {shell: 'bash -el {0}'}}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes
stops self-hosted runners accidentally using each other's sandboxed conda envs.

## Checklist
- [x] I have performed a self-review of my code
- [x] ~I have added docstrings in line with the guidance in the developer guide~
- [x] ~I have updated the relevant documentation~
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] ~CHANGELOG.md has been updated with any functionality change~
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes
Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.
- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
