### PR TITLE
Update test_SIRF.py to latest signature of Algorithm run method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 * XX.X
   - Bug fixes:
       - Fix deprecation warning for rtol and atol in GD (#2056)
+      - Fix in signature of the usage of run method in test_SIRF.py (#2070)
 
 
 * 24.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 * XX.X
   - Bug fixes:
       - Fix deprecation warning for rtol and atol in GD (#2056)
-      - Fix in signature of the usage of run method in test_SIRF.py (#2070)
+      - Removed the deprecated usage of run method in test_SIRF.py (#2070)
 
 
 * 24.3.0

--- a/Wrappers/Python/test/test_SIRF.py
+++ b/Wrappers/Python/test/test_SIRF.py
@@ -255,8 +255,8 @@ class TestGradientMR_2D(unittest.TestCase, GradientSIRF):
 
         # compare with FISTA algorithm
         f =  0.5 * L2NormSquared(b=self.image1)
-        fista = FISTA(initial=self.image1*0.0, f=f, g=TV, max_iteration=10, update_objective_interval=10)
-        fista.run(verbose=0)
+        fista = FISTA(initial=self.image1*0.0, f=f, g=TV, update_objective_interval=10)
+        fista.run(10, verbose=0)
         np.testing.assert_array_almost_equal(fista.solution.as_array(), res2.as_array(), decimal=3)
 
 
@@ -533,8 +533,8 @@ class TestCILSIRFPrecond(unittest.TestCase):
         trunc.apply(initial_image)
 
         ista = ISTA(initial = initial_image, f = obj_fun, g = IndicatorBox(lower=0.),  step_size = -1.0, 
-                    preconditioner=sens,update_objective_interval=1, max_iteration=10)
-        ista.run(verbose=0)      
+                    preconditioner=sens,update_objective_interval=1)
+        ista.run(10, verbose=0)      
 
         print("adad")
         np.testing.assert_allclose(ista.solution.as_array()[0], reconstructed_image.as_array()[0], rtol=1e-3)         


### PR DESCRIPTION
## Description

The SIRF tests failed because they did not pass iteration number to the `run` method of the algorithm.

## Example Usage
<!--minimal working example-->

:heart: *Thanks for your contribution!*








## Changes

Added iteration number to the call in the test

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

Test on the SIRF VM.

## Related issues/links

- https://github.com/TomographicImaging/CIL/issues/2070

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
