### PR TITLE
find_package(Python)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,5 @@ if(NOT DEFINED CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif()
 
-find_package(Git REQUIRED)
-find_package(Python COMPONENTS Interpreter REQUIRED)
-
 add_subdirectory(src/Core)
 add_subdirectory(Wrappers/Python)

--- a/Wrappers/Python/CMakeLists.txt
+++ b/Wrappers/Python/CMakeLists.txt
@@ -1,50 +1,32 @@
-option (BUILD_PYTHON_WRAPPER "Build Python Wrapper" ON)
+find_package(PythonInterp REQUIRED)
 
-if (BUILD_PYTHON_WRAPPER)
-  find_package(PythonInterp REQUIRED)
+if(PYTHON_DEST_DIR)
+  file(TO_CMAKE_PATH "${PYTHON_DEST_DIR}" PYTHON_DEST)
+endif()
 
-  #set(PYTHON_DEST_DIR "" CACHE PATH "Directory of the Python wrappers")
-  if (PYTHON_DEST_DIR)
-    file(TO_CMAKE_PATH "${PYTHON_DEST_DIR}" TMP)
-    set(PYTHON_DEST "${TMP}")
-    unset(TMP)
+message("CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
+if(NOT DEFINED)
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif()
+
+if (PYTHONINTERP_FOUND)
+  # TODO: add to add_custom_command DEPENDS the list of python files of the project.
+  # file(GLOB_RECURSE DEPS ${CMAKE_CURRENT_SOURCE_DIR}/cil/*.py )
+  message("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL: $ENV{SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL}")
+  message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+  if(PYTHON_DEST_DIR)
+    message(STATUS "CIL install using ${PYTHON_EXECUTABLE} -m pip install -t ${PYTHON_DEST}")
+    add_custom_target(pythonsetup ALL
+      COMMAND ${PYTHON_EXECUTABLE} -m pip install ${CMAKE_SOURCE_DIR} -t ${PYTHON_DEST} --upgrade
+      DEPENDS cilacc)
+  else()
+    message(STATUS "CIL install using ${PYTHON_EXECUTABLE} -m pip install")
+    add_custom_target(pythonsetup ALL
+      COMMAND ${PYTHON_EXECUTABLE} -m pip install ${CMAKE_SOURCE_DIR} --upgrade
+      DEPENDS cilacc)
   endif()
-
-  message("CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
-  if(NOT DEFINED)
-    set(CMAKE_BUILD_TYPE "RelWithDebInfo")
-  endif()
-
-  find_package(PythonLibs)
-  if (PYTHONINTERP_FOUND)
-    message(STATUS "Found PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
-    message(STATUS "Python version ${PYTHON_VERSION_STRING}")
-  endif()
-  if (PYTHONLIBS_FOUND)
-    message(STATUS "Found PYTHON_INCLUDE_DIRS=${PYTHON_INCLUDE_DIRS}")
-    message(STATUS "Found PYTHON_LIBRARIES=${PYTHON_LIBRARIES}")
-  endif()
-
-  if (PYTHONINTERP_FOUND)
-      message("Python found " ${PYTHON_EXECUTABLE})
-      # TODO: add to add_custom_command DEPENDS the list of python files of the project.
-      # file(GLOB_RECURSE DEPS ${CMAKE_CURRENT_SOURCE_DIR}/cil/*.py )
-      message("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL: $ENV{SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL}")
-      message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
-      if(PYTHON_DEST_DIR)
-        message(STATUS "CIL install using ${PYTHON_EXECUTABLE} -m pip install -t ${PYTHON_DEST}")
-        add_custom_target(pythonsetup ALL
-          COMMAND ${PYTHON_EXECUTABLE} -m pip install ${CMAKE_SOURCE_DIR} -t ${PYTHON_DEST} --upgrade
-          DEPENDS cilacc)
-      else()
-        message(STATUS "CIL install using ${PYTHON_EXECUTABLE} -m pip install")
-        add_custom_target(pythonsetup ALL
-          COMMAND ${PYTHON_EXECUTABLE} -m pip install ${CMAKE_SOURCE_DIR} --upgrade
-          DEPENDS cilacc)
-      endif()
-      # install the data if not a conda build. With conda the data is in the dependency package cil-data
-      if (NOT CONDA_BUILD)
-        install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data/ DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cil)
-      endif()
+  # install the data if not a conda build. With conda the data is in the dependency package cil-data
+  if (NOT CONDA_BUILD)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data/ DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cil)
   endif()
 endif()

--- a/Wrappers/Python/CMakeLists.txt
+++ b/Wrappers/Python/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(PythonInterp REQUIRED)
+find_package(Python COMPONENTS Interpreter REQUIRED)
 
 if(PYTHON_DEST_DIR)
   file(TO_CMAKE_PATH "${PYTHON_DEST_DIR}" PYTHON_DEST)
@@ -9,24 +9,22 @@ if(NOT DEFINED)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif()
 
-if (PYTHONINTERP_FOUND)
-  # TODO: add to add_custom_command DEPENDS the list of python files of the project.
-  # file(GLOB_RECURSE DEPS ${CMAKE_CURRENT_SOURCE_DIR}/cil/*.py )
-  message("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL: $ENV{SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL}")
-  message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
-  if(PYTHON_DEST_DIR)
-    message(STATUS "CIL install using ${PYTHON_EXECUTABLE} -m pip install -t ${PYTHON_DEST}")
-    add_custom_target(pythonsetup ALL
-      COMMAND ${PYTHON_EXECUTABLE} -m pip install ${CMAKE_SOURCE_DIR} -t ${PYTHON_DEST} --upgrade
-      DEPENDS cilacc)
-  else()
-    message(STATUS "CIL install using ${PYTHON_EXECUTABLE} -m pip install")
-    add_custom_target(pythonsetup ALL
-      COMMAND ${PYTHON_EXECUTABLE} -m pip install ${CMAKE_SOURCE_DIR} --upgrade
-      DEPENDS cilacc)
-  endif()
-  # install the data if not a conda build. With conda the data is in the dependency package cil-data
-  if (NOT CONDA_BUILD)
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data/ DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cil)
-  endif()
+# TODO: add to add_custom_command DEPENDS the list of python files of the project.
+# file(GLOB_RECURSE DEPS ${CMAKE_CURRENT_SOURCE_DIR}/cil/*.py )
+message("SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL: $ENV{SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL}")
+message("CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+if(PYTHON_DEST_DIR)
+  message(STATUS "CIL install using ${Python_EXECUTABLE} -m pip install -t ${PYTHON_DEST}")
+  add_custom_target(pythonsetup ALL
+    COMMAND ${Python_EXECUTABLE} -m pip install ${CMAKE_SOURCE_DIR} -t ${PYTHON_DEST} --upgrade
+    DEPENDS cilacc)
+else()
+  message(STATUS "CIL install using ${Python_EXECUTABLE} -m pip install")
+  add_custom_target(pythonsetup ALL
+    COMMAND ${Python_EXECUTABLE} -m pip install ${CMAKE_SOURCE_DIR} --upgrade
+    DEPENDS cilacc)
+endif()
+# install the data if not a conda build. With conda the data is in the dependency package cil-data
+if (NOT CONDA_BUILD)
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data/ DESTINATION ${CMAKE_INSTALL_PREFIX}/share/cil)
 endif()


### PR DESCRIPTION
- force building the Python wrapper (removes/ignores the CMake option `BUILD_PYTHON_WRAPPER`)
- [x] fix CMake forward-compatibility/deprecation warning (fixes #1835)
- [x] rebase after #1876
- part of #1875

👉 [diff *sans* whitespace](https://github.com/TomographicImaging/CIL/pull/1842/files?diff=unified&w=1)