### PR TITLE
docs: fix version switcher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
         name: DocumentationHTML
         path: docs/build
     - name: Push changes
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
       uses: casperdcl/push-dir@v1
       with:
         message: Update documentation

--- a/docs/docs_environment.yml
+++ b/docs/docs_environment.yml
@@ -20,7 +20,7 @@ channels:
 dependencies:
   # in addition to CIL deps (see ../scripts/requirements-test.yml)
   - jinja2
-  - pydata-sphinx-theme
+  # - pydata-sphinx-theme
   - recommonmark
   - sphinx
   - sphinx_rtd_theme
@@ -33,3 +33,7 @@ dependencies:
   - sphinx-gallery
   - sphinx-copybutton
   - notebook
+  # TODO: remove after https://github.com/pydata/pydata-sphinx-theme/pull/1795 is released
+  - pip
+  - pip:
+    - git+https://github.com/TomographicImaging/pydata-sphinx-theme@fix-version-switcher-dirhtml#egg=pydata-sphinx-theme

--- a/docs/mkversions.py
+++ b/docs/mkversions.py
@@ -25,4 +25,5 @@ except ValueError:
 else:
     versions += [{"name": "stable", "version": stable["version"], "url": stable["url"], "preferred": True}]
 
+versions.sort(key=lambda v: (version.parse(v["version"]), v["name"]), reverse=True)
 (build / "versions.json").write_text(json.dumps(versions))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,7 +93,7 @@ html_context = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['docsstatic']
+#html_static_path = ['docsstatic']
 htmlhelp_basename = 'CILdoc'
 
 # LaTeX config


### PR DESCRIPTION
- fix version switcher suffixing `.html`
  + i.e. we want `/CIL/nightly/` not `/CIL/nightly.html`
  + vis. https://github.com/pydata/pydata-sphinx-theme/pull/1795
- consistently sort version switcher dropdown options
- misc framework updates
  + push docs on tagged release
  + suppress missing `html_static_path` build warning

## Testing you performed
https://github.com/TomographicImaging/CIL/blob/fix-docs-version-switcher/.github/workflows/README.md#docs

## Related issues/links
- #1579
  + https://github.com/pydata/pydata-sphinx-theme/pull/1795
  + #1699

## Checklist
- [x] I have performed a self-review of my code
- [x] ~I have added docstrings in line with the guidance in the developer guide~
- [x] ~I have updated the relevant documentation~
- [x] ~I have implemented unit tests that cover any new or modified functionality~
- [x] ~CHANGELOG.md has been updated with any functionality change~
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes
Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.
- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
