### PR TITLE
Add python executable path to fix issues with cmake getting wrong python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - Fix bug passing `kwargs` to PDHG (#2010)
     - Show1D correctly applies slices to N-dimensional data (#2022)
     - BlockOperator direct and adjoint methods: can pass out as a DataContainer instead of a (1,1) BlockDataContainer where geometry permits (#1926)
+    - Add path to python executable to cmake commands to fix issue with cmake retrieving wrong python (#2044)
   - Enhancements:
     - Removed multiple exits from numba implementation of KullbackLeibler divergence (#1901)
     - Updated the `SPDHG` algorithm to take a stochastic `Sampler`(#1644)

--- a/README.md
+++ b/README.md
@@ -144,18 +144,27 @@ conda env create -f scripts/requirements-test.yml
 CMake and a C++ compiler are required to build the source code. Let's suppose that the user is in the source directory, then the following commands should work:
 
 ```sh
-cmake -S . -B ./build -DCMAKE_INSTALL_PREFIX=<install_directory>
+cmake -S . -B ./build -DCMAKE_INSTALL_PREFIX=<install_directory> -DPython_EXECUTABLE=<path_to_python_executable>
 cmake --build ./build --target install
 ```
 
-If targeting an active conda environment then the `<install_directory>` can be set to the `CONDA_PREFIX` environment variable (e.g. `${CONDA_PREFIX}` in Bash, or `%CONDA_PREFIX%` in the Anaconda Prompt on Windows).
+If targeting an active conda environment then the `<install_directory>` can be set to the `CONDA_PREFIX` environment variable (e.g. `${CONDA_PREFIX}` in Bash, or `%CONDA_PREFIX%` in the Anaconda Prompt on Windows). Similarly, `<path_to_python_executable>` can be set to the active conda environment by passing `${CONDA_PREFIX}/bin/python` on linux or `%CONDA_PREFIX%/python` in windows.
+
+#### Linux
+```sh
+cmake -S . -B ./build -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DPython_EXECUTABLE=${CONDA_PREFIX}/bin/python
+```
+#### Windows
+```sh
+cmake -S . -B ./build -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX% -DPython_EXECUTABLE=%CONDA_PREFIX%/python
+```
 
 If not installing to a conda environment then the user will also need to set the locations of the IPP library and includes, and the path to CIL.
 
 By default the location of the IPP library and includes is `${CMAKE_INSTALL_PREFIX}/lib` and `${CMAKE_INSTALL_PREFIX}/include` respectively. To pass the location of the IPP library and headers please pass the following parameters:
 
 ```sh
-cmake -S . -B ./build -DCMAKE_INSTALL_PREFIX=<install_directory> -DIPP_LIBRARY=<path_to_ipp_library> -DIPP_INCLUDE=<path_to_ipp_includes>
+cmake -S . -B ./build -DCMAKE_INSTALL_PREFIX=<install_directory> -DPython_EXECUTABLE=<path_to_python_executable> -DIPP_LIBRARY=<path_to_ipp_library> -DIPP_INCLUDE=<path_to_ipp_includes>
 ```
 
 The user will then need to add the path `<install_directory>/lib` to the environment variable `PATH` or `LD_LIBRARY_PATH`, depending on system OS.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ cmake -S . -B ./build -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DPython_EXECUTABLE
 ```
 #### Windows
 ```sh
-cmake -S . -B ./build -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX% -DPython_EXECUTABLE=%CONDA_PREFIX%/python
+cmake -S . -B .\build -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX% -DPython_EXECUTABLE=%CONDA_PREFIX%\python
 ```
 
 If not installing to a conda environment then the user will also need to set the locations of the IPP library and includes, and the path to CIL.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ cmake -S . -B ./build -DCMAKE_INSTALL_PREFIX=<install_directory> -DPython_EXECUT
 cmake --build ./build --target install
 ```
 
-If targeting an active conda environment then the `<install_directory>` can be set to the `CONDA_PREFIX` environment variable (e.g. `${CONDA_PREFIX}` in Bash, or `%CONDA_PREFIX%` in the Anaconda Prompt on Windows). Similarly, `<path_to_python_executable>` can be set to the active conda environment by passing `${CONDA_PREFIX}/bin/python` on linux or `%CONDA_PREFIX%/python` in windows.
+If targeting an active conda environment then the `<install_directory>` can be set to the `CONDA_PREFIX` environment variable (e.g. `${CONDA_PREFIX}` in Bash, or `%CONDA_PREFIX%` in the Anaconda Prompt on Windows). Similarly, `<path_to_python_executable>` can be set to the active conda environment by passing `${CONDA_PREFIX}/bin/python` on linux or `%CONDA_PREFIX%\python` in windows.
 
 #### Linux
 ```sh

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,7 +8,7 @@ if not "%GIT_DESCRIBE_NUMBER%"=="0" (
 :: -G "Visual Studio 16 2019" specifies the the generator
 :: -T v142 specifies the toolset
 
-cmake -S "%RECIPE_DIR%\.." -B "%SRC_DIR%\build_framework" -G "Visual Studio 16 2019" -T "v142" -DCONDA_BUILD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBRARY_LIB=%CONDA_PREFIX%\lib -DLIBRARY_INC=%CONDA_PREFIX% -DCMAKE_INSTALL_PREFIX=%PREFIX%
+cmake -S "%RECIPE_DIR%\.." -B "%SRC_DIR%\build_framework" -G "Visual Studio 16 2019" -T "v142" -DCONDA_BUILD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBRARY_LIB=%CONDA_PREFIX%\lib -DLIBRARY_INC=%CONDA_PREFIX% -DCMAKE_INSTALL_PREFIX=%PREFIX% -DPython_EXECUTABLE=%CONDA_PREFIX%/python
 if errorlevel 1 exit 1
 
 cmake --build "%SRC_DIR%\build_framework" --target install --config RelWithDebInfo

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,7 +8,8 @@ if not "%GIT_DESCRIBE_NUMBER%"=="0" (
 :: -G "Visual Studio 16 2019" specifies the the generator
 :: -T v142 specifies the toolset
 
-cmake -S "%RECIPE_DIR%\.." -B "%SRC_DIR%\build_framework" -G "Visual Studio 16 2019" -T "v142" -DCONDA_BUILD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBRARY_LIB=%CONDA_PREFIX%\lib -DLIBRARY_INC=%CONDA_PREFIX% -DCMAKE_INSTALL_PREFIX=%PREFIX% -DPython_EXECUTABLE=%CONDA_PREFIX%/python
+cmake -S "%RECIPE_DIR%\.." -B "%SRC_DIR%\build_framework" -G "Visual Studio 16 2019" -T "v142" -DCONDA_BUILD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLIBRARY_LIB=%CONDA_PREFIX%\lib -DLIBRARY_INC=%CONDA_PREFIX% -DCMAKE_INSTALL_PREFIX=%PREFIX% -DPython_EXECUTABLE=%CONDA_PREFIX%\python
+
 if errorlevel 1 exit 1
 
 cmake --build "%SRC_DIR%\build_framework" --target install --config RelWithDebInfo

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,10 +13,11 @@ export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL="${PKG_VERSION}"
 if test "${GIT_DESCRIBE_NUMBER}" != "0"; then
   export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CIL="${PKG_VERSION}.dev${GIT_DESCRIBE_NUMBER}+${GIT_DESCRIBE_HASH}"
 fi
-cmake ${RECIPE_DIR}/../ $extra_args \
+cmake ${RECIPE_DIR}/../ ${extra_args} \
                         -DCONDA_BUILD=ON \
                         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                        -DLIBRARY_LIB=$CONDA_PREFIX/lib \
-                        -DLIBRARY_INC=$CONDA_PREFIX/include \
-                        -DCMAKE_INSTALL_PREFIX=$PREFIX
+                        -DLIBRARY_LIB=${CONDA_PREFIX}/lib \
+                        -DLIBRARY_INC=${CONDA_PREFIX}/include \
+                        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+                        -DPython_EXECUTABLE=${CONDA_PREFIX}/bin/python
 cmake --build . --target install


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->
- Closes #2040 
## Example Usage
<!--minimal working example-->

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

Tested cmake command locally on linux with python 3.10 to 3.12 and cmake 3.31.2, 3.22.1, 3.30.5, 3.31.4, including with cmake installed in the environment, in base and in system and found the correct python to be retrieved every time (unlike with the original command)

Tested conda-build locally on linux with

`conda build . -c conda-forge -c https://software.repos.intel.com/python/conda -c ccpi `

## Related issues/links


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
