### PR TITLE
BlockOperator direct and adjoint methods: can pass out as a DataContainer instead of a (1,1) BlockDataContainer where geometry permits 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Make Paganin Processor work with AcquistionData with one angle (#1920)
     - Fix bug passing `kwargs` to PDHG (#2010)
     - Show1D correctly applies slices to N-dimensional data (#2022)
+    - BlockOperator direct and adjoint methods: can pass out as a DataContainer instead of a (1,1) BlockDataContainer where geometry permits (#1926)
   - Enhancements:
     - Removed multiple exits from numba implementation of KullbackLeibler divergence (#1901)
     - Updated the `SPDHG` algorithm to take a stochastic `Sampler`(#1644)

--- a/Wrappers/Python/cil/optimisation/operators/BlockOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/BlockOperator.py
@@ -204,7 +204,7 @@ class BlockOperator(Operator):
                         prod += self.get_item(row,
                                               col).direct(x_b.get_item(col))
                 res.append(prod)
-            if 1 == shape[0] == shape[1]:
+            if (1 == shape[0]) and (1 == shape[1]):
                 # the output is a single DataContainer, so we can take it out 
                 return res[0] 
             else: 
@@ -213,13 +213,13 @@ class BlockOperator(Operator):
 
         else:
             if not isinstance(out, BlockDataContainer):
-                if 1 == shape[0] == shape[1]:
+                if (1 == shape[0]) and (1 == shape[1]):
                     out = BlockDataContainer(out)
-                    flag_return_data_container = True
+                    flag_single_element = True
                 else:
                     raise ValueError(f'You passed to `out` a `DataContainer`. You needed to pass a `BlockDataContainer` of shape {shape}')
             else:
-                flag_return_data_container = False
+                flag_single_element = False
             tmp = self.range_geometry().allocate()
             if not isinstance(tmp, BlockDataContainer):
                 tmp = BlockDataContainer(tmp)
@@ -235,7 +235,7 @@ class BlockOperator(Operator):
                                                       x_b.get_item(col),
                                                       out=tmp.get_item(row))
                         temp_out_row += tmp.get_item(row)
-            if flag_return_data_container:
+            if flag_single_element:
                 return out.get_item(0)
             else:
                 return out
@@ -279,13 +279,13 @@ class BlockOperator(Operator):
                 return BlockDataContainer(*res, shape=shape)
         else:
             if not isinstance(out, BlockDataContainer):
-                if 1 == shape[0] == shape[1]:
+                if (1 == shape[0]) and (1 == shape[1]):
                     out = BlockDataContainer(out)
-                    flag_return_data_container = True
+                    flag_single_element = True
                 else:
                     raise ValueError(f'You passed to `out` a `DataContainer`. You needed to pass a `BlockDataContainer` of shape {shape}')
             else:
-                flag_return_data_container = False
+                flag_single_element = False
             for col in range(self.shape[1]):
                 for row in range(self.shape[0]):
                     if row == 0:
@@ -310,7 +310,7 @@ class BlockOperator(Operator):
                             temp_out_col += self.get_item(row,col).adjoint(
                                                         x_b.get_item(row),
                                                         )
-            if flag_return_data_container:
+            if flag_single_element:
                 return out.get_item(0)
             else:
                 return out

--- a/Wrappers/Python/cil/optimisation/operators/BlockOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/BlockOperator.py
@@ -200,10 +200,10 @@ class BlockOperator(Operator):
             raise ValueError(
                 'We expect the input to be a block data container of shape {}'.format(  self._domain_block_shape))
         
-        return_data_container = False
+        unwrap_data_container_on_return = False
         
-        if self._range_block_shape[0]==1:
-            return_data_container = True ##TODO: Does this default make sense?
+        if self._range_block_shape == (1,1):
+            unwrap_data_container_on_return = True 
 
         if out is None:
             # allocate the output blockdatacontainer of the correct shape
@@ -211,14 +211,14 @@ class BlockOperator(Operator):
                                      for row in range(self.shape[0])], shape=self._range_block_shape)
         elif not isinstance(out, BlockDataContainer):
                 # Handle datacontainers or sirf datacontainers
-                if self._range_block_shape[0]==1:
+                if unwrap_data_container_on_return: 
                     res = BlockDataContainer(out)
                 else:
                     raise ValueError(
-                        f'Expected `out` to be `None` or a `BlockDataContainer` of shape {self._range_block_shape}')             
+                        f'The range of this block operator is not compatible with the `out` that was passed. Expected `out` to be `None` or a `BlockDataContainer` of shape {self._range_block_shape}')             
         else:
             res = out
-            return_data_container = False
+            unwrap_data_container_on_return = False
 
         for row in range(self.shape[0]):
             for col in range(self.shape[1]):
@@ -230,7 +230,8 @@ class BlockOperator(Operator):
                     temp_out_row = res.get_item(row)
                     temp_out_row += self.get_item(row, col).direct(x_b.get_item(col))
 
-        if return_data_container:
+        if unwrap_data_container_on_return:
+            # Return the out as the user passed it in case the range shape is (1,1)
             return res.get_item(0)
         else:
             return res
@@ -263,10 +264,10 @@ class BlockOperator(Operator):
             raise ValueError(
                 'We expect the input to be a block data container of shape {}'.format(  self._range_block_shape))
         
-        return_data_container = False
+        unwrap_data_container_on_return = False
         
-        if self._domain_block_shape[0]==1:
-            return_data_container = True ##TODO: Does this default make sense?
+        if self._domain_block_shape == (1,1):
+            unwrap_data_container_on_return = True 
         
 
         if out is None:
@@ -277,17 +278,17 @@ class BlockOperator(Operator):
 
         elif not isinstance(out, BlockDataContainer):
             # Handle datacontainers or sirf datacontainers
-            if self._domain_block_shape[0]==1:
+            if unwrap_data_container_on_return:
                     res = BlockDataContainer(out)
                         
 
             else:
                 raise ValueError(
-                    f'Expected `out` to be `None` or a `BlockDataContainer` of shape {self._domain_block_shape}')    
+                    f'The domain of this block operator is not compatible with the `out` that was passed. Expected `out` to be `None` or a `BlockDataContainer` of shape {self._domain_block_shape}')    
                     
         else:
             res = out
-            return_data_container = False
+            unwrap_data_container_on_return = False
 
         for col in range(self.shape[1]):
             for row in range(self.shape[0]):
@@ -303,7 +304,8 @@ class BlockOperator(Operator):
                         x_b.get_item(row),
                     )
                     
