### PR TITLE
Remove md5sums.txt file after download

### DIFF
--- a/Wrappers/Python/cil/utilities/dataexample.py
+++ b/Wrappers/Python/cil/utilities/dataexample.py
@@ -75,6 +75,8 @@ class REMOTEDATA(DATA):
             with ZipFile(os.path.join(data_dir, cls.ZIP_FILE), 'r') as zip_ref:
                 zip_ref.extractall(os.path.join(data_dir, cls.FOLDER))
             os.remove(os.path.join(data_dir, cls.ZIP_FILE))
+            if os.path.exists(os.path.join(data_dir, 'md5sums.txt')):
+                os.remove(os.path.join(data_dir, 'md5sums.txt'))
             return True
 
 class BOAT(CILDATA):


### PR DESCRIPTION
## Description
Datexample REMOTEDATA class uses zenodo_get to download data which creates an md5sums.txt file


## Changes
Remove the md5sums.txt file after data is downloaded

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links
Closes #1967 

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties


