### PR TITLE
Add Example of Callbacks to the rendered notebooks in the user guide

### DIFF
--- a/docs/mkdemos.py
+++ b/docs/mkdemos.py
@@ -13,7 +13,8 @@ from tqdm import tqdm
 # URLS of the notebooks to render
 NOTEBOOKS = (
     "https://github.com/TomographicImaging/CIL-Demos/raw/main/demos/1_Introduction/00_CIL_geometry.ipynb",
-    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/003_1D_integral_inverse_problem/deriv2_cgls.ipynb"
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/003_1D_integral_inverse_problem/deriv2_cgls.ipynb",
+    "https://github.com/TomographicImaging/CIL-Demos/raw/main/misc/callback_demonstration.ipynb"
 )
 SOURCE = Path(__file__).parent / "source" # sphinx documentation dir
 NBDIR = "demos" # notebook subdir to create


### PR DESCRIPTION
## Changes

Adds https://github.com/TomographicImaging/CIL-Demos/blob/main/misc/callback_demonstration.ipynb to the rendered notebooks in the documentation.

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

I downloaded the [artifact ](https://github.com/TomographicImaging/CIL/actions/runs/9078489940/artifacts/1500795076)and checked that the notebook is correctly rendered.

## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
