### PR TITLE
docs: use upstream release

### DIFF
--- a/docs/docs_environment.yml
+++ b/docs/docs_environment.yml
@@ -20,7 +20,7 @@ channels:
 dependencies:
   # in addition to CIL deps (see ../scripts/requirements-test.yml)
   - jinja2
-  # - pydata-sphinx-theme
+  - pydata-sphinx-theme>=0.15.3
   - recommonmark
   - sphinx
   - sphinx_rtd_theme
@@ -33,7 +33,3 @@ dependencies:
   - sphinx-gallery
   - sphinx-copybutton
   - notebook
-  # TODO: remove after https://github.com/pydata/pydata-sphinx-theme/pull/1795 is released
-  - pip
-  - pip:
-    - git+https://github.com/pydata/pydata-sphinx-theme


### PR DESCRIPTION
Bump docs dependencies

## Testing you performed
See CI

## Related issues/links
- part of #1579
- https://github.com/pydata/pydata-sphinx-theme/pull/1795

## Checklist
- [x] I have performed a self-review of my code
- [x] ~I have added docstrings in line with the guidance in the developer guide~
- [x] ~I have updated the relevant documentation~
- [x] ~I have implemented unit tests that cover any new or modified functionality~
- [x] ~CHANGELOG.md has been updated with any functionality change~
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes
Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.
- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
