### PR TITLE
Make the call to `next()` in algorithm iteration loop explicit  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 * XX.X
   - Bug fixes:
       - Fix deprecation warning for rtol and atol in GD (#2056)
+  - Enhancements:
+      - Made the call to next() in algorithm iteration loop explicit (#2069)
 
 
 * 24.3.0

--- a/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
@@ -277,8 +277,8 @@ class Algorithm:
         iters = (count(self.iteration) if np.isposinf(self.max_iteration)
                  else range(self.iteration, self.max_iteration))
         for _ in iters:
+            self.__next__()
             try:
-                self.__next__()
                 for callback in callbacks:
                     callback(self)
             except StopIteration:

--- a/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
@@ -276,8 +276,9 @@ class Algorithm:
         self.max_iteration = self.iteration + iterations
         iters = (count(self.iteration) if np.isposinf(self.max_iteration)
                  else range(self.iteration, self.max_iteration))
-        for _ in zip(iters, self):
+        for _ in iters:
             try:
+                self.__next__()
                 for callback in callbacks:
                     callback(self)
             except StopIteration:

--- a/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
@@ -277,8 +277,8 @@ class Algorithm:
         iters = (count(self.iteration) if np.isposinf(self.max_iteration)
                  else range(self.iteration, self.max_iteration))
         for _ in iters:
-            self.__next__()
             try:
+                self.__next__()
                 for callback in callbacks:
                     callback(self)
             except StopIteration:


### PR DESCRIPTION
## Description
Changed this line https://github.com/TomographicImaging/CIL/blob/5749b38a9f59a8d6730e86a395184e62cc152b44/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py#L279 
to make the call to `next()`  (which then  calls `update`)  explicit.  


## Related issues/links
Closes #2063 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
