### PR TITLE
Add python path in cmake commands in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         conda env remove -n "${{ steps.reqs.outputs.envname }}"
   test:
     defaults: {run: {shell: 'bash -el {0}'}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
@@ -88,7 +88,7 @@ jobs:
     - name: test
       run: python -m unittest discover -v ./Wrappers/Python/test
   conda-matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       python-version: ${{ steps.matrix.outputs.python-version }}
       numpy-version: ${{ steps.matrix.outputs.numpy-version }}
@@ -104,7 +104,7 @@ jobs:
         fi
   conda:
     defaults: {run: {shell: 'bash -el {0}'}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: conda-matrix
     strategy:
       matrix:
@@ -148,7 +148,7 @@ jobs:
   conda-reindex:
     if: startsWith(github.ref, 'refs/tags')
     needs: conda
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: conda index tomography.stfc.ac.uk/conda
       run: |
@@ -158,7 +158,7 @@ jobs:
           'bash -lic "conda index --bz2 --zst --run-exports --channeldata --rss -n ccpi ${{ secrets.STFC_SSH_CONDA_DIR }}"'
   docs:
     defaults: {run: {shell: 'bash -el {0}', working-directory: docs}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -212,7 +212,7 @@ jobs:
         dir: docs/build
         nojekyll: true
   docker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -264,5 +264,5 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
   pass:
     needs: [test-cuda, test, conda, docs, docker]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps: [{run: echo success}]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       name: build
       run: |
         conda activate "${{ steps.reqs.outputs.envname }}"
-        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"-DPython_EXECUTABLE=${CONDA_PREFIX}/bin/python -DIPP_LIBRARY=${CMAKE_INSTALL_PREFIX}/lib -DIPP_INCLUDE=${CMAKE_INSTALL_PREFIX}/includes
+        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"-DPython_EXECUTABLE=${CONDA_PREFIX}/bin/python
         cmake --build ./build --target install
     - name: test
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       name: build
       run: |
         conda activate "${{ steps.reqs.outputs.envname }}"
-        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"-DPython_EXECUTABLE=${CONDA_PREFIX}/bin/python
+        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"-DPython_EXECUTABLE=${CONDA_PREFIX}/bin/python -DIPP_LIBRARY=${CMAKE_INSTALL_PREFIX}/lib -DIPP_INCLUDE=${CMAKE_INSTALL_PREFIX}/includes
         cmake --build ./build --target install
     - name: test
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         conda env remove -n "${{ steps.reqs.outputs.envname }}"
   test:
     defaults: {run: {shell: 'bash -el {0}'}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -88,7 +88,7 @@ jobs:
     - name: test
       run: python -m unittest discover -v ./Wrappers/Python/test
   conda-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       python-version: ${{ steps.matrix.outputs.python-version }}
       numpy-version: ${{ steps.matrix.outputs.numpy-version }}
@@ -104,7 +104,7 @@ jobs:
         fi
   conda:
     defaults: {run: {shell: 'bash -el {0}'}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: conda-matrix
     strategy:
       matrix:
@@ -148,7 +148,7 @@ jobs:
   conda-reindex:
     if: startsWith(github.ref, 'refs/tags')
     needs: conda
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: conda index tomography.stfc.ac.uk/conda
       run: |
@@ -158,7 +158,7 @@ jobs:
           'bash -lic "conda index --bz2 --zst --run-exports --channeldata --rss -n ccpi ${{ secrets.STFC_SSH_CONDA_DIR }}"'
   docs:
     defaults: {run: {shell: 'bash -el {0}', working-directory: docs}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -212,7 +212,7 @@ jobs:
         dir: docs/build
         nojekyll: true
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -264,5 +264,5 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
   pass:
     needs: [test-cuda, test, conda, docs, docker]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps: [{run: echo success}]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       name: build
       run: |
         conda activate "${{ steps.reqs.outputs.envname }}"
-        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"
+        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"-DPython_EXECUTABLE=${CONDA_PREFIX}/bin/python
         cmake --build ./build --target install
     - name: test
       run: |
@@ -83,7 +83,7 @@ jobs:
         activate-environment: cil_dev
     - name: build
       run: |
-        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"
+        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" -DPython_EXECUTABLE=${CONDA_PREFIX}/bin/python
         cmake --build ./build --target install
     - name: test
       run: python -m unittest discover -v ./Wrappers/Python/test
@@ -181,7 +181,7 @@ jobs:
     - name: build cil
       working-directory: .
       run: |
-        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"
+        cmake -S . -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONDA_BUILD=ON -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" -DPython_EXECUTABLE=${CONDA_PREFIX}/bin/python
         cmake --build ./build --target install
     - name: checkout docs
       uses: actions/checkout@v4


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->

Closes #2082 

When ubuntu-latest updated to 24.04.1 the actions stopped working (#2017). The reason was due to the same cmake error we saw on linux and windows when trying to build cil locally. I updated the cmake commands in the actions to contain the path to the python executable, which is the same fix we did in our instructions for cmake in the README.

We are not going to update to ubuntu-latest yet, see issue here: #2017

## Example Usage
<!--minimal working example-->

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
