### PR TITLE
Remove empty dimensions from DataContainer array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 __pycache__/
 /Wrappers/Python/build/
 /Wrappers/Python/cil/version.py
+/build*
+*.vscode*
 *.egg*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   - Enhancements:
     - Use ravel instead of flat in KullbackLeibler numba backend (#1874)
     - Upgrade Python wrapper (#1873, #1875)
+  - Bug fixes:
+      - `DataContainer` removes dimensions of size 1 from the input array. This fixes an issue where single slice reconstructions from 3D data would fail due to shape mismatches (#1885)
 
 * 24.1.0
   - New Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     - Use ravel instead of flat in KullbackLeibler numba backend (#1874)
     - Upgrade Python wrapper (#1873, #1875)
   - Bug fixes:
-      - `DataContainer` removes dimensions of size 1 from the input array. This fixes an issue where single slice reconstructions from 3D data would fail due to shape mismatches (#1885)
+      - `ImageData` removes dimensions of size 1 from the input array. This fixes an issue where single slice reconstructions from 3D data would fail due to shape mismatches (#1885)
 
 * 24.1.0
   - New Features:

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2772,9 +2772,9 @@ class DataContainer(object):
 
         if type(array) == numpy.ndarray:
             if deep_copy:
-                self.array = array.copy()
+                self.array = numpy.squeeze(array.copy())
             else:
-                self.array = array
+                self.array = numpy.squeeze(array)
         else:
             raise TypeError('Array must be NumpyArray, passed {0}'\
                             .format(type(array)))
@@ -3645,7 +3645,7 @@ class ImageData(DataContainer):
         else:
             raise TypeError('array must be a CIL type DataContainer or numpy.ndarray got {}'.format(type(array)))
 
-        if array.shape != geometry.shape:
+        if numpy.squeeze(array).shape != geometry.shape:
             raise ValueError('Shape mismatch {} {}'.format(array.shape, geometry.shape))
 
         if array.ndim not in [2,3,4]:
@@ -3814,7 +3814,7 @@ class AcquisitionData(DataContainer, Partitioner):
         else:
             raise TypeError('array must be a CIL type DataContainer or numpy.ndarray got {}'.format(type(array)))
 
-        if array.shape != geometry.shape:
+        if numpy.squeeze(array).shape != geometry.shape:
             raise ValueError('Shape mismatch got {} expected {}'.format(array.shape, geometry.shape))
 
         super(AcquisitionData, self).__init__(array, deep_copy, geometry=geometry,**kwargs)

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -3813,7 +3813,7 @@ class AcquisitionData(DataContainer, Partitioner):
         else:
             raise TypeError('array must be a CIL type DataContainer or numpy.ndarray got {}'.format(type(array)))
 
-        if numpy.squeeze(array).shape != geometry.shape:
+        if array.shape != geometry.shape:
             raise ValueError('Shape mismatch got {} expected {}'.format(array.shape, geometry.shape))
 
         super(AcquisitionData, self).__init__(array, deep_copy, geometry=geometry,**kwargs)

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -468,6 +468,7 @@ class ImageGeometry(object):
             repres += "center : x{0},y{1}\n".format(self.center_x, self.center_y)
 
         return repres
+    
     def allocate(self, value=0, **kwargs):
         '''allocates an ImageData according to the size expressed in the instance
 
@@ -2768,13 +2769,12 @@ class DataContainer(object):
     __container_priority__ = 1
     def __init__ (self, array, deep_copy=True, dimension_labels=None,
                   **kwargs):
-        '''Holds the data'''
 
         if type(array) == numpy.ndarray:
             if deep_copy:
-                self.array = numpy.squeeze(array.copy())
+                self.array = array.copy()
             else:
-                self.array = numpy.squeeze(array)
+                self.array = array
         else:
             raise TypeError('Array must be NumpyArray, passed {0}'\
                             .format(type(array)))
@@ -2920,11 +2920,7 @@ class DataContainer(object):
             return
         if dimension == {}:
             if isinstance(array, numpy.ndarray):
-                if numpy.squeeze(array).shape != self.shape:
-                    raise ValueError('Cannot fill with the provided array.' + \
-                                     'Expecting shape {0} got {1}'.format(
-                                     self.shape,array.shape))
-                numpy.copyto(self.array, array)
+                numpy.copyto(self.array, array)               
             elif isinstance(array, Number):
                 self.array.fill(array)
             elif issubclass(array.__class__ , DataContainer):
@@ -3641,11 +3637,12 @@ class ImageData(DataContainer):
         elif issubclass(type(array) , DataContainer):
             array = array.as_array()
         elif issubclass(type(array) , numpy.ndarray):
-            pass
+            # remove singleton dimensions
+            array = numpy.squeeze(array)
         else:
             raise TypeError('array must be a CIL type DataContainer or numpy.ndarray got {}'.format(type(array)))
 
-        if numpy.squeeze(array).shape != geometry.shape:
+        if array.shape != geometry.shape:
             raise ValueError('Shape mismatch {} {}'.format(array.shape, geometry.shape))
 
         if array.ndim not in [2,3,4]:
@@ -3798,6 +3795,7 @@ class AcquisitionData(DataContainer, Partitioner):
 
         dtype = kwargs.get('dtype', numpy.float32)
 
+        
         if geometry is None:
             raise AttributeError("AcquisitionData requires a geometry")
 
@@ -3810,7 +3808,8 @@ class AcquisitionData(DataContainer, Partitioner):
         elif issubclass(type(array) , DataContainer):
             array = array.as_array()
         elif issubclass(type(array) , numpy.ndarray):
-            pass
+            # remove singleton dimensions
+            array = numpy.squeeze(array)
         else:
             raise TypeError('array must be a CIL type DataContainer or numpy.ndarray got {}'.format(type(array)))
 

--- a/Wrappers/Python/cil/framework/framework.py
+++ b/Wrappers/Python/cil/framework/framework.py
@@ -2920,7 +2920,7 @@ class DataContainer(object):
             return
         if dimension == {}:
             if isinstance(array, numpy.ndarray):
-                if array.shape != self.shape:
+                if numpy.squeeze(array).shape != self.shape:
                     raise ValueError('Cannot fill with the provided array.' + \
                                      'Expecting shape {0} got {1}'.format(
                                      self.shape,array.shape))

--- a/Wrappers/Python/test/test_BlockDataContainer.py
+++ b/Wrappers/Python/test/test_BlockDataContainer.py
@@ -1024,6 +1024,10 @@ class TestBlockDataContainerGeometry(BDCUnittest):
 
         assert cp0.geometry == cp1.geometry
 
+        cp1 = BlockDataContainer(data2,data2)
+
+        assert cp0 != cp1
+
         cp1 = BlockDataContainer(data2,data2,data2)
 
         assert cp0 != cp1
@@ -1034,7 +1038,7 @@ class TestBlockDataContainerGeometry(BDCUnittest):
         data0 = ig0.allocate(0)
         
         from cil.framework import DataContainer
-        X, Y, Z = 1, 12, 5
+        X, Y, Z = 2, 12, 5
         
         a = numpy.ones((X, Y, Z), dtype='float32')
         ds = DataContainer(a, False, ['X', 'Y', 'Z'])

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -467,6 +467,41 @@ class TestDataContainer(CCPiTestClass):
         self.assertNumpyArrayEqual(numpy.asarray(data.shape), data.as_array().shape)
 
 
+    def test_ImageData_from_numpy(self):
+        """
+        Test the creation and manipulation of ImageData from a numpy array.
+        """
+        # Initialize array and ImageGeometry
+        arr = numpy.arange(24, dtype=numpy.float32).reshape(2, 3, 4)
+        ig = ImageGeometry(voxel_num_x=4, voxel_num_y=3, voxel_num_z=2)
+        data = ImageData(arr, deep_copy=True, geometry=ig)
+        
+        # Check initial shape, geometry, and deep copy
+        self.assertEqual(data.shape, (2, 3, 4))
+        self.assertEqual(data.geometry, ig)
+        self.assertNotEqual(id(data.array), id(arr))
+    
+        # Fill with zeros and check
+        data.fill(0)
+        numpy.testing.assert_array_equal(data.as_array(), numpy.zeros(ig.shape))
+        
+        # Fill with original array and check
+        data.fill(arr)
+        self.assertEqual(data.shape, (2, 3, 4))
+        self.assertEqual(data.geometry, ig)  
+        
+        # Reshape array with singleton dimension and create new ImageData
+        arr = arr.reshape(1, 2, 3, 4)
+        data = ImageData(arr, geometry=ig)
+        self.assertEqual(data.shape, (2, 3, 4))
+        self.assertEqual(data.geometry, ig)
+    
+        # Fill with zeros and reshaped array, then check
+        data.fill(0)
+        data.fill(arr)
+        self.assertEqual(data.shape, (2, 3, 4))
+        self.assertEqual(data.geometry, ig)
+
     def test_ImageData_apply_circular_mask(self):
         ig = ImageGeometry(voxel_num_x=6, voxel_num_y=3, voxel_size_x=0.5, voxel_size_y = 1)
         data_orig = ig.allocate(1)
@@ -491,8 +526,6 @@ class TestDataContainer(CCPiTestClass):
 
 
 
-
-
     def test_AcquisitionData(self):
         sgeometry = AcquisitionGeometry.create_Parallel3D().set_angles(numpy.linspace(0, 180, num=10)).set_panel((5,3)).set_channels(2)
 
@@ -512,6 +545,48 @@ class TestDataContainer(CCPiTestClass):
         data = ag2.allocate()
         self.assertNumpyArrayEqual(numpy.asarray(data.shape), numpy.asarray(ag2.shape))
         self.assertNumpyArrayEqual(numpy.asarray(data.shape), data.as_array().shape)
+
+    def test_AcquisitionData_from_numpy(self):
+        """
+        Test the creation and manipulation of AcquisitionData from a numpy array.
+        """
+        arr = numpy.arange(24, dtype=numpy.float32).reshape(2, 3, 4)
+        ag = AcquisitionGeometry.create_Parallel3D().set_angles([0, 1]).set_panel((4, 3))
+        data = AcquisitionData(arr, deep_copy=True, geometry=ag)
+        
+        # Check initial shape, geometry, and deep copy
+        self.assertEqual(data.shape, (2, 3, 4))
+        self.assertEqual(data.geometry, ag)
+        self.assertNotEqual(id(data.array), id(arr))
+
+        # Fill with zeros and check
+        data.fill(0)
+        numpy.testing.assert_array_equal(data.as_array(), numpy.zeros(ag.shape))
+        
+        # Fill with original array and check
+        data.fill(arr)
+        self.assertEqual(data.shape, (2, 3, 4))
+        self.assertEqual(data.geometry, ag)
+        numpy.testing.assert_array_equal(data.as_array(), arr)
+
+        # Reshape array to add empty dimensions and test create AcquisitionData
+        arr = arr.reshape(1, 2, 3, 4)
+        data = AcquisitionData(arr, geometry=ag)
+        self.assertEqual(data.shape, (2, 3, 4))
+        self.assertEqual(data.geometry, ag)
+
+        # Fill with reshaped array
+        data.fill(0)
+        data.fill(arr)
+        self.assertEqual(data.shape, (2, 3, 4))
+        self.assertEqual(data.geometry, ag)  
+
+        # Change dtype to float64, fill, and check
+        arr = arr.astype(numpy.float64)
+        data.fill(arr)
+        self.assertEqual(data.shape, (2, 3, 4))
+        self.assertEqual(data.geometry, ag)
+        self.assertEqual(data.dtype, numpy.float32)
 
 
     def test_ImageGeometry_allocate(self):


### PR DESCRIPTION
## Changes
 - When passed a `numpy.ndarray` `AcquisitionData` and `ImageData` now remove dimensions of 1 from the numpy meta data before passing to `DataContainer`. This matches `AcquisitionGeometry` and `ImageGeometry`
 - `ImageData` and `AcquisitionData` compare squeezed array shape with geometry, which does not report 1's in shape.
 - `DataContainer.(fill)` removes shape check for `numpy.ndarray` and relies on numpy raiseing the error. Note: `np.copyto` does not care about singleton dimensions. 
 - FBP unittests updated to test reconstruction of a single slice (where bug was initially reported)
 - Added unittests on `ImageData` and `AcquisitionData` for initialisation and filling.

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

Tested on example code in issue.

## Related issues/links
closes #1884

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

