### PR TITLE
Autofix: Identity Operator - Domain and Range geometry should be the same

### DIFF
--- a/Wrappers/Python/cil/optimisation/operators/IdentityOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/IdentityOperator.py
@@ -22,29 +22,22 @@ import numpy as np
 
 
 class IdentityOperator(LinearOperator):
+    r''' `IdentityOperator`: :math:`\mathrm{Id}: X \rightarrow X`,  :math:`\mathrm{Id}(x) = x`
 
-    r''' `IdentityOperator`: :math:`\mathrm{Id}: X \rightarrow Y`,  :math:`\mathrm{Id}(x) = x`
-
-                   :math:`X` : domain
-                   :math:`Y` : range ( Default: :math:`Y = X` )
+                   :math:`X` : domain and range
 
     Parameters
     ----------
     domain_geometry: CIL Geometry
-        domain of the operator
-    range_geometry: CIL Geometry, optional
-        range of the operator, default: same as domain
+        domain and range of the operator
     '''
 
 
-    def __init__(self, domain_geometry, range_geometry=None):
 
-
-        if range_geometry is None:
-            range_geometry = domain_geometry
+    def __init__(self, domain_geometry):
 
         super(IdentityOperator, self).__init__(domain_geometry=domain_geometry,
-                                       range_geometry=range_geometry)
+                                       range_geometry=domain_geometry)
 
     def direct(self,x,out=None):
 


### PR DESCRIPTION
Modified the IdentityOperator class to remove the option of passing a range_geometry. The operator now always uses the domain_geometry as its range_geometry. Updated the class docstring and __init__ method accordingly. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    