### PR TITLE
Allow MaskGenerator to be run on a DataContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Bug fixes:
   - Fix bug with 'median' and 'mean' methods in Masker averaging over the wrong axes.
   - `SPDHG` `gamma` parameter is now applied correctly so that the product of the dual and primal step sizes remains constant as `gamma` varies (#1644)
+  - Allow MaskGenerator to be run on DataContainers (#2001)
 - Enhancements:
   - Removed multiple exits from numba implementation of KullbackLeibler divergence (#1901)
   - Updated the `SPDHG` algorithm to take a stochastic `Sampler`(#1644)

--- a/Wrappers/Python/cil/processors/MaskGenerator.py
+++ b/Wrappers/Python/cil/processors/MaskGenerator.py
@@ -374,7 +374,11 @@ class MaskGenerator(DataProcessor):
 
         if out is None:
             mask = numpy.asarray(mask, dtype=bool)
-            out = type(data)(mask, deep_copy=False, dtype=mask.dtype, geometry=data.geometry.copy(), suppress_warning=True, dimension_labels=data.dimension_labels)
+            if data.geometry is not None:
+                geometry = data.geometry.copy()
+            else:
+                geometry = None
+            out = type(data)(mask, deep_copy=False, dtype=mask.dtype, geometry=geometry, suppress_warning=True, dimension_labels=data.dimension_labels)
         else:
             out.fill(mask)
         

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -2368,17 +2368,20 @@ class TestMaskGenerator(unittest.TestCase):
 
         IG = ImageGeometry(voxel_num_x=10,
                         voxel_num_y=10)
+        AG = AcquisitionGeometry.create_Parallel2D().set_panel((10,10)).set_angles(1)
 
         data = IG.allocate('random')
 
         data.as_array()[2,3] = float('inf')
         data.as_array()[4,5] = float('nan')
 
+   
         data_as_image_data = data
         data_as_data_container = DataContainer(data.as_array().copy())
+        data_as_acq_data = AcquisitionData(array=data.copy(), geometry=AG)
 
-        data_objects = [data_as_image_data, data_as_data_container]
-        data_type_name = ['ImageData', 'DataContainer']
+        data_objects = [data_as_image_data, data_as_data_container, data_as_acq_data]
+        data_type_name = ['ImageData', 'DataContainer', 'AcquisitionData']
 
         for i, data in enumerate(data_objects):
             with self.subTest(data_type=data_type_name[i]):
@@ -2463,11 +2466,11 @@ class TestMaskGenerator(unittest.TestCase):
                 numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
 
-        # Tests on larger data
-
-        # check mean
+        # Tests on larger data for checking mean and median
         IG = ImageGeometry(voxel_num_x=200,
                             voxel_num_y=200)
+
+        AG = AcquisitionGeometry.create_Parallel2D().set_panel((200,200)).set_angles(1)
         data = IG.allocate()
         numpy.random.seed(10)
         data.fill(numpy.random.rand(200,200))
@@ -2475,7 +2478,8 @@ class TestMaskGenerator(unittest.TestCase):
 
         data_as_data_container = DataContainer(data.as_array().copy())
         data_as_image_data = data
-        data_objects = [data_as_image_data, data_as_data_container]
+        data_as_acq_data = AcquisitionData(array=data.copy(), geometry=AG)
+        data_objects = [data_as_image_data, data_as_data_container, data_as_acq_data]
 
         for i, data in enumerate(data_objects):
             with self.subTest(data_type=data_type_name[i]):

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -2415,7 +2415,8 @@ class TestMaskGenerator(unittest.TestCase):
                 numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
                 # check threshold
-                data = IG.allocate('random')
+                data.as_array()[2,3] = numpy.random.rand()
+                data.as_array()[4,5] = numpy.random.rand()
                 data.as_array()[6,8] = 100
                 data.as_array()[1,3] = 80
 
@@ -2439,7 +2440,6 @@ class TestMaskGenerator(unittest.TestCase):
                 numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
                 # check quantile
-                data = IG.allocate('random')
                 data.as_array()[6,8] = 100
                 data.as_array()[1,3] = 80
 
@@ -2462,16 +2462,25 @@ class TestMaskGenerator(unittest.TestCase):
 
                 numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-                # check mean
-                IG = ImageGeometry(voxel_num_x=200,
-                                    voxel_num_y=200)
-                #data = IG.allocate('random', seed=10)
-                data = IG.allocate()
-                numpy.random.seed(10)
-                data.fill(numpy.random.rand(200,200))
-                data.as_array()[7,4] += 10 * numpy.std(data.as_array()[7,:])
 
-                m = MaskGenerator.mean(axis='horizontal_x')
+        # Tests on larger data
+
+        # check mean
+        IG = ImageGeometry(voxel_num_x=200,
+                            voxel_num_y=200)
+        data = IG.allocate()
+        numpy.random.seed(10)
+        data.fill(numpy.random.rand(200,200))
+        data.as_array()[7,4] += 10 * numpy.std(data.as_array()[7,:])
+
+        data_as_data_container = DataContainer(data.as_array().copy())
+        data_as_image_data = data
+        data_objects = [data_as_image_data, data_as_data_container]
+
+        for i, data in enumerate(data_objects):
+            with self.subTest(data_type=data_type_name[i]):
+
+                m = MaskGenerator.mean(axis=1) # this gives horizontal_x for ImageData, or 'dimension_01' for DataContainer
                 m.set_input(data)
                 mask = m.process()
 
@@ -2490,7 +2499,7 @@ class TestMaskGenerator(unittest.TestCase):
                 numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
                 # check median
-                m = MaskGenerator.median(axis='horizontal_x')
+                m = MaskGenerator.median(axis=1)
                 m.set_input(data)
                 mask = m.process()
 
@@ -2517,7 +2526,7 @@ class TestMaskGenerator(unittest.TestCase):
                 numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
                 #
-                m = MaskGenerator.mean(window=20, axis='horizontal_y')
+                m = MaskGenerator.mean(window=20, axis=0) # this gives horizontal_y for ImageData, or 'dimension_00' for DataContainer
                 m.set_input(data)
                 mask = m.process()
 

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -2378,7 +2378,7 @@ class TestMaskGenerator(unittest.TestCase):
    
         data_as_image_data = data
         data_as_data_container = DataContainer(data.as_array().copy())
-        data_as_acq_data = AcquisitionData(array=data.copy(), geometry=AG)
+        data_as_acq_data = AcquisitionData(array=data.as_array().copy(), geometry=AG)
 
         data_objects = [data_as_image_data, data_as_data_container, data_as_acq_data]
         data_type_name = ['ImageData', 'DataContainer', 'AcquisitionData']
@@ -2478,7 +2478,7 @@ class TestMaskGenerator(unittest.TestCase):
 
         data_as_data_container = DataContainer(data.as_array().copy())
         data_as_image_data = data
-        data_as_acq_data = AcquisitionData(array=data.copy(), geometry=AG)
+        data_as_acq_data = AcquisitionData(array=data.as_array().copy(), geometry=AG)
         data_objects = [data_as_image_data, data_as_data_container, data_as_acq_data]
 
         for i, data in enumerate(data_objects):

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -1008,7 +1008,7 @@ class TestSlicer(unittest.TestCase):
                 {'channel':(None,None,4),'angle':(None,None,2),'vertical':(None,None,8),'horizontal':(None,None,16)},
 
                 # shift detector with crop
-                {'vertical':(32,65,2)},
+                {'vertical':(32,64,2)},
 
                 # slice to single dimension
                 {'vertical':(32,34,2)},

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -351,7 +351,7 @@ class TestBinner(unittest.TestCase):
                 {'channel':(None,None,4),'angle':(None,None,2),'vertical':(None,None,8),'horizontal':(None,None,16)},
 
                 # shift detector with crop
-                {'vertical':(32,65,2)},
+                {'vertical':(32,64,2)},
 
                 # bin to single dimension
                 {'vertical':(31,33,2)},
@@ -2374,172 +2374,181 @@ class TestMaskGenerator(unittest.TestCase):
         data.as_array()[2,3] = float('inf')
         data.as_array()[4,5] = float('nan')
 
-        # check special values - default
-        m = MaskGenerator.special_values()
-        m.set_input(data)
-        mask = m.process()
+        data_as_image_data = data
+        data_as_data_container = DataContainer(data.as_array().copy())
 
-        mask_manual = numpy.ones((10,10), dtype=bool)
-        mask_manual[2,3] = 0
-        mask_manual[4,5] = 0
+        data_objects = [data_as_image_data, data_as_data_container]
+        data_type_name = ['ImageData', 'DataContainer']
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+        for i, data in enumerate(data_objects):
+            with self.subTest(data_type=data_type_name[i]):
 
-        # check nan
-        m = MaskGenerator.special_values(inf=False)
-        m.set_input(data)
-        mask = m.process()
+                # check special values - default
+                m = MaskGenerator.special_values()
+                m.set_input(data)
+                mask = m.process()
 
-        mask_manual = numpy.ones((10,10), dtype=bool)
-        mask_manual[4,5] = 0
+                mask_manual = numpy.ones((10,10), dtype=bool)
+                mask_manual[2,3] = 0
+                mask_manual[4,5] = 0
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        # check inf
-        m = MaskGenerator.special_values(nan=False)
-        m.set_input(data)
-        mask = m.process()
+                # check nan
+                m = MaskGenerator.special_values(inf=False)
+                m.set_input(data)
+                mask = m.process()
 
-        mask_manual = numpy.ones((10,10), dtype=bool)
-        mask_manual[2,3] = 0
+                mask_manual = numpy.ones((10,10), dtype=bool)
+                mask_manual[4,5] = 0
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        # check threshold
-        data = IG.allocate('random')
-        data.as_array()[6,8] = 100
-        data.as_array()[1,3] = 80
+                # check inf
+                m = MaskGenerator.special_values(nan=False)
+                m.set_input(data)
+                mask = m.process()
 
-        m = MaskGenerator.threshold(None, 70)
-        m.set_input(data)
-        mask = m.process()
+                mask_manual = numpy.ones((10,10), dtype=bool)
+                mask_manual[2,3] = 0
 
-        mask_manual = numpy.ones((10,10), dtype=bool)
-        mask_manual[6,8] = 0
-        mask_manual[1,3] = 0
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                # check threshold
+                data = IG.allocate('random')
+                data.as_array()[6,8] = 100
+                data.as_array()[1,3] = 80
 
-        m = MaskGenerator.threshold(None, 80)
-        m.set_input(data)
-        mask = m.process()
+                m = MaskGenerator.threshold(None, 70)
+                m.set_input(data)
+                mask = m.process()
 
-        mask_manual = numpy.ones((10,10), dtype=bool)
-        mask_manual[6,8] = 0
+                mask_manual = numpy.ones((10,10), dtype=bool)
+                mask_manual[6,8] = 0
+                mask_manual[1,3] = 0
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        # check quantile
-        data = IG.allocate('random')
-        data.as_array()[6,8] = 100
-        data.as_array()[1,3] = 80
+                m = MaskGenerator.threshold(None, 80)
+                m.set_input(data)
+                mask = m.process()
 
-        m = MaskGenerator.quantile(None, 0.98)
-        m.set_input(data)
-        mask = m.process()
+                mask_manual = numpy.ones((10,10), dtype=bool)
+                mask_manual[6,8] = 0
 
-        mask_manual = numpy.ones((10,10), dtype=bool)
-        mask_manual[6,8] = 0
-        mask_manual[1,3] = 0
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                # check quantile
+                data = IG.allocate('random')
+                data.as_array()[6,8] = 100
+                data.as_array()[1,3] = 80
 
-        m = MaskGenerator.quantile(None, 0.99)
-        m.set_input(data)
-        mask = m.process()
+                m = MaskGenerator.quantile(None, 0.98)
+                m.set_input(data)
+                mask = m.process()
 
-        mask_manual = numpy.ones((10,10), dtype=bool)
-        mask_manual[6,8] = 0
+                mask_manual = numpy.ones((10,10), dtype=bool)
+                mask_manual[6,8] = 0
+                mask_manual[1,3] = 0
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        # check mean
-        IG = ImageGeometry(voxel_num_x=200,
-                            voxel_num_y=200)
-        #data = IG.allocate('random', seed=10)
-        data = IG.allocate()
-        numpy.random.seed(10)
-        data.fill(numpy.random.rand(200,200))
-        data.as_array()[7,4] += 10 * numpy.std(data.as_array()[7,:])
+                m = MaskGenerator.quantile(None, 0.99)
+                m.set_input(data)
+                mask = m.process()
 
-        m = MaskGenerator.mean(axis='horizontal_x')
-        m.set_input(data)
-        mask = m.process()
+                mask_manual = numpy.ones((10,10), dtype=bool)
+                mask_manual[6,8] = 0
 
-        mask_manual = numpy.ones((200,200), dtype=bool)
-        mask_manual[7,4] = 0
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                # check mean
+                IG = ImageGeometry(voxel_num_x=200,
+                                    voxel_num_y=200)
+                #data = IG.allocate('random', seed=10)
+                data = IG.allocate()
+                numpy.random.seed(10)
+                data.fill(numpy.random.rand(200,200))
+                data.as_array()[7,4] += 10 * numpy.std(data.as_array()[7,:])
 
-        m = MaskGenerator.mean(window=5)
-        m.set_input(data)
-        mask = m.process()
+                m = MaskGenerator.mean(axis='horizontal_x')
+                m.set_input(data)
+                mask = m.process()
 
-        mask_manual = numpy.ones((200,200), dtype=bool)
-        mask_manual[7,4] = 0
+                mask_manual = numpy.ones((200,200), dtype=bool)
+                mask_manual[7,4] = 0
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        # check median
-        m = MaskGenerator.median(axis='horizontal_x')
-        m.set_input(data)
-        mask = m.process()
+                m = MaskGenerator.mean(window=5)
+                m.set_input(data)
+                mask = m.process()
 
-        mask_manual = numpy.ones((200,200), dtype=bool)
-        mask_manual[7,4] = 0
+                mask_manual = numpy.ones((200,200), dtype=bool)
+                mask_manual[7,4] = 0
 
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        m = MaskGenerator.median()
-        m.set_input(data)
-        mask = m.process()
+                # check median
+                m = MaskGenerator.median(axis='horizontal_x')
+                m.set_input(data)
+                mask = m.process()
 
-        mask_manual = numpy.ones((200,200), dtype=bool)
-        mask_manual[7,4] = 0
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                mask_manual = numpy.ones((200,200), dtype=bool)
+                mask_manual[7,4] = 0
 
-        # check movmean
-        m = MaskGenerator.mean(window=10)
-        m.set_input(data)
-        mask = m.process()
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        mask_manual = numpy.ones((200,200), dtype=bool)
-        mask_manual[7,4] = 0
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                m = MaskGenerator.median()
+                m.set_input(data)
+                mask = m.process()
 
-        #
-        m = MaskGenerator.mean(window=20, axis='horizontal_y')
-        m.set_input(data)
-        mask = m.process()
+                mask_manual = numpy.ones((200,200), dtype=bool)
+                mask_manual[7,4] = 0
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        mask_manual = numpy.ones((200,200), dtype=bool)
-        mask_manual[7,4] = 0
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                # check movmean
+                m = MaskGenerator.mean(window=10)
+                m.set_input(data)
+                mask = m.process()
 
-        m = MaskGenerator.mean(window=10, threshold_factor=10)
-        m.set_input(data)
-        mask = m.process()
+                mask_manual = numpy.ones((200,200), dtype=bool)
+                mask_manual[7,4] = 0
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        mask_manual = numpy.ones((200,200), dtype=bool)
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                #
+                m = MaskGenerator.mean(window=20, axis='horizontal_y')
+                m.set_input(data)
+                mask = m.process()
 
-        # check movmedian
-        m = MaskGenerator.median(window=20)
-        m.set_input(data)
-        mask = m.process()
+                mask_manual = numpy.ones((200,200), dtype=bool)
+                mask_manual[7,4] = 0
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        mask_manual = numpy.ones((200,200), dtype=bool)
-        mask_manual[7,4] = 0
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                m = MaskGenerator.mean(window=10, threshold_factor=10)
+                m.set_input(data)
+                mask = m.process()
 
-        # check movmedian
-        m = MaskGenerator.median(window=40)
-        m.set_input(data)
-        mask = m.process()
+                mask_manual = numpy.ones((200,200), dtype=bool)
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
-        mask_manual = numpy.ones((200,200), dtype=bool)
-        mask_manual[7,4] = 0
-        numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+                # check movmedian
+                m = MaskGenerator.median(window=20)
+                m.set_input(data)
+                mask = m.process()
+
+                mask_manual = numpy.ones((200,200), dtype=bool)
+                mask_manual[7,4] = 0
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
+
+                # check movmedian
+                m = MaskGenerator.median(window=40)
+                m.set_input(data)
+                mask = m.process()
+
+                mask_manual = numpy.ones((200,200), dtype=bool)
+                mask_manual[7,4] = 0
+                numpy.testing.assert_array_equal(mask.as_array(), mask_manual)
 
 class TestTransmissionAbsorptionConverter(unittest.TestCase):
 

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -2368,7 +2368,7 @@ class TestMaskGenerator(unittest.TestCase):
 
         IG = ImageGeometry(voxel_num_x=10,
                         voxel_num_y=10)
-        AG = AcquisitionGeometry.create_Parallel2D().set_panel((10,10)).set_angles(1)
+        AG = AcquisitionGeometry.create_Parallel3D().set_panel((10,10)).set_angles(1)
 
         data = IG.allocate('random')
 
@@ -2470,7 +2470,7 @@ class TestMaskGenerator(unittest.TestCase):
         IG = ImageGeometry(voxel_num_x=200,
                             voxel_num_y=200)
 
-        AG = AcquisitionGeometry.create_Parallel2D().set_panel((200,200)).set_angles(1)
+        AG = AcquisitionGeometry.create_Parallel3D().set_panel((200,200)).set_angles(1)
         data = IG.allocate()
         numpy.random.seed(10)
         data.fill(numpy.random.rand(200,200))


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->
We may want to create a bad pixel mask based on the flat field data which would be stored in a DataContainer.
Currently throws an error if try to run MaskGenerator on a DataContainer - this PR resolves this (closes #1994 )

## Example Usage
<!--minimal working example-->

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

Updated unit tests to cover DataContainers and AcquisitionData as inputs to MaskGenerator

Also found in the unit tests for other processors some were throwing an error:

`WARNING:cil.processors.Slicer:ROI for axis vertical has 'stop' out of bounds. Using axis length as stop value. Got stop index: 65, using 64`

So I updated some ROI values to fix this

I tested that the new tests which I added on DataContainers failed on master but not on this branch


## Related issues/links
- Closes #1994 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
