### PR TITLE
CI: force cleanup on setup fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,9 +69,10 @@ jobs:
         TESTS_FORCE_GPU=1 python -m unittest discover -v -k tigre -k TIGRE -k astra -k ASTRA -k gpu -k GPU ./Wrappers/Python/test
     - if: always()
       name: Post Run conda-incubator/setup-miniconda@v3
+      shell: bash
       run: |
-        conda deactivate
         sed -i '/${{ steps.reqs.outputs.envname }}/d' ~/.profile
+        source ~/.profile
         conda env remove -n "${{ steps.reqs.outputs.envname }}"
   test:
     defaults: {run: {shell: 'bash -el {0}'}}


### PR DESCRIPTION
## Changes
During conda setup, any error will result in a broken environment.
Such broken environments hardcoded in `~/.profile` will cause all future jobs to fail.
This PR force-removes environments.

## Testing you performed

## Related issues/links
- e.g. temperamental conda internal server error (5xx) https://github.com/TomographicImaging/CIL/actions/runs/8551980244/job/23432143727#step:4:332
- follow-up to #1767
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell

## Checklist
- [x] I have performed a self-review of my code
- [x] ~I have added docstrings in line with the guidance in the developer guide~
- [x] ~I have updated the relevant documentation~
- [x] ~I have implemented unit tests that cover any new or modified functionality~
- [x] ~CHANGELOG.md has been updated with any functionality change~
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes
Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.
- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
