### PR TITLE
Add flux normaliser processor

### DIFF
--- a/Wrappers/Python/cil/processors/FluxNormaliser.py
+++ b/Wrappers/Python/cil/processors/FluxNormaliser.py
@@ -1,0 +1,79 @@
+#  Copyright 2024 United Kingdom Research and Innovation
+#  Copyright 2024 The University of Manchester
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# Authors:
+# CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
+
+from cil.framework import Processor, DataContainer, AcquisitionData,\
+ AcquisitionGeometry, ImageGeometry, ImageData
+import numpy
+
+class FluxNormaliser(Processor):
+    '''Flux normalisation based on float or region of interest
+
+    This processor reads in a AcquisitionData and normalises it based on
+    a float or array of float values, or a region of interest.
+
+    Input: AcquisitionData
+    Parameter: 2D projection with flat field (or stack)
+               2D projection with dark field (or stack)
+    Output: AcquisitionDataSet
+    '''
+
+    def __init__(self, flux=None, roi=None, tolerance=1e-5):
+            kwargs = {
+                    'flux'  : flux,
+                    'roi'  : roi,
+                    # very small number. Used when there is a division by zero
+                    'tolerance'   : tolerance
+                    }
+            super(FluxNormaliser, self).__init__(**kwargs)
+            
+    def check_input(self, dataset):
+        flux_size = (numpy.shape(self.flux))
+        if len(flux_size) > 0:
+            data_size = numpy.shape(dataset.geometry.angles)
+            if data_size != flux_size:
+                raise ValueError("Flux must be a scalar or array with length \
+                                    \n = data.geometry.angles, found {} and {}"
+                                    .format(flux_size, data_size))
+            
+        return True
+
+    def process(self, out=None):
+
+        data = self.get_input()
+
+        if out is None:
+            out = data.copy()
+
+        flux_size = (numpy.shape(self.flux))
+        
+        proj_axis = data.get_dimension_axis('angle')
+        slice_proj = [slice(None)]*len(data.shape)
+        slice_proj[proj_axis] = 0
+        
+        f = self.flux
+        for i in range(numpy.shape(data)[proj_axis]):
+            if len(flux_size) > 0:
+                f = self.flux[i]
+
+            slice_proj[proj_axis] = i
+            with numpy.errstate(divide='ignore', invalid='ignore'):
+                out.array[tuple(slice_proj)] = data.array[tuple(slice_proj)]/f
+                        
+        out.array[ ~ numpy.isfinite( out.array )] = self.tolerance
+
+        return out

--- a/Wrappers/Python/cil/processors/__init__.py
+++ b/Wrappers/Python/cil/processors/__init__.py
@@ -27,3 +27,4 @@ from .TransmissionAbsorptionConverter import TransmissionAbsorptionConverter
 from .Masker import Masker
 from .Padder import Padder
 from .PaganinProcessor import PaganinProcessor
+from .FluxNormaliser import FluxNormaliser

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -30,7 +30,7 @@ from cil.recon import FBP
 from cil.processors import CentreOfRotationCorrector
 from cil.processors.CofR_xcorrelation import CofR_xcorrelation
 from cil.processors import TransmissionAbsorptionConverter, AbsorptionTransmissionConverter
-from cil.processors import Slicer, Binner, MaskGenerator, Masker, Padder, PaganinProcessor
+from cil.processors import Slicer, Binner, MaskGenerator, Masker, Padder, PaganinProcessor, FluxNormaliser
 import gc
 
 from scipy import constants
@@ -3072,7 +3072,37 @@ class TestPaganinProcessor(unittest.TestCase):
         self.assertLessEqual(quality_measures.mse(output, thickness), 0.05)
 
         # 'horizontal, vertical, angles
-        
+
+class TestFluxNormaliser(unittest.TestCase):
+
+    def setUp(self):
+        self.data_parallel = dataexample.SIMULATED_PARALLEL_BEAM_DATA.get()
+        self.data_cone = dataexample.SIMULATED_CONE_BEAM_DATA.get()
+        ag = AcquisitionGeometry.create_Parallel3D()\
+            .set_angles(numpy.linspace(0,360,360,endpoint=False))\
+            .set_panel([128,128],0.1)\
+            .set_channels(4)
+
+        self.data_multichannel = ag.allocate('random')
+
+    def error_message(self,processor, test_parameter):
+            return "Failed with processor " + str(processor) + " on test parameter " + test_parameter
+
+    def test_init(self):
+        # test default values are initialised
+        processor = FluxNormaliser()
+        test_parameter = ['flux','roi','tolerance']
+        test_value = [None, None, 1e-5]
+
+        for i in numpy.arange(len(test_value)):
+            self.assertEqual(getattr(processor, test_parameter[i]), test_value[i], msg=self.error_message(processor, test_parameter[i]))
+
+        # test non-default values are initialised
+        processor = FluxNormaliser(1,2,3)
+        test_value = [1, 2, 3]
+        for i in numpy.arange(len(test_value)):
+            self.assertEqual(getattr(processor, test_parameter[i]), test_value[i], msg=self.error_message(processor, test_parameter[i]))
+
 if __name__ == "__main__":
 
     d = TestDataProcessor()


### PR DESCRIPTION
## Description
New FluxNormaliser processor to normalise data
- [ ] to a float value
- [ ] to an array of floats with size matching the 
- [ ] to the mean value calculated from a specified region of interest in the data itself

## Example Usage
```
processor = FluxNormaliser(flux=10)
processor.set_input(self.data_cone)
data_norm = processor.get_output()
```

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc
Tests in test_DataProcessor.py TestFluxNormaliser class

## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