-        if return_data_container:
+        if unwrap_data_container_on_return:
+            # Return the out as the user passed it in case the range shape is (1,1)
             return res.get_item(0)
         else:
             return res

--- a/Wrappers/Python/cil/optimisation/operators/BlockOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/BlockOperator.py
@@ -185,6 +185,13 @@ class BlockOperator(Operator):
     def direct(self, x, out=None):
         '''Direct operation for the BlockOperator
 
+        Parameters
+        ----------
+        x: BlockDataContainer
+            The input BlockDataContainer to apply the BlockOperator on. Can be a DataContainer if the domain geometry permits.  
+        out: BlockDataContainer, optional
+            The output BlockDataContainer to store the result of the operation. If not provided, a new BlockDataContainer is created. Can be a DataContainer if the range geometry permits.
+
         Note
         -----
         BlockOperators work on BlockDataContainers, but they will also work on DataContainers
@@ -240,6 +247,12 @@ class BlockOperator(Operator):
     def adjoint(self, x, out=None):
         '''Adjoint operation for the BlockOperator
 
+        Parameters
+        ----------
+        x: BlockDataContainer
+            The input BlockDataContainer to apply the BlockOperator adjoint on. Can be a DataContainer if the range geometry permits.
+        out: BlockDataContainer, optional
+            The output BlockDataContainer to store the result of the operation. If not provided, a new BlockDataContainer is created. Can be a DataContainer if the domain geometry permits.
         Note
         -----
         BlockOperator may contain both LinearOperator and Operator

--- a/Wrappers/Python/cil/optimisation/operators/BlockOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/BlockOperator.py
@@ -212,7 +212,17 @@ class BlockOperator(Operator):
             
 
         else:
+            if not isinstance(out, BlockDataContainer):
+                if 1 == shape[0] == shape[1]:
+                    out = BlockDataContainer(out)
+                    flag_return_data_container = True
+                else:
+                    raise ValueError(f'You passed to `out` a `DataContainer`. You needed to pass a `BlockDataContainer` of shape {shape}')
+            else:
+                flag_return_data_container = False
             tmp = self.range_geometry().allocate()
