### PR TITLE
Fix deprecation warning for `rtol` and `atol` in GD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* XX.X
+  - Bug fixes:
+      - Fix deprecation warning for rtol and atol in GD (#2056)
+
+
 * 24.3.0
   - New features:
     - Added `FluxNormaliser` processor (#1878)

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -33,7 +33,8 @@ Institutions Key:
 10 - University of Warwick
 11 - University of Helsinki
 12 - Australian e-Health Research, Australia
-13 - KU Leuven 
+13 - KU Leuven
+14 - Independent Contributor
 
 CIL Developers in date order:
 Edoardo Pasca (2017 – present) - 1
@@ -69,6 +70,7 @@ Sam Porter (2024) - 5
 Joshua Hellier (2024) - 3
 Nicholas Whyatt (2024) - 1
 Rasmia Kulan (2024) - 1
+Emmanuel Ferdman (2025) - 14
 
 CIL Advisory Board:
 Llion Evans - 9

--- a/Wrappers/Python/cil/optimisation/algorithms/GD.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/GD.py
@@ -61,10 +61,11 @@ class GD(Algorithm):
         if self.alpha is not None or self.beta is not None: # to be deprecated
             warn('To modify the parameters for the Armijo rule please use `step_size_rule=ArmijoStepSizeRule(alpha, beta, kmax)`. The arguments `alpha` and `beta` will be deprecated. ', DeprecationWarning, stacklevel=2)
 
-        if self.rtol!=0 or self.atol!=0: # to be deprecated (released in 25.0)
-            warn('`rtol` and `atol` are deprecated. For early stopping, please use a callback (cil.optimisation.utilities.callbacks),  for example `EarlyStoppingObjectiveValue`.', DeprecationWarning, stacklevel=2)
-        else:
-            log.warn('Breaking backwards compatibility, GD no longer automatically stops if the objective function is close to zero. For this functionality, please use a callback (cil.optimisation.utilities.callbacks).' )    
+        if self.rtol is not None or self.atol is not None: # to be deprecated (released in 25.0)
+            if self.rtol != 0 or self.atol != 0: # to be deprecated (released in 25.0)
+                warn('`rtol` and `atol` are deprecated. For early stopping, please use a callback (cil.optimisation.utilities.callbacks), for example `EarlyStoppingObjectiveValue`.', DeprecationWarning, stacklevel=2)
+            else:
+                log.warning('Breaking backwards compatibility, GD no longer automatically stops if the objective function is close to zero. For this functionality, please use a callback (cil.optimisation.utilities.callbacks).')
             
         super().__init__(**kwargs)
         


### PR DESCRIPTION
## Description
The commit contains the following changes: 
- Avoid printing deprecation warnings for `rtol` and `atol` when they are not passed to the GC constructor (or passed with `None`).
- Replace the deprecated `log.warn()` with `log.warning()` as `log.warn()` was deprecated in Python 3.3. See [cpython-#105376](https://github.com/python/cpython/issues/105376) for more details.

## Example Usage
```python
myGD_LS = GD(initial=x0, f=f1, step_size=None, update_objective_interval=10)
```
## Related issues/links
- Fixes #2054

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties