### PR TITLE
build cilacc.dll as release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     - `ImageData` removes dimensions of size 1 from the input array. This fixes an issue where single slice reconstructions from 3D data would fail due to shape mismatches (#1885)
     - Make Binner accept accelerated=False (#1887)
     - Added checks on memory allocations within `FiniteDifferenceLibrary.cpp` and verified the status of the return in `GradientOperator` (#1929)
+    - Build release version of `cilacc.dll` for Windows. Previously was defaulting to the debug build (#1928)
   - Changes that break backwards compatibility:
     - CGLS will no longer automatically stop iterations once a default tolerance is reached. The option to pass `tolerance` will be deprecated to be replaced by `optimisation.utilities.callbacks` (#1892)
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,8 +5,11 @@ if not "%GIT_DESCRIBE_NUMBER%"=="0" (
     set SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL="%PKG_VERSION%.dev%GIT_DESCRIBE_NUMBER%+%GIT_DESCRIBE_HASH%"
 )
 
-cmake -S "%RECIPE_DIR%\.." -B "%SRC_DIR%\build_framework" -G "NMake Makefiles" -DCONDA_BUILD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBRARY_LIB=%CONDA_PREFIX%\lib -DLIBRARY_INC=%CONDA_PREFIX% -DCMAKE_INSTALL_PREFIX=%PREFIX%
+:: -G "Visual Studio 16 2019" specifies the the generator
+:: -T v142 specifies the toolset
+
+cmake -S "%RECIPE_DIR%\.." -B "%SRC_DIR%\build_framework" -G "Visual Studio 16 2019" -T "v142" -DCONDA_BUILD=ON -DCMAKE_BUILD_TYPE=Release -DLIBRARY_LIB=%CONDA_PREFIX%\lib -DLIBRARY_INC=%CONDA_PREFIX% -DCMAKE_INSTALL_PREFIX=%PREFIX%
 if errorlevel 1 exit 1
 
-cmake --build "%SRC_DIR%\build_framework" --target install
+cmake --build "%SRC_DIR%\build_framework" --target install --config Release
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,8 +8,8 @@ if not "%GIT_DESCRIBE_NUMBER%"=="0" (
 :: -G "Visual Studio 16 2019" specifies the the generator
 :: -T v142 specifies the toolset
 
-cmake -S "%RECIPE_DIR%\.." -B "%SRC_DIR%\build_framework" -G "Visual Studio 16 2019" -T "v142" -DCONDA_BUILD=ON -DCMAKE_BUILD_TYPE=Release -DLIBRARY_LIB=%CONDA_PREFIX%\lib -DLIBRARY_INC=%CONDA_PREFIX% -DCMAKE_INSTALL_PREFIX=%PREFIX%
+cmake -S "%RECIPE_DIR%\.." -B "%SRC_DIR%\build_framework" -G "Visual Studio 16 2019" -T "v142" -DCONDA_BUILD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBRARY_LIB=%CONDA_PREFIX%\lib -DLIBRARY_INC=%CONDA_PREFIX% -DCMAKE_INSTALL_PREFIX=%PREFIX%
 if errorlevel 1 exit 1
 
-cmake --build "%SRC_DIR%\build_framework" --target install --config Release
+cmake --build "%SRC_DIR%\build_framework" --target install --config RelWithDebInfo
 if errorlevel 1 exit 1


### PR DESCRIPTION
## Changes

Added:
`--config RelWithDebInfo`

specified the generator and toolkit in the windows build script to keep consistency between builders.


OUTDATED
Need to build the shared library as 'Release'. Previous build 'RelWithDebug' requires debug dlls which are not included in the VC redistributable installed in the conda environment.

Built as 'RelWithDebug':
```
Dependencies:
Success: ippcore.dll, Version: 2021,12,0,1052
Success: ipps.dll, Version: 2021,12,0,1087
Success: ippi.dll, Version: 2021,12,0,1083
Failure: VCOMP140D.DLL, Error: DLL not found
Failure: VCRUNTIME140D.dll, Error: DLL not found
Failure: ucrtbased.dll, Error: DLL not found
Success: KERNEL32.dll, Version: 10.0.19041.4717 (WinBuild.160101.0800)
```

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc
Built and tested on windows. Confirmed dll dependencies in conda environments.

## Related issues/links
Needed to address for #1880

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

