### PR TITLE
Bug fix to PD3O with stochastic gradient optimisers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - Removed the deprecated usage of run method in test_SIRF.py (#2070)
       - Ensured CIL forward and back projectors always return, even when `out` is passed (#2059)
       - Made ProjectionOperator `device` input case-insensitive (#1990)
+      - Ensured the same approximate gradient is used within each iteration for PD3O with a stochastic function `f` (#2043)
   - Documentation
       - Updated documentation for the ChannelWiseOperator including new example (#2096)
       - Updated documentation for LADMM (#2015)

--- a/Wrappers/Python/cil/optimisation/algorithms/PD3O.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/PD3O.py
@@ -112,7 +112,11 @@ class PD3O(Algorithm):
 
         Note
         -----
-        Note that currently :math:`f` in PD3O can be any type of deterministic function, an `ApproximateGradientSumFunction` or a scaled `ApproximateGradientSumFunction` but we have not implemented or tested when it is a `SumFunction` or `TranslatedFunction` which contains `ApproximateGradientSumFunction`s. 
+        Note that currently :math:`f` in PD3O can be any type of deterministic function, an `ApproximateGradientSumFunction` or a scaled `ApproximateGradientSumFunction`.
+        
+        Note
+        -----
+        We have not implemented or tested when  :math:`f` is a stochastic function (`ApproximateGradientSumFunction`) wrapped as a `SumFunction` or `TranslatedFunction`.  
 
         Reference
         ---------
@@ -131,8 +135,6 @@ class PD3O(Algorithm):
     def set_up(self, f, g, h, operator, delta=None, gamma=None, initial=None,**kwargs):
         
         logging.info("{} setting up".format(self.__class__.__name__, ))
-        
-        
         
         if isinstance(f, ZeroFunction):
             warnings.warn(" If f is the ZeroFunction, then PD3O = PDHG. Please use PDHG instead. Otherwise, select a relatively small parameter gamma ", UserWarning)
@@ -195,11 +197,7 @@ class PD3O(Algorithm):
         self.g.proximal(self.x_old, self.gamma, out = self.x)
     
         # update step        
-        
-        
-        self.f.gradient(self.x, out=self.x_old)    
-            
-                    
+        self.f.gradient(self.x, out=self.x_old)                    
         self.x_old *= self.gamma
         self.grad_f += self.x_old
         self.x.sapyb(2, self.grad_f, -1.0,  out=self.x_old) # 2*x - x_old + gamma*(grad_f_x_old) - gamma*(grad_f_x)

--- a/Wrappers/Python/cil/optimisation/algorithms/PD3O.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/PD3O.py
@@ -18,7 +18,7 @@
 
 
 from cil.optimisation.algorithms import Algorithm
-from cil.optimisation.functions import ZeroFunction
+from cil.optimisation.functions import ZeroFunction, SGFunction, SVRGFunction, LSVRGFunction, SAGAFunction, SAGFunction
 import logging
 import warnings
 class PD3O(Algorithm):
@@ -125,7 +125,12 @@ class PD3O(Algorithm):
         self.g.proximal(self.x_old, self.gamma, out = self.x)
     
         # update step        
-        self.f.gradient(self.x, out=self.x_old)                    
+        if isinstance(self.f, (SAGFunction, SAGAFunction, SGFunction)):
+            self.f.approximate_gradient( self.x, self.f.function_num, out=self.x_old)
+        elif isinstance(self.f, (SVRGFunction, LSVRGFunction)):
+            raise NotImplementedError("The CIL PD3O algorithm is not currently compatible with SVRG and LSVRG approximate gradient functions.")
+        else:
+            self.f.gradient(self.x, out=self.x_old)            
         self.x_old *= self.gamma
         self.grad_f += self.x_old
         self.x.sapyb(2, self.grad_f, -1.0,  out=self.x_old) # 2*x - x_old + gamma*(grad_f_x_old) - gamma*(grad_f_x)

--- a/Wrappers/Python/cil/optimisation/functions/SVRGFunction.py
+++ b/Wrappers/Python/cil/optimisation/functions/SVRGFunction.py
@@ -225,7 +225,7 @@ class LSVRGFunction(SVRGFunction):
 
     Parameters
     ----------
-     functions : `list`  of functions
+    functions : `list`  of functions
         A list of functions: :code:`[f_{0}, f_{1}, ..., f_{n-1}]`. Each function is assumed to be smooth with an implemented :func:`~Function.gradient` method. All functions must have the same domain. The number of functions `n` must be strictly greater than 1. 
     sampler: An instance of a CIL Sampler class ( :meth:`~optimisation.utilities.sampler`) or of another class which has a `next` function implemented to output integers in {0,...,n-1}.
         This sampler is called each time gradient is called and  sets the internal `function_num` passed to the `approximate_gradient` function.  Default is `Sampler.random_with_replacement(len(functions))`. 
@@ -233,7 +233,8 @@ class LSVRGFunction(SVRGFunction):
         The probability of updating the full gradient (taking a snapshot) at each iteration. The default is :math:`1./n` so, in expectation, a snapshot will be taken every :math:`n` iterations. 
     store_gradients : bool, default: `False`
         Flag indicating whether to store an update a list of gradients for each function :math:`f_i` or just to store the snapshot point :math:` \tilde{x}` and it's gradient :math:`\nabla \sum_{i=0}^{n-1}f_i(\tilde{x})`.
-
+    seed: int
+        Seed for the random number generator (numpy.random).
 
     Note
     ----

--- a/Wrappers/Python/cil/optimisation/functions/SVRGFunction.py
+++ b/Wrappers/Python/cil/optimisation/functions/SVRGFunction.py
@@ -60,7 +60,7 @@ class SVRGFunction(ApproximateGradientSumFunction):
     snapshot_update_interval : positive int or None, optional
         The interval for updating the full gradient (taking a snapshot). The default is 2*len(functions) so a "snapshot" is taken every 2*len(functions) iterations. If the user passes `0` then no full gradient snapshots will be taken. 
     store_gradients : bool, default: `False`
-        Flag indicating whether to store an update a list of gradients for each function :math:`f_i` or just to store the snapshot point :math:`\tilde{x}` and its gradient :math:`\nabla \sum_{i=0}^{n-1}f_i(\tilde{x})`.
+        Flag indicating whether to store and update a list of gradients for each function :math:`f_i` or just to store the snapshot point :math:`\tilde{x}` and its gradient :math:`\nabla \sum_{i=0}^{n-1}f_i(\tilde{x})`.
 
 
     """
@@ -156,11 +156,11 @@ class SVRGFunction(ApproximateGradientSumFunction):
 
     def _update_full_gradient_and_return(self, x, out=None):
         """
-        Takes a "snapshot" at the point :math:`x`, saving both the point :math:` \tilde{x}=x` and its gradient :math:`\sum_{i=0}^{n-1}f_i{\tilde{x}}`. The function returns :math:`\sum_{i=0}^{n-1}f_i{\tilde{x}}` as the gradient calculation. If :code:`store_gradients==True`, the gradient of all the :math:`f_i`s is computed and stored at the "snapshot"..
+        Takes a "snapshot" at the point :math:`x`, saving both the point :math:`\tilde{x}=x` and its gradient :math:`\sum_{i=0}^{n-1}f_i{\tilde{x}}`. The function returns :math:`\sum_{i=0}^{n-1}f_i{\tilde{x}}` as the gradient calculation. If :code:`store_gradients==True`, the gradient of all the :math:`f_i`s is computed and stored at the "snapshot"..
 
         Parameters
         ----------
-        Takes a "snapshot" at the point :math:`x`. The function returns :math:`\sum_{i=0}^{n-1}f_i{\tilde{x}}` as the gradient calculation. If :code:`store_gradients==True`, the gradient of all the :math:`f_i`s is stored, otherwise only  the sum of the gradients and the snapshot point :math:` \tilde{x}=x` are stored.
+        Takes a "snapshot" at the point :math:`x`. The function returns :math:`\sum_{i=0}^{n-1}f_i{\tilde{x}}` as the gradient calculation. If :code:`store_gradients==True`, the gradient of all the :math:`f_i`s is stored, otherwise only  the sum of the gradients and the snapshot point :math:`\tilde{x}=x` are stored.
         out: return DataContainer, if `None` a new DataContainer is returned, default `None`.
 
         Returns
@@ -224,9 +224,9 @@ class LSVRGFunction(SVRGFunction):
     snapshot_update_probability: positive float, default: 1/n
         The probability of updating the full gradient (taking a snapshot) at each iteration. The default is :math:`1./n` so, in expectation, a snapshot will be taken every :math:`n` iterations. 
     store_gradients : bool, default: `False`
-        Flag indicating whether to store an update a list of gradients for each function :math:`f_i` or just to store the snapshot point :math:` \tilde{x}` and it's gradient :math:`\nabla \sum_{i=0}^{n-1}f_i(\tilde{x})`.
+        Flag indicating whether to store and update a list of gradients for each function :math:`f_i` or just to store the snapshot point :math:`\tilde{x}` and it's gradient :math:`\nabla \sum_{i=0}^{n-1}f_i(\tilde{x})`.
     seed: int
-        Seed for the random number generator (numpy.random).
+        Seed for calculating the random update snapshot intervals (generated using numpy.random).
 
         
     Reference

--- a/Wrappers/Python/test/test_algorithm_convergence.py
+++ b/Wrappers/Python/test/test_algorithm_convergence.py
@@ -2,7 +2,6 @@ from cil.optimisation.algorithms import SPDHG, PDHG, GD, PD3O
 from cil.optimisation.functions import L2NormSquared, IndicatorBox, BlockFunction, ZeroFunction, LeastSquares, TotalVariation, MixedL21Norm
 from cil.optimisation.operators import BlockOperator, IdentityOperator, MatrixOperator, GradientOperator
 from cil.optimisation.utilities import Sampler, BarzilaiBorweinStepSizeRule
-
 from cil.framework import AcquisitionGeometry, BlockDataContainer, BlockGeometry, VectorData
 
 from cil.utilities import dataexample

--- a/Wrappers/Python/test/test_algorithm_convergence.py
+++ b/Wrappers/Python/test/test_algorithm_convergence.py
@@ -1,6 +1,6 @@
-from cil.optimisation.algorithms import SPDHG, PDHG
-from cil.optimisation.functions import L2NormSquared, IndicatorBox, BlockFunction, ZeroFunction
-from cil.optimisation.operators import BlockOperator, IdentityOperator, MatrixOperator
+from cil.optimisation.algorithms import SPDHG, PDHG, PD3O
+from cil.optimisation.functions import L2NormSquared, IndicatorBox, BlockFunction, ZeroFunction, TotalVariation, MixedL21Norm
+from cil.optimisation.operators import BlockOperator, IdentityOperator, MatrixOperator, GradientOperator
 from cil.optimisation.utilities import Sampler 
 from cil.framework import AcquisitionGeometry, BlockDataContainer, BlockGeometry, VectorData
 
@@ -106,7 +106,7 @@ class TestAlgorithmConvergence(CCPiTestClass):
             alg_stochastic.x.as_array(), b.as_array(), decimal=6)
         
     def test_pd3o_convergence(self):
-
+        data = dataexample.CAMERA.get(size=(32, 32))
         # pd30 convergence test using TV denoising
 
         # regularisation parameter
@@ -114,16 +114,16 @@ class TestAlgorithmConvergence(CCPiTestClass):
 
         # use TotalVariation from CIL (with Fast Gradient Projection algorithm)
         TV = TotalVariation(max_iteration=200)
-        tv_cil = TV.proximal(self.data, tau=alpha)
+        tv_cil = TV.proximal(data, tau=alpha)
 
         F = alpha * MixedL21Norm()
-        operator = GradientOperator(self.data.geometry)
+        operator = GradientOperator(data.geometry)
         norm_op = operator.norm()
 
         # setup PD3O denoising  (H proximalble and G,F = 1/4 * L2NormSquared)
         H = alpha * MixedL21Norm()
-        G = 0.25 * L2NormSquared(b=self.data)
-        F = 0.25 * L2NormSquared(b=self.data)
+        G = 0.25 * L2NormSquared(b=data)
+        F = 0.25 * L2NormSquared(b=data)
         gamma = 2./F.L
         delta = 1./(gamma*norm_op**2)
 

--- a/Wrappers/Python/test/test_algorithm_convergence.py
+++ b/Wrappers/Python/test/test_algorithm_convergence.py
@@ -115,7 +115,7 @@ class TestAlgorithmConvergence(CCPiTestClass):
         alpha = 0.11
 
         # use TotalVariation from CIL (with Fast Gradient Projection algorithm)
-        TV = TotalVariation(max_iteration=200)
+        TV = TotalVariation(max_iteration=40)
         tv_cil = TV.proximal(data, tau=alpha)
 
         F = alpha * MixedL21Norm()
@@ -131,7 +131,7 @@ class TestAlgorithmConvergence(CCPiTestClass):
 
         pd3O_with_f = PD3O(f=F, g=G, h=H, operator=operator, gamma=gamma, delta=delta,
                            update_objective_interval=100)
-        pd3O_with_f.run(1000)
+        pd3O_with_f.run(800)
 
         # pd30 vs fista
         np.testing.assert_allclose(

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -1764,18 +1764,32 @@ class Test_PD3O(unittest.TestCase):
             A=MatrixOperator(np.diag(diagonal))
             functions.append( LeastSquares(A, A.direct(b)))
         
-        f=SVRGFunction(functions, sampler)
         H1 = 0.1 * L1Norm()
         operator = IdentityOperator(initial.geometry)
         G1 = IndicatorBox(lower=0)
-        with self.assertRaises(NotImplementedError):
-            algo_pd3o = PD3O(f=f, g=G1, h=H1, operator=operator)
-            algo_pd3o.run(1)
+
+
+        f=SVRGFunction(functions, sampler, snapshot_update_interval=3)
+        algo_pd3o = PD3O(f=f, g=G1, h=H1, operator=operator)
+        algo_pd3o.run(1)
+        self.assertEqual(f.data_passes[-1], 1)
+        self.assertEqual(f.data_passes_indices, [[0,1,2]])
+        algo_pd3o.run(1)
+        self.assertEqual(f.data_passes[-1], 4/3)
+        self.assertEqual(f.data_passes_indices, [[0,1,2], [0]])
+        algo_pd3o.run(1)
+        self.assertAlmostEqual(f.data_passes[-1], 5/3)
+        self.assertEqual(f.data_passes_indices, [[0,1,2], [0], [1]])
+        algo_pd3o.run(1)
+        self.assertAlmostEqual(f.data_passes[-1], 8/3)
+        self.assertEqual(f.data_passes_indices, [[0,1,2], [0], [1], [0,1,2]])
         
+        sampler=Sampler.sequential(3)
         f=LSVRGFunction(functions, sampler)
-        with self.assertRaises(NotImplementedError):
-            algo_pd3o = PD3O(f=f, g=G1, h=H1, operator=operator)
-            algo_pd3o.run(1)
+        algo_pd3o = PD3O(f=f, g=G1, h=H1, operator=operator)
+        algo_pd3o.run(1)
+        self.assertEqual(f.data_passes[-1], 1)
+        self.assertEqual(f.data_passes_indices, [[0,1,2]])
             
         sampler=Sampler.sequential(3)
         f=SGFunction(functions, sampler)

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -35,7 +35,7 @@ from cil.optimisation.operators import IdentityOperator
 from cil.optimisation.operators import GradientOperator, BlockOperator, MatrixOperator
 
 
-from cil.optimisation.functions import MixedL21Norm, BlockFunction, L1Norm, KullbackLeibler, IndicatorBox, LeastSquares, ZeroFunction, L2NormSquared, OperatorCompositionFunction, TotalVariation, SGFunction, SVRGFunction, SAGAFunction, SAGFunction, LSVRGFunction
+from cil.optimisation.functions import MixedL21Norm, BlockFunction, L1Norm, KullbackLeibler, IndicatorBox, LeastSquares, ZeroFunction, L2NormSquared, OperatorCompositionFunction, TotalVariation, SGFunction, SVRGFunction, SAGAFunction, SAGFunction, LSVRGFunction, ScaledFunction
 from cil.optimisation.algorithms import Algorithm, GD, CGLS, SIRT, FISTA, ISTA, SPDHG, PDHG, LADMM, PD3O, PGD, APGD
 
 
@@ -1695,7 +1695,7 @@ class Test_PD3O(CCPiTestClass):
         G1 = IndicatorBox(lower=0)
 
         algo_pd3o = PD3O(f=F1, g=G1, h=H1, operator=operator)
-        self.assertEqual(algo_pd3o.gamma, 0.99*2.0/F1.L)
+        self.assertEqual(algo_pd3o.gamma, 0.99*2.0/F1.L) 
         self.assertEqual(algo_pd3o.delta, F1.L/(2.0*operator.norm()**2))
         np.testing.assert_array_equal(
             algo_pd3o.x.array, self.data.geometry.allocate(0).array)
@@ -1786,7 +1786,9 @@ class Test_PD3O(CCPiTestClass):
         
         sampler=Sampler.sequential(3)
         f=SVRGFunction(functions, sampler, snapshot_update_interval=5, store_gradients=True)
-        algo_pd3o = PD3O(f=f, g=G1, h=H1, operator=operator)
+        algo_pd3o = PD3O(f= 2*f, g=G1, h=H1, operator=operator)
+        self.assertTrue(isinstance(2*f,ScaledFunction) )
+        self.assertEqual(algo_pd3o.f.scalar, 2)
         algo_pd3o.run(1)
         self.assertEqual(f.data_passes[-1], 1)
         self.assertEqual(f.data_passes_indices, [[0,1,2]])

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -1681,7 +1681,7 @@ class TestADMM(unittest.TestCase):
             admm.solution.array, pdhg.solution.array,  decimal=3)
 
 
-class Test_PD3O(unittest.TestCase):
+class Test_PD3O(CCPiTestClass):
 
     def setUp(self):
 
@@ -1783,6 +1783,25 @@ class Test_PD3O(unittest.TestCase):
         algo_pd3o.run(1)
         self.assertAlmostEqual(f.data_passes[-1], 8/3)
         self.assertEqual(f.data_passes_indices, [[0,1,2], [0], [1], [0,1,2]])
+        
+        sampler=Sampler.sequential(3)
+        f=SVRGFunction(functions, sampler, snapshot_update_interval=5, store_gradients=True)
+        algo_pd3o = PD3O(f=f, g=G1, h=H1, operator=operator)
+        algo_pd3o.run(1)
+        self.assertEqual(f.data_passes[-1], 1)
+        self.assertEqual(f.data_passes_indices, [[0,1,2]])
+        self.assertNumpyArrayAlmostEqual(f._list_stored_gradients[2].array, f.functions[2].gradient(algo_pd3o.solution).array )
+        algo_pd3o.run(1)
+        self.assertEqual(f.data_passes[-1], 4/3)
+        self.assertEqual(f.data_passes_indices, [[0,1,2], [0]])
+        algo_pd3o.run(1)
+        self.assertAlmostEqual(f.data_passes[-1], 5/3)
+        self.assertEqual(f.data_passes_indices, [[0,1,2], [0], [1]])
+        algo_pd3o.run(1)
+        self.assertAlmostEqual(f.data_passes[-1], 6/3)
+        self.assertEqual(f.data_passes_indices, [[0,1,2], [0], [1], [2]])
+        
+        
         
         sampler=Sampler.sequential(3)
         f=LSVRGFunction(functions, sampler)

--- a/Wrappers/Python/test/test_algorithms.py
+++ b/Wrappers/Python/test/test_algorithms.py
@@ -1786,9 +1786,9 @@ class Test_PD3O(CCPiTestClass):
         
         sampler=Sampler.sequential(3)
         f=SVRGFunction(functions, sampler, snapshot_update_interval=5, store_gradients=True)
-        algo_pd3o = PD3O(f= 2*f, g=G1, h=H1, operator=operator)
-        self.assertTrue(isinstance(2*f,ScaledFunction) )
-        self.assertEqual(algo_pd3o.f.scalar, 2)
+        algo_pd3o = PD3O(f= 3*(2*f), g=G1, h=H1, operator=operator)
+        self.assertTrue(isinstance(3*2*f,ScaledFunction) )
+        self.assertEqual(algo_pd3o.f.scalar, 6)
         algo_pd3o.run(1)
         self.assertEqual(f.data_passes[-1], 1)
         self.assertEqual(f.data_passes_indices, [[0,1,2]])


### PR DESCRIPTION
## Changes
- The algorithm will use the same approximate gradient in each iteration for SG, SAG and SAGA functions, `f`, in PD3O. 
- For SVRG and LSVRG functions in the second gradient calculation in each iteration, the code checks the data passes indices to see if a full gradient or an approximate gradient was used for the first gradient calculation. It then repeats the previous gradient calculation for the second gradient approximation (saving to a snapshot if a full gradient is calculated). It then pops the end of the stored data passes indices. 
- For other functions, there is no change to the PD3O behaviour. 

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc
- New unit tests added, checking data passes and data passes indices after a couple of iterations 

## Related issues/links
Closes #2021 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


