### PR TITLE
Use matplotlib-base instead of matplotlib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,8 @@ jobs:
     - name: conda build & test
       working-directory: recipe
       run: |
-        conda build . -c conda-forge -c https://tomography.stfc.ac.uk/conda --override-channels --python=${{ matrix.python-version }} --numpy=${{ matrix.numpy-version }} --output-folder .
+        conda install boa
+        conda mambabuild . -c conda-forge -c https://tomography.stfc.ac.uk/conda --override-channels --python=${{ matrix.python-version }} --numpy=${{ matrix.numpy-version }} --output-folder .
     - uses: actions/upload-artifact@v4
       with:
         name: cil-package-py${{ matrix.python-version }}-np${{ matrix.numpy-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,8 +127,7 @@ jobs:
     - name: conda build & test
       working-directory: recipe
       run: |
-        conda install boa
-        conda mambabuild . -c conda-forge -c https://tomography.stfc.ac.uk/conda --override-channels --python=${{ matrix.python-version }} --numpy=${{ matrix.numpy-version }} --output-folder .
+        conda build . -c conda-forge -c https://tomography.stfc.ac.uk/conda --override-channels --python=${{ matrix.python-version }} --numpy=${{ matrix.numpy-version }} --output-folder .
     - uses: actions/upload-artifact@v4
       with:
         name: cil-package-py${{ matrix.python-version }}-np${{ matrix.numpy-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - Add FluxNormaliser processor (#1878)
   - Dependencies:
     - Added scikit-image to CIL-Demos conda install command as needed for new Callbacks notebook.
+    - Replaced matplotlib dependency with matplotlib-base (#2031)
   - Changes that break backwards compatibility:
     - show1D argument renamed `label`->`dataset_labels`, default plot size has changed. (#2022)
     - show1D Default behaviour for displaying and labeling multiple plots has changed. Each slice requested will be displayed on a new subplot comparing all datasets at that position. (#2022)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - python
     - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x.x') }}
     - scipy >=1.4.0
-    - matplotlib >=3.3.0
+    - matplotlib-base >=3.3.0
     - h5py
     - pillow
     - libgcc-ng     # [linux]

--- a/scripts/create_local_env_for_cil_development.sh
+++ b/scripts/create_local_env_for_cil_development.sh
@@ -54,7 +54,7 @@ conda_args=(create --name="$name"
   ipp-include'>=2021.10'
   libgcc-ng
   libstdcxx-ng
-  matplotlib
+  matplotlib-base
   numba
   olefile'>=0.46'
   packaging

--- a/scripts/requirements-test.yml
+++ b/scripts/requirements-test.yml
@@ -37,7 +37,7 @@ dependencies:
   - ipp=2021.12
   - ipywidgets
   - scipy
-  - matplotlib
+  - matplotlib-base
   - h5py
   - pillow
   - libgcc-ng     # [linux]


### PR DESCRIPTION
## Description
* Closes #1936 

<!--overview of changes, reason/motivation, issue link(s), etc.-->

## Example Usage
<!--minimal working example-->
This will mean that installing cil without tigre will pull matplotlib-base instead of matplotlib

However, if you install tigre it will also pull matplotlib

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

Tested locally on linux making an environment using 

 scripts/create_local_env_for_cil_development.sh
 
 but with python=3.12 and numpy=1.26
 
Used the cmake commands in the README to build CIL
 
 And checked the unit tests passed

Tested manually:

- [x] show_geometry
- [x] show_2D
- [x] show_1D

## Related issues/links


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
