### PR TITLE
SAPYB for block data container can take None 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     - Updated the `SPDHG` algorithm to take a stochastic `Sampler`(#1644)
     - Updated the `SPDHG` algorithm to include setters for step sizes (#1644)
     - Add FluxNormaliser processor (#1878)
+    - SAPBY for the BlockDataContainer now does not require an `out` to be passed (#2008)
   - Dependencies:
     - Added scikit-image to CIL-Demos conda install command as needed for new Callbacks notebook.
   - Changes that break backwards compatibility:

--- a/Wrappers/Python/cil/framework/block.py
+++ b/Wrappers/Python/cil/framework/block.py
@@ -283,7 +283,7 @@ class BlockDataContainer(object):
         '''
         return self.binary_operations(BlockDataContainer.MINIMUM, other, *args, **kwargs)
 
-    def sapyb(self, a, y, b, out, num_threads = NUM_THREADS):
+    def sapyb(self, a, y, b, out=None, num_threads = NUM_THREADS):
         r'''performs axpby element-wise on the BlockDataContainer containers
 
         Does the operation .. math:: a*x+b*y and stores the result in out, where x is self
@@ -307,9 +307,9 @@ class BlockDataContainer(object):
         >>> out = bdc1.sapyb(a,bdc2,b)
         '''
         if out is None:
-            raise ValueError("out container cannot be None")
+            out=0*y
         kwargs = {'a':a, 'b':b, 'out':out, 'num_threads': NUM_THREADS}
-        self.binary_operations(BlockDataContainer.SAPYB, y, **kwargs)
+        return self.binary_operations(BlockDataContainer.SAPYB, y, **kwargs)
 
 
     def axpby(self, a, b, y, out, dtype=numpy.float32, num_threads = NUM_THREADS):

--- a/Wrappers/Python/cil/framework/block.py
+++ b/Wrappers/Python/cil/framework/block.py
@@ -332,7 +332,7 @@ class BlockDataContainer(object):
         >>> out = bdc1.sapyb(a,bdc2,b)
         '''
         if out is None:
-            out=self*0
+            out = self * 0
         kwargs = {'a':a, 'b':b, 'out':out, 'num_threads': NUM_THREADS}
         return self.binary_operations(BlockDataContainer.SAPYB, y, **kwargs)
 

--- a/Wrappers/Python/cil/framework/block.py
+++ b/Wrappers/Python/cil/framework/block.py
@@ -307,7 +307,7 @@ class BlockDataContainer(object):
         >>> out = bdc1.sapyb(a,bdc2,b)
         '''
         if out is None:
-            out=0*y
+            out=self*0
         kwargs = {'a':a, 'b':b, 'out':out, 'num_threads': NUM_THREADS}
         return self.binary_operations(BlockDataContainer.SAPYB, y, **kwargs)
 

--- a/Wrappers/Python/cil/framework/block.py
+++ b/Wrappers/Python/cil/framework/block.py
@@ -236,50 +236,73 @@ class BlockDataContainer(object):
     def add(self, other, *args, **kwargs):
         '''Algebra: add method of BlockDataContainer with number/DataContainer or BlockDataContainer
 
-        :param: other (number, DataContainer or subclasses or BlockDataContainer
-        :param: out (optional): provides a placehold for the resul.
+        Parameters
+        ----------
+        other : number, DataContainer or subclasses or BlockDataContainer
+        out : BlockDataContainer, optional
+            Provides a placeholder for the result
         '''
         return self.binary_operations(BlockDataContainer.ADD, other, *args, **kwargs)
     def subtract(self, other, *args, **kwargs):
         '''Algebra: subtract method of BlockDataContainer with number/DataContainer or BlockDataContainer
 
-        :param: other (number, DataContainer or subclasses or BlockDataContainer
-        :param: out (optional): provides a placeholder for the result.
+        Parameters
+        ----------
+        other : number, DataContainer or subclasses or BlockDataContainer
+        out : BlockDataContainer, optional
+            Provides a placeholder for the result
         '''
         return self.binary_operations(BlockDataContainer.SUBTRACT, other, *args, **kwargs)
     def multiply(self, other, *args, **kwargs):
         '''Algebra: multiply method of BlockDataContainer with number/DataContainer or BlockDataContainer
 
-        :param: other (number, DataContainer or subclasses or BlockDataContainer)
-        :param: out (optional): provides a placeholder for the result.
+        Parameters
+        ----------
+        other : number, DataContainer or subclasses or BlockDataContainer
+        out : BlockDataContainer, optional
+            Provides a placeholder for the result
         '''
         return self.binary_operations(BlockDataContainer.MULTIPLY, other, *args, **kwargs)
     def divide(self, other, *args, **kwargs):
         '''Algebra: divide method of BlockDataContainer with number/DataContainer or BlockDataContainer
 
-        :param: other (number, DataContainer or subclasses or BlockDataContainer)
-        :param: out (optional): provides a placeholder for the result.
+        Parameters
+        ----------
+        other : number, DataContainer or subclasses or BlockDataContainer
+        out : BlockDataContainer, optional
+            Provides a placeholder for the result
+
         '''
         return self.binary_operations(BlockDataContainer.DIVIDE, other, *args, **kwargs)
     def power(self, other, *args, **kwargs):
         '''Algebra: power method of BlockDataContainer with number/DataContainer or BlockDataContainer
 
-        :param: other (number, DataContainer or subclasses or BlockDataContainer
-        :param: out (optional): provides a placeholder for the result.
+        Parameters
+        ----------
+        other : number, DataContainer or subclasses or BlockDataContainer
+        out : BlockDataContainer, optional
+            Provides a placeholder for the result
         '''
         return self.binary_operations(BlockDataContainer.POWER, other, *args, **kwargs)
     def maximum(self, other, *args, **kwargs):
-        '''Algebra: power method of BlockDataContainer with number/DataContainer or BlockDataContainer
+        '''Algebra: maximum method of BlockDataContainer with number/DataContainer or BlockDataContainer
 
-        :param: other (number, DataContainer or subclasses or BlockDataContainer)
-        :param: out (optional): provides a placeholder for the result.
+        Parameters
+        ----------
+        other : number, DataContainer or subclasses or BlockDataContainer
+        out : BlockDataContainer, optional
+            Provides a placeholder for the result
         '''
         return self.binary_operations(BlockDataContainer.MAXIMUM, other, *args, **kwargs)
     def minimum(self, other, *args, **kwargs):
-        '''Algebra: power method of BlockDataContainer with number/DataContainer or BlockDataContainer
+        '''Algebra: minimum method of BlockDataContainer with number/DataContainer or BlockDataContainer
 
-        :param: other (number, DataContainer or subclasses or BlockDataContainer)
-        :param: out (optional): provides a placeholder for the result.
+        Parameters
+        ----------
+        other : number, DataContainer or subclasses or BlockDataContainer
+        out : BlockDataContainer, optional
+            Provides a placeholder for the result
+            
         '''
         return self.binary_operations(BlockDataContainer.MINIMUM, other, *args, **kwargs)
 
@@ -288,11 +311,13 @@ class BlockDataContainer(object):
 
         Does the operation .. math:: a*x+b*y and stores the result in out, where x is self
 
-        :param a: scalar
-        :param b: scalar
-        :param y: compatible (Block)DataContainer
-        :param out: (Block)DataContainer to store the result
-
+        Parameters
+        ----------
+        a : scalar or BlockDataContainer
+        b : scalar or BlockDataContainer
+        y : compatible (Block)DataContainer
+        out : BlockDataContainer, optional
+            Provides a placeholder for the result
 
         Example:
         --------

--- a/Wrappers/Python/test/test_BlockDataContainer.py
+++ b/Wrappers/Python/test/test_BlockDataContainer.py
@@ -455,141 +455,195 @@ class TestBlockDataContainer(BDCUnittest):
         self.assertBlockDataContainerEqual(out, nested)
 
 
+    def test_sapyb_a_b_scalar(self):
+        # test axpby between BlockDataContainers, with a as a blockdatacontainer
 
-
-    def test_sapyb(self):
-        # test axpby between BlockDataContainers
         ig0 = ImageGeometry(2,3,4)
         ig1 = ImageGeometry(2,3,5)
 
         data0 = ig0.allocate(-1)
-        data2 = ig1.allocate(1)
+        data2 = ig0.allocate(1)
 
         data1 = ig0.allocate(2)
-        data3 = ig1.allocate(3)
+        data3 = ig0.allocate(3)
+
+
 
         cp0 = BlockDataContainer(data0,data2)
         cp1 = BlockDataContainer(data1,data3)
+    
 
         out = cp0 * 0. - 10
 
-        cp0.sapyb(3,cp1, -2,out, num_threads=4)
+        # cp0.axpby(a,-2,cp1,out, num_threads=4)
+        cp0.sapyb(3, cp1,-2,out, num_threads=1)
 
         # operation should be [  3 * -1 + (-2) * 2 , 3 * 1 + (-2) * 3 ]
-        # output should be [ -7 , -3 ]
+        # output should be [ -7 , -4 ]
         res0 = ig0.allocate(-7)
-        res2 = ig1.allocate(-3)
+        res2 = ig0.allocate(-3)
         res = BlockDataContainer(res0, res2)
 
         self.assertBlockDataContainerEqual(out, res)
         
-    def test_sapyb_out_none(self):
-        # test axpby between BlockDataContainers
+        #With out is None
+        out = cp0.sapyb(3,cp1,-2, num_threads=4)
+        
+        self.assertBlockDataContainerEqual(out, res)
+
+    def test_sapyb_a_blockdc(self):
+        # test axpby between BlockDataContainers, with a as a blockdatacontainer
+
         ig0 = ImageGeometry(2,3,4)
         ig1 = ImageGeometry(2,3,5)
 
         data0 = ig0.allocate(-1)
-        data2 = ig1.allocate(1)
+        data2 = ig0.allocate(1)
 
         data1 = ig0.allocate(2)
-        data3 = ig1.allocate(3)
+        data3 = ig0.allocate(3)
+
+        a1 = ig0.allocate(3)
+        a2 = ig0.allocate(2)
 
         cp0 = BlockDataContainer(data0,data2)
         cp1 = BlockDataContainer(data1,data3)
+        a = BlockDataContainer(a1,a2)
 
+        out = cp0 * 0. - 10
 
-        out = cp0.sapyb(3,cp1, -2, num_threads=4)
+        # cp0.axpby(a,-2,cp1,out, num_threads=4)
+        cp0.sapyb(a, cp1,-2,out, num_threads=1)
 
-        # operation should be [  3 * -1 + (-2) * 2 , 3 * 1 + (-2) * 3 ]
-        # output should be [ -7 , -3 ]
+        # operation should be [  3 * -1 + (-2) * 2 , 2 * 1 + (-2) * 3 ]
+        # output should be [ -7 , -4 ]
         res0 = ig0.allocate(-7)
-        res2 = ig1.allocate(-3)
+        res2 = ig0.allocate(-4)
         res = BlockDataContainer(res0, res2)
 
         self.assertBlockDataContainerEqual(out, res)
+        
+        #With out is None
+        out = cp0.sapyb(a,cp1,-2, num_threads=4)
+        
+        self.assertBlockDataContainerEqual(out, res)
 
-    def test_sapyb2(self):
-        # test axpby with BlockDataContainer and DataContainer
+
+    def test_sapyb_b_blockdc(self):
+        # test axpby between BlockDataContainers, with b as a blockdatacontainer
+
         ig0 = ImageGeometry(2,3,4)
-        # ig1 = ImageGeometry(2,3,5)
+        ig1 = ImageGeometry(2,3,5)
 
         data0 = ig0.allocate(-1)
         data2 = ig0.allocate(1)
 
         data1 = ig0.allocate(2)
-        # data3 = ig1.allocate(3)
+        data3 = ig0.allocate(3)
+
+        b1 = ig0.allocate(-2)
+        b2 = ig0.allocate(-3)
 
         cp0 = BlockDataContainer(data0,data2)
-        # cp1 = BlockDataContainer(data1,data3)
+        cp1 = BlockDataContainer(data1,data3)
+        b = BlockDataContainer(b1,b2)
 
         out = cp0 * 0. - 10
 
-        cp0.sapyb(3,data1,-2,out)
+        cp0.sapyb(3,cp1, b,out, num_threads=4)
 
-        # operation should be [  3 * -1 + (-2) * 2 , 3 * 1 + (-2) * 2 ]
-        # output should be [ -7 , -1 ]
+        # operation should be [  3 * -1 + (-2) * 2 , 3 * 1 + (-3) * 3 ]
+        # output should be [ -7 , -3 ]
         res0 = ig0.allocate(-7)
-        res2 = ig0.allocate(-1)
+        res2 = ig0.allocate(-6)
         res = BlockDataContainer(res0, res2)
 
         self.assertBlockDataContainerEqual(out, res)
+        
+        #With out is None
+        out = cp0.sapyb(3,cp1, b, num_threads=4)
+        
+        self.assertBlockDataContainerEqual(out, res)
 
+    def test_sapyb_ab_blockdc(self):
+        # test axpby between BlockDataContainers, with a and b as a blockdatacontainer
 
-    def test_sapyb3(self):
-        # test axpby with nested BlockDataContainer
         ig0 = ImageGeometry(2,3,4)
         ig1 = ImageGeometry(2,3,5)
 
         data0 = ig0.allocate(-1)
         data2 = ig0.allocate(1)
 
-        # data1 = ig0.allocate(2)
-        data3 = ig1.allocate(3)
+        data1 = ig0.allocate(2)
+        data3 = ig0.allocate(3)
+
+        a1 = ig0.allocate(3)
+        a2 = ig0.allocate(2)
+
+        b1 = ig0.allocate(-2)
+        b2 = ig0.allocate(-3)
 
         cp0 = BlockDataContainer(data0,data2)
-        cp1 = BlockDataContainer(cp0 *0. +  [2, -2], data3)
+        cp1 = BlockDataContainer(data1,data3)
+        a = BlockDataContainer(a1,a2)
+        b = BlockDataContainer(b1,b2)
 
-        out = cp1 * 0.
-        cp2 = out + [1,3]
+        out = cp0 * 0. - 10
 
-        cp2.sapyb(3,cp1, -2 ,out)
+        cp0.sapyb(a,cp1,b,out, num_threads=4)
 
-        # output should be [ [ -1 , 7 ] , 3]
-        res0 = ig0.allocate(-1)
-        res2 = ig0.allocate(7)
-        res3 = ig1.allocate(3)
-        res = BlockDataContainer(BlockDataContainer(res0, res2), res3)
+        # operation should be [  3 * -1 + (-2) * 2 , 2 * 1 + (-3) * 3 ]
+        # output should be [ -7 , -7 ]
+        res0 = ig0.allocate(-7)
+        res2 = ig0.allocate(-7)
+        res = BlockDataContainer(res0, res2)
 
         self.assertBlockDataContainerEqual(out, res)
+        
+        #With out is None
+        out = cp0.sapyb(a,cp1,b, num_threads=4)
+        
+        self.assertBlockDataContainerEqual(out, res)
 
-    def test_sapyb4(self):
-        # test axpby with nested BlockDataContainer
+
+    def test_sapyb_ab_blockdc_y_dc(self):
+        # test axpby between BlockDataContainers, with a and b as a blockdatacontainer, and y as a dc
+
         ig0 = ImageGeometry(2,3,4)
-        ig1 = ImageGeometry(2,3,5)
 
         data0 = ig0.allocate(-1)
         data2 = ig0.allocate(1)
 
-        # data1 = ig0.allocate(2)
-        data3 = ig1.allocate(3)
+        data1 = ig0.allocate(2)
+
+        a1 = ig0.allocate(3)
+        a2 = ig0.allocate(2)
+
+        b1 = ig0.allocate(-2)
+        b2 = ig0.allocate(-3)
 
         cp0 = BlockDataContainer(data0,data2)
-        cp1 = BlockDataContainer(cp0 *0. +  [2, -2], data3)
 
-        out = cp1 * 0.
-        cp2 = out + [1,3]
+        a = BlockDataContainer(a1,a2)
+        b = BlockDataContainer(b1,b2)
 
-        cp2.sapyb(3, cp1, -2, out, num_threads=4)
+        out = cp0 * 0. - 10
 
-        # output should be [ [ -1 , 7 ] , 3]
-        res0 = ig0.allocate(-1)
-        res2 = ig0.allocate(7)
-        res3 = ig1.allocate(3)
-        res = BlockDataContainer(BlockDataContainer(res0, res2), res3)
+        cp0.sapyb(a,data1,b,out, num_threads=4)
+
+        # operation should be [  3 * -1 + (-2) * 2 , 2 * 1 + (-3) * 2 ]
+        # output should be [ -7 , -4 ]
+        res0 = ig0.allocate(-7)
+        res2 = ig0.allocate(-4)
+        res = BlockDataContainer(res0, res2)
 
         self.assertBlockDataContainerEqual(out, res)
-
-
+        
+        #With out is None
+        out = cp0.sapyb(a,data1,b, num_threads=4)
+        
+        self.assertBlockDataContainerEqual(out, res)
+        
 class TestOutParameter(BDCUnittest):
     def setUp(self):
         ig0 = ImageGeometry(2,3,4)
@@ -742,138 +796,6 @@ class TestOutParameter(BDCUnittest):
         res = BlockDataContainer(self.ig0.allocate(1), self.ig1.allocate(1))
         self.assertBlockDataContainerAlmostEqual(res, cp1)
 
-    def test_sapyb_a_blockdc(self):
-        # test axpby between BlockDataContainers, with a as a blockdatacontainer
-
-        ig0 = ImageGeometry(2,3,4)
-        ig1 = ImageGeometry(2,3,5)
-
-        data0 = ig0.allocate(-1)
-        data2 = ig0.allocate(1)
-
-        data1 = ig0.allocate(2)
-        data3 = ig0.allocate(3)
-
-        a1 = ig0.allocate(3)
-        a2 = ig0.allocate(2)
-
-        cp0 = BlockDataContainer(data0,data2)
-        cp1 = BlockDataContainer(data1,data3)
-        a = BlockDataContainer(a1,a2)
-
-        out = cp0 * 0. - 10
-
-        # cp0.axpby(a,-2,cp1,out, num_threads=4)
-        cp0.sapyb(a, cp1,-2,out, num_threads=1)
-
-        # operation should be [  3 * -1 + (-2) * 2 , 2 * 1 + (-2) * 3 ]
-        # output should be [ -7 , -4 ]
-        res0 = ig0.allocate(-7)
-        res2 = ig0.allocate(-4)
-        res = BlockDataContainer(res0, res2)
-
-        self.assertBlockDataContainerEqual(out, res)
-
-
-    def test_sapyb_b_blockdc(self):
-        # test axpby between BlockDataContainers, with b as a blockdatacontainer
-
-        ig0 = ImageGeometry(2,3,4)
-        ig1 = ImageGeometry(2,3,5)
-
-        data0 = ig0.allocate(-1)
-        data2 = ig0.allocate(1)
-
-        data1 = ig0.allocate(2)
-        data3 = ig0.allocate(3)
-
-        b1 = ig0.allocate(-2)
-        b2 = ig0.allocate(-3)
-
-        cp0 = BlockDataContainer(data0,data2)
-        cp1 = BlockDataContainer(data1,data3)
-        b = BlockDataContainer(b1,b2)
-
-        out = cp0 * 0. - 10
-
-        cp0.sapyb(3,cp1, b,out, num_threads=4)
-
-        # operation should be [  3 * -1 + (-2) * 2 , 3 * 1 + (-3) * 3 ]
-        # output should be [ -7 , -3 ]
-        res0 = ig0.allocate(-7)
-        res2 = ig0.allocate(-6)
-        res = BlockDataContainer(res0, res2)
-
-        self.assertBlockDataContainerEqual(out, res)
-
-    def test_sapyb_ab_blockdc(self):
-        # test axpby between BlockDataContainers, with a and b as a blockdatacontainer
-
-        ig0 = ImageGeometry(2,3,4)
-        ig1 = ImageGeometry(2,3,5)
-
-        data0 = ig0.allocate(-1)
-        data2 = ig0.allocate(1)
-
-        data1 = ig0.allocate(2)
-        data3 = ig0.allocate(3)
-
-        a1 = ig0.allocate(3)
-        a2 = ig0.allocate(2)
-
-        b1 = ig0.allocate(-2)
-        b2 = ig0.allocate(-3)
-
-        cp0 = BlockDataContainer(data0,data2)
-        cp1 = BlockDataContainer(data1,data3)
-        a = BlockDataContainer(a1,a2)
-        b = BlockDataContainer(b1,b2)
-
-        out = cp0 * 0. - 10
-
-        cp0.sapyb(a,cp1,b,out, num_threads=4)
-
-        # operation should be [  3 * -1 + (-2) * 2 , 2 * 1 + (-3) * 3 ]
-        # output should be [ -7 , -7 ]
-        res0 = ig0.allocate(-7)
-        res2 = ig0.allocate(-7)
-        res = BlockDataContainer(res0, res2)
-
-        self.assertBlockDataContainerEqual(out, res)
-
-
-    def test_sapyb_ab_blockdc_y_dc(self):
-        # test axpby between BlockDataContainers, with a and b as a blockdatacontainer, and y as a dc
-
-        ig0 = ImageGeometry(2,3,4)
-
-        data0 = ig0.allocate(-1)
-        data2 = ig0.allocate(1)
-
-        data1 = ig0.allocate(2)
-
-        a1 = ig0.allocate(3)
-        a2 = ig0.allocate(2)
-
-        b1 = ig0.allocate(-2)
-        b2 = ig0.allocate(-3)
-
-        cp0 = BlockDataContainer(data0,data2)
-
-        a = BlockDataContainer(a1,a2)
-        b = BlockDataContainer(b1,b2)
-
-        out = cp0 * 0. - 10
-
-        cp0.sapyb(a,data1,b,out, num_threads=4)
-
-        # operation should be [  3 * -1 + (-2) * 2 , 2 * 1 + (-3) * 2 ]
-        # output should be [ -7 , -4 ]
-        res0 = ig0.allocate(-7)
-        res2 = ig0.allocate(-4)
-        res = BlockDataContainer(res0, res2)
-
-        self.assertBlockDataContainerEqual(out, res)
 
     def test_iterator(self):
         ig0 = VectorGeometry(5)

--- a/Wrappers/Python/test/test_BlockDataContainer.py
+++ b/Wrappers/Python/test/test_BlockDataContainer.py
@@ -463,10 +463,10 @@ class TestBlockDataContainer(BDCUnittest):
         ig1 = ImageGeometry(2,3,5)
 
         data0 = ig0.allocate(-1)
-        data2 = ig0.allocate(1)
+        data2 = ig1.allocate(1)
 
         data1 = ig0.allocate(2)
-        data3 = ig0.allocate(3)
+        data3 = ig1.allocate(3)
 
         cp0 = BlockDataContainer(data0,data2)
         cp1 = BlockDataContainer(data1,data3)
@@ -478,7 +478,32 @@ class TestBlockDataContainer(BDCUnittest):
         # operation should be [  3 * -1 + (-2) * 2 , 3 * 1 + (-2) * 3 ]
         # output should be [ -7 , -3 ]
         res0 = ig0.allocate(-7)
-        res2 = ig0.allocate(-3)
+        res2 = ig1.allocate(-3)
+        res = BlockDataContainer(res0, res2)
+
+        self.assertBlockDataContainerEqual(out, res)
+        
+    def test_sapyb_out_none(self):
+        # test axpby between BlockDataContainers
+        ig0 = ImageGeometry(2,3,4)
+        ig1 = ImageGeometry(2,3,5)
+
+        data0 = ig0.allocate(-1)
+        data2 = ig1.allocate(1)
+
+        data1 = ig0.allocate(2)
+        data3 = ig1.allocate(3)
+
+        cp0 = BlockDataContainer(data0,data2)
+        cp1 = BlockDataContainer(data1,data3)
+
+
+        out = cp0.sapyb(3,cp1, -2, num_threads=4)
+
+        # operation should be [  3 * -1 + (-2) * 2 , 3 * 1 + (-2) * 3 ]
+        # output should be [ -7 , -3 ]
+        res0 = ig0.allocate(-7)
+        res2 = ig1.allocate(-3)
         res = BlockDataContainer(res0, res2)
 
         self.assertBlockDataContainerEqual(out, res)


### PR DESCRIPTION
## Changes
Allow SAPYB for the block container to take `out=None` by creating an out, if needed, the same shape as the container `y`. 
SAPYB for the block container now also always returns

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links
Closes #1997 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

