### PR TITLE
build: correct version even if unannotated tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,10 @@ jobs:
         numpy-version: [1.25]
     steps:
     - uses: actions/checkout@v4
-      with: {fetch-depth: 0, submodules: recursive}
+      with:
+        fetch-depth: 0
+        submodules: recursive
+        ref: ${{ github.event.pull_request.head.sha || github.ref }} # fix SHA
     - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
@@ -130,7 +133,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with: {fetch-depth: 0, submodules: recursive}
+      with:
+        fetch-depth: 0
+        submodules: recursive
+        ref: ${{ github.event.pull_request.head.sha || github.ref }} # fix SHA
     - uses: conda-incubator/setup-miniconda@v3
       with: {python-version: 3.11}
     - name: install dependencies

--- a/Wrappers/Python/CMake/parse_git_describe.py
+++ b/Wrappers/Python/CMake/parse_git_describe.py
@@ -21,7 +21,7 @@ import re, subprocess, sys, os
 git_executable = os.path.abspath(sys.argv[1])
 
 pattern = re.compile('v([0-9]*)\.([0-9]*)(\.*)([0-9]*)')
-git_describe_string = subprocess.check_output(f'"{git_executable}" describe', shell=True).decode("utf-8").rstrip()
+git_describe_string = subprocess.check_output(f'"{git_executable}" describe --tags', shell=True).decode("utf-8").rstrip()
 v = git_describe_string.split('-')
 if len(v) == 3:
     git_version_string, git_commit_number, git_hash = git_describe_string.split('-')


### PR DESCRIPTION
Last release (v24) reports `cil.version` as 23.0.1 because the tag was unannotated so doesn't appear in `git describe`

used by: https://github.com/TomographicImaging/CIL/blob/e51e2ab706a0826df11408a5a75114e07b639bd0/Wrappers/Python/CMake/parse_git_describe.py#L24

Note that the docs rely on `cil.version` to render correctly

## Changes

- allow unannotated tags
- force the CI to use the correct SHA so that `git describe` works correctly