+            if not isinstance(tmp, BlockDataContainer):
+                tmp = BlockDataContainer(tmp)
             for row in range(self.shape[0]):
                 for col in range(self.shape[1]):
                     if col == 0:
@@ -225,7 +235,10 @@ class BlockOperator(Operator):
                                                       x_b.get_item(col),
                                                       out=tmp.get_item(row))
                         temp_out_row += tmp.get_item(row)
-            return out
+            if flag_return_data_container:
+                return out.get_item(0)
+            else:
+                return out
 
     def adjoint(self, x, out=None):
         '''Adjoint operation for the BlockOperator
@@ -265,6 +278,14 @@ class BlockOperator(Operator):
             else:
                 return BlockDataContainer(*res, shape=shape)
         else:
+            if not isinstance(out, BlockDataContainer):
+                if 1 == shape[0] == shape[1]:
+                    out = BlockDataContainer(out)
+                    flag_return_data_container = True
+                else:
+                    raise ValueError(f'You passed to `out` a `DataContainer`. You needed to pass a `BlockDataContainer` of shape {shape}')
+            else:
+                flag_return_data_container = False
             for col in range(self.shape[1]):
                 for row in range(self.shape[0]):
                     if row == 0:
@@ -289,7 +310,10 @@ class BlockOperator(Operator):
                             temp_out_col += self.get_item(row,col).adjoint(
                                                         x_b.get_item(row),
                                                         )
-            return out
+            if flag_return_data_container:
+                return out.get_item(0)
+            else:
+                return out
 
     def is_linear(self):
         '''Returns whether all the elements of the BlockOperator are linear'''

--- a/Wrappers/Python/test/test_BlockOperator.py
+++ b/Wrappers/Python/test/test_BlockOperator.py
@@ -209,7 +209,66 @@ class TestBlockOperator(CCPiTestClass):
 
         self.assertEqual(K.domain_geometry(), ig)
 
+    def test_blockoperator_out_datacontainer(self):
+        
+        #test direct
+        M, N ,W = 3, 4, 5
+        ig = ImageGeometry(M, N, W)
+        operator0=IdentityOperator(ig)
+        operator1=-IdentityOperator(ig)
+        K = BlockOperator(operator0, operator1, shape = (1,2))
+        bg=BlockGeometry(ig, ig)
+        data=bg.allocate('random', seed=2)
+        out=K.range.allocate(0)
+        assert not isinstance(out, BlockDataContainer)
+        ans = K.direct(data)  
+        K.direct(data, out)
+        self.assertNumpyArrayEqual(ans.array, out.array) 
+        
+        #test direct out is BlockDataContainer 
+        out = BlockDataContainer(out)
+        assert isinstance(out, BlockDataContainer)
+        ans = K.direct(data)  
+        K.direct(data, out)
+        self.assertNumpyArrayEqual(ans.array, out.get_item(0).array) 
+        
+        #test adjoint wrong dimension 
+        out=ig.allocate(0) 
+        data = ig.allocate('random')
+        print(K.range_geometry)
+        with self.assertRaises(ValueError):
+            K.adjoint(data, out)
+        
+        
+        #test adjoint out not BlockDataContainer 
+        M, N ,W = 3, 4, 5
+        operator0=IdentityOperator(ig)
+        operator1=-IdentityOperator(ig)
+        K = BlockOperator(operator0, operator1, shape = (2,1))
+        bg=BlockGeometry(ig, ig)
+        data=bg.allocate('random', seed=2)
+        out=K.domain.allocate(0)
+        assert not isinstance(out, BlockDataContainer)
+        ans = K.adjoint(data)  
+        K.adjoint(data, out)
+        self.assertNumpyArrayEqual(ans.array, out.array) 
+        
+        #test adjoint out is BlockDataContainer 
+        out = BlockDataContainer(out)
+        assert isinstance(out, BlockDataContainer)
+        ans = K.adjoint(data)  
+        K.adjoint(data, out)
+        self.assertNumpyArrayEqual(ans.array, out.get_item(0).array) 
+        
+        #test direct wrong dimension 
+        out=ig.allocate(0) 
+        data = ig.allocate('random')
+        print(K.range_geometry)
+        with self.assertRaises(ValueError):
+            K.direct(data, out)
 
+        
+        
 
     @unittest.skipIf(True, 'Skipping time tests')
     def test_timedifference(self):


### PR DESCRIPTION
## Description
Linked to  #1863











## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


