### PR TITLE
Remove "num_cols" from show1D documentation

### DIFF
--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -132,9 +132,6 @@ class show1D(show_base):
         Linestyle(s) for each line plot
     axis_labels : tuple of str, list of str, default=('Index','Value')
         Axis labels in the form (x_axis_label,y_axis_label)
-    num_cols : int, default=3
-        The number of columns in the grid of subplots produced in the case
-        of multiple plots
     size : tuple, default=(8,6)
         The size of the figure
 


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->
"num_cols" appears in the doc string for show1D but show1D doesnt use it.

## Example Usage
<!--minimal working example-->

:heart: *Thanks for your contribution!*







<!-- please IGNORE the below if you aren't a CIL team member

blame GH for this text: https://github.com/orgs/community/discussions/81319

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
