### PR TITLE
For astra and tigre ProjectionOperators, if `out` is passed it is filled and returned 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Bug fixes:
       - Fix deprecation warning for rtol and atol in GD (#2056)
       - Removed the deprecated usage of run method in test_SIRF.py (#2070)
+      - Ensured CIL forward and back projectors always return, even when `out` is passed (#2059)
   - Documentation
       - Updated documentation for the ChannelWiseOperator including new example (#2096)
       - Updated documentation for LADMM (#2015)

--- a/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
+++ b/Wrappers/Python/cil/plugins/astra/operators/ProjectionOperator.py
@@ -155,7 +155,7 @@ class ProjectionOperator_ag(ProjectionOperator):
         Returns
         -------
         DataContainer
-            The processed data. Suppressed if `out` is passed
+            The processed data.
         '''
 
         return self.operator.direct(IM, out=out)
@@ -174,7 +174,7 @@ class ProjectionOperator_ag(ProjectionOperator):
         Returns
         -------
         DataContainer
-            The processed data. Suppressed if `out` is passed
+            The processed data.
         '''
         return self.operator.adjoint(DATA, out=out)
 

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
@@ -115,6 +115,6 @@ class AstraBackProjector2D(DataProcessor):
         arr_out = np.squeeze(arr_out)
         if out is None:
             out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
-            return out
         else:
             out.fill(arr_out)
+        return out

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
@@ -58,7 +58,7 @@ class AstraBackProjector3D(DataProcessor):
     def check_input(self, dataset):
 
         if self.sinogram_geometry.shape != dataset.geometry.shape:
-            raise ValueError("Dataset not compatible with geometry used to create the projector")
+            raise ValueError("Dataset not compatible with geometry used to create the projector. Expected shape {0}, got {1}".format(self.sinogram_geometry.shape, dataset.geometry.shape))
 
         return True
     

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
@@ -114,9 +114,9 @@ class AstraBackProjector3D(DataProcessor):
 
         if out is None:
             out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
-            return out
         else:
             out.fill(arr_out)
+        return out
 
     def create_backprojection3d_gpu(self, data, proj_geom, vol_geom, returnData=True, vol_id=None):
 

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
@@ -118,6 +118,6 @@ class AstraForwardProjector2D(DataProcessor):
         arr_out = np.squeeze(arr_out)
         if out is None:
             out = AcquisitionData(arr_out, deep_copy=False, geometry=self.sinogram_geometry.copy(), suppress_warning=True)
-            return out
         else:
             out.fill(arr_out)
+        return out

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector3D.py
@@ -115,9 +115,9 @@ class AstraForwardProjector3D(DataProcessor):
 
         if out is None:
             out = AcquisitionData(arr_out, deep_copy=False, geometry=self.sinogram_geometry.copy(), suppress_warning=True)
-            return out
         else:
             out.fill(arr_out)
+        return out
 
     def create_sino3d_gpu(self, data, proj_geom, vol_geom, returnData=True, gpuIndex=None, sino_id=None):
         """

--- a/Wrappers/Python/cil/plugins/astra/processors/FBP_Flexible.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FBP_Flexible.py
@@ -185,6 +185,6 @@ class FBP_CPU(Processor):
         arr_out = np.flip(arr_out, 0)
         if out is None:
             out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
-            return out
         else:
             out.fill(arr_out)
+        return out

--- a/Wrappers/Python/cil/plugins/astra/processors/FDK_Flexible.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FDK_Flexible.py
@@ -114,6 +114,6 @@ class FDK_Flexible(DataProcessor):
 
         if out is None:
             out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
-            return out
         else:
             out.fill(arr_out)
+        return out

--- a/Wrappers/Python/cil/plugins/tigre/ProjectionOperator.py
+++ b/Wrappers/Python/cil/plugins/tigre/ProjectionOperator.py
@@ -203,9 +203,9 @@ class ProjectionOperator_ag(ProjectionOperator):
                                   deep_copy=False,
                                   geometry=self._range_geometry.copy(),
                                   suppress_warning=True)
-            return out
         else:
             out.fill(arr_out)
+        return out
 
     def __call_Atb(self, data):
         if has_gpu_sel:
@@ -236,9 +236,9 @@ class ProjectionOperator_ag(ProjectionOperator):
                             deep_copy=False,
                             geometry=self._domain_geometry.copy(),
                             suppress_warning=True)
-            return out
         else:
             out.fill(arr_out)
+        return out
 
     def domain_geometry(self):
         return self._domain_geometry

--- a/Wrappers/Python/test/test_out_in_place.py
+++ b/Wrappers/Python/test/test_out_in_place.py
@@ -131,7 +131,6 @@ class TestFunctionOutAndInPlace(CCPiTestClass):
 
 
         ]
-        
 
         np.random.seed(5)
         self.data_arrays=[np.random.normal(0,1, (10,10)).astype(np.float32),  np.array(range(0,65500, 655), dtype=np.uint16).reshape((10,10)), np.random.uniform(-0.1,1,(10,10)).astype(np.float32)]
@@ -351,57 +350,25 @@ class TestProjectionOperatorOutAndInPlace(CCPiTestClass):
         absorption_cone = TransmissionAbsorptionConverter()(data_cone)
         absorption_parallel = TransmissionAbsorptionConverter()(data_parallel)
         
-        absorption_cone_2D = absorption_cone.get_slice(vertical='centre')
-        absorption_parallel_2D = absorption_parallel.get_slice(vertical='centre')
-
-        ground_truth_2D = ground_truth.get_slice(vertical='centre')
 
         self.operator_geom_test_list = [] # Contains (operator, domain_geom, range_geom, data_order)
-            
+        #Note that we only test one astra and one tigre projection operator. This is because there is also tests in test/utils_projectors.py: TestCommon_ProjectionOperator_SIM and TestCommon_ProjectionOperatorBlockOperator. 
+        
         if has_astra and has_nvidia:
             absorption_cone.reorder(order='astra')
-            absorption_parallel.reorder(order='astra')
-            absorption_cone_2D.reorder(order='astra')
-            absorption_parallel_2D.reorder(order='astra')
             
             A_cone_astra = AstraProjector(image_geometry=ground_truth.geometry, 
                         acquisition_geometry=absorption_cone.geometry)
             self.operator_geom_test_list.append((A_cone_astra, 'astra'))
         
-            A_parallel_astra = AstraProjector(image_geometry=ground_truth.geometry,
-                            acquisition_geometry=absorption_parallel.geometry)
-            self.operator_geom_test_list.append((A_parallel_astra, 'astra'))
-            
-            A_cone_astra_2D = AstraProjector(image_geometry=ground_truth_2D.geometry,
-                            acquisition_geometry=absorption_cone_2D.geometry)
-            self.operator_geom_test_list.append((A_cone_astra_2D, 'astra'))
-            
-            A_parallel_astra_2D = AstraProjector(image_geometry=ground_truth_2D.geometry,
-                            acquisition_geometry=absorption_parallel_2D.geometry)
-            self.operator_geom_test_list.append((A_parallel_astra_2D, 'astra'))
             
         if has_tigre and has_nvidia:
-        
-            absorption_cone.reorder(order='tigre')
             absorption_parallel.reorder(order='tigre')
-            absorption_cone_2D.reorder(order='tigre')
-            absorption_parallel_2D.reorder(order='tigre')
-            
-            A_cone_tigre = TigreProjector(image_geometry=ground_truth.geometry,
-                            acquisition_geometry=absorption_cone.geometry)
-            self.operator_geom_test_list.append((A_cone_tigre, 'tigre'))
             
             A_parallel_tigre = TigreProjector(image_geometry=ground_truth.geometry,
                             acquisition_geometry=absorption_parallel.geometry)
             self.operator_geom_test_list.append((A_parallel_tigre, 'tigre'))
-            
-            A_cone_tigre_2D = TigreProjector(image_geometry=ground_truth_2D.geometry,
-                            acquisition_geometry=absorption_cone_2D.geometry)
-            self.operator_geom_test_list.append((A_cone_tigre_2D, 'tigre'))
-            
-            A_parallel_tigre_2D = TigreProjector(image_geometry=ground_truth_2D.geometry,
-                            acquisition_geometry=absorption_parallel_2D.geometry)
-            self.operator_geom_test_list.append((A_parallel_tigre_2D, 'tigre'))
+
     
         
 

--- a/Wrappers/Python/test/test_out_in_place.py
+++ b/Wrappers/Python/test/test_out_in_place.py
@@ -60,13 +60,13 @@ from cil.utilities.quality_measures import mae
 
 from utils import  initialise_tests
 
-from utils import has_astra, has_tigre
+from utils import has_astra, has_tigre, has_nvidia
 
 
 
-if has_astra:
+if has_astra and has_nvidia:
     from cil.plugins.astra.operators import ProjectionOperator as AstraProjector
-if has_tigre:
+if has_tigre and has_nvidia:
     from cil.plugins.tigre import ProjectionOperator as TigreProjector
     
 
@@ -342,11 +342,11 @@ class TestOperatorOutAndInPlace(CCPiTestClass):
 class TestProjectionOperatorOutAndInPlace(CCPiTestClass):
     def setUp(self):
 
-        ground_truth = dataexample.SIMULATED_SPHERE_VOLUME.get()
+        ground_truth = dataexample.SIMULATED_SPHERE_VOLUME.get(size = (16, 16,16))
 
-        data_cone = dataexample.SIMULATED_CONE_BEAM_DATA.get()
+        data_cone = dataexample.SIMULATED_CONE_BEAM_DATA.get(size= (20, 16,16))
 
-        data_parallel = dataexample.SIMULATED_PARALLEL_BEAM_DATA.get()
+        data_parallel = dataexample.SIMULATED_PARALLEL_BEAM_DATA.get(size= (20, 16,16))
         
         absorption_cone = TransmissionAbsorptionConverter()(data_cone)
         absorption_parallel = TransmissionAbsorptionConverter()(data_parallel)
@@ -358,7 +358,7 @@ class TestProjectionOperatorOutAndInPlace(CCPiTestClass):
 
         self.operator_geom_test_list = [] # Contains (operator, domain_geom, range_geom, data_order)
             
-        if has_astra:
+        if has_astra and has_nvidia:
             absorption_cone.reorder(order='astra')
             absorption_parallel.reorder(order='astra')
             absorption_cone_2D.reorder(order='astra')
@@ -380,7 +380,7 @@ class TestProjectionOperatorOutAndInPlace(CCPiTestClass):
                             acquisition_geometry=absorption_parallel_2D.geometry)
             self.operator_geom_test_list.append((A_parallel_astra_2D, 'astra'))
             
-        if has_tigre:
+        if has_tigre and has_nvidia:
         
             absorption_cone.reorder(order='tigre')
             absorption_parallel.reorder(order='tigre')

--- a/Wrappers/Python/test/utils_projectors.py
+++ b/Wrappers/Python/test/utils_projectors.py
@@ -439,8 +439,9 @@ class TestCommon_ProjectionOperator_SIM(SimData):
 
         fp2 = fp.copy()
         fp2.fill(0)
-        Op.direct(self.img_data,out=fp2)
+        fp3 = Op.direct(self.img_data,out=fp2)
         np.testing.assert_allclose(fp.as_array(), fp2.as_array(),1e-8)
+        np.testing.assert_equal(id(fp2), id(fp3))
 
 
     def test_backward_projectors_functionality(self):
@@ -450,8 +451,9 @@ class TestCommon_ProjectionOperator_SIM(SimData):
 
         bp2 = bp.copy()
         bp2.fill(0)
-        Op.adjoint(self.acq_data,out=bp2)
+        bp3 = Op.adjoint(self.acq_data,out=bp2)
         np.testing.assert_allclose(bp.as_array(), bp2.as_array(), 1e-8)
+        np.testing.assert_equal(id(bp2), id(bp3))
 
 
     def test_input_arguments(self):
@@ -518,8 +520,9 @@ class TestCommon_ProjectionOperatorBlockOperator(object):
         # test if using data output
 
         v.fill(0)
-        K.adjoint(self.datasplit, out=v)
+        v2 = K.adjoint(self.datasplit, out=v)
         np.testing.assert_allclose(u.as_array(), v.as_array(), rtol=1.2e-6, atol=1.6e-4)
+        np.testing.assert_equal(id(v), id(v2))
 
 
 
@@ -557,5 +560,6 @@ class TestCommon_ProjectionOperatorBlockOperator(object):
 
         check_data_is_the_same(x,y)
         y.fill(0)
-        K.direct(v, out=y)
+        y2 = K.direct(v, out=y)
         check_data_is_the_same(x,y)
+        np.testing.assert_equal(id(y), id(y2))


### PR DESCRIPTION
## Changes
For astra and tigre ProjectionOperators, if `out` is passed it is filled and returned. Previously it just filled. I have also added unit tests to fix this 

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc
```python

from cil.processors import TransmissionAbsorptionConverter, Slicer
from cil.plugins.tigre import ProjectionOperator
from cil.utilities import dataexample

# Load data
ground_truth = dataexample.SIMULATED_SPHERE_VOLUME.get()

data = dataexample.SIMULATED_CONE_BEAM_DATA.get()

# Consider just a single 2D slice 
data = data.get_slice(vertical='centre')
ground_truth = ground_truth.get_slice(vertical='centre')

absorption = TransmissionAbsorptionConverter()(data)
absorption = Slicer(roi={'angle':(0, -1, 5)})(absorption)

ig = ground_truth.geometry

A = ProjectionOperator(image_geometry=ig, 
                       acquisition_geometry=absorption.geometry)
A_scaled=3*A
```
![image](https://github.com/user-attachments/assets/7ffba4b0-0175-4e6a-acec-6a5d1b91b42f)
![image](https://github.com/user-attachments/assets/2331b500-b93c-44ab-a3ac-8e24902fa98d)
![image](https://github.com/user-attachments/assets/8409bf66-3d83-4659-8bd4-488d9b061344)
![image](https://github.com/user-attachments/assets/66287996-4f7b-4eab-9879-3ce06a446016)

Also tested on CIL-demos, week 2, SPDHG notebook. 


## Related issues/links
Closes #2058 

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties


