### PR TITLE
Extra functionality for sampler: get_previous_samples() and get_current_sample()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,8 +122,9 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
-        mamba-version: "1.5"
+        mamba-version: "*"
         channels: conda-forge
+        conda-remove-defaults: "true"
     - name: conda build & test
       working-directory: recipe
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
       - Made the call to next() in algorithm iteration loop explicit (#2069)
       - Added option for a random seed in the power method in the linear operator (#1585)
       - Improved efficiency of `Normaliser` processor. Reduced memory use and increased speed (#2111)
+      - Extra functionality for sampler: `get_previous_samples()` and `get_current_sample()` (#2079)
   - Testing
       - Developers can now add `#all-tests` to their commit message on a PR to run the full matrix of GitHub actions tests (#2081)
       - Added tests for ProjectionOperator inputs that use `unittest-parametrize` module (#1990)

--- a/Wrappers/Python/cil/optimisation/utilities/sampler.py
+++ b/Wrappers/Python/cil/optimisation/utilities/sampler.py
@@ -145,6 +145,9 @@ class Sampler():
 
     @property
     def current_iter_number(self):
+        """
+        Returns the current iteration number of the sampler.
+        """
         return self._iteration_number
 
     def next(self):
@@ -162,7 +165,7 @@ class Sampler():
 
     def get_samples(self,  num_samples):
         """
-        Generates a list of the first num_samples output by the sampler. Calling this does not increment the sampler index or affect the behaviour of the sampler .
+        Generates a numpy array of the first num_samples output by the sampler. Calling this does not increment the sampler index or affect the behaviour of the sampler .
 
         Parameters
         ----------
@@ -171,7 +174,7 @@ class Sampler():
 
         Returns
         --------
-        List
+        Numpy Array
             The first `num_samples" output by the sampler.
         """
         save_last_index = self._iteration_number
@@ -186,15 +189,15 @@ class Sampler():
     
     def get_previous_samples(self):
         """
-        Generates a list of the samples outputted by the sampler since it was initialised. Calling this does not increment the sampler index or affect the behaviour of the sampler .
+        Generates a numpy array of the samples outputted by the sampler since it was initialised. Calling this does not increment the sampler index or affect the behaviour of the sampler .
 
         Returns
         --------
-        List
+        Numpy Array
             A list of the samples outputted by the sampler since it was initialised
         """
 
-        return get_samples(self._iteration_number)
+        return self.get_samples(self._iteration_number)
     
     def get_current_sample(self):
         """
@@ -205,7 +208,9 @@ class Sampler():
         int
             The current sample of the sampler.
         """
-        return self._function(self._iteration_number)
+        if self._iteration_number == 0:
+            raise ValueError('The sampler has not yet been incremented. ')
+        return self._function(self._iteration_number-1)
 
     def __str__(self):
         repres = "Sampler that selects from a list of indices {0, 1, …, N-1}, where N is the number of indices. \n"
@@ -689,6 +694,7 @@ class SamplerRandom(Sampler):
         self._generator = np.random.RandomState(self._seed)
         self._sampling_list = None
         self._replace = replace
+        self._current_sample = None
 
         super(SamplerRandom, self).__init__(num_indices, self._function,
                                             sampling_type=sampling_type, prob_weights=prob)
@@ -724,6 +730,7 @@ class SamplerRandom(Sampler):
             The first `num_samples` produced by the sampler
         """
         save_last_index = self._iteration_number
+        save_current_value = self._current_sample
         self._iteration_number = 0
 
         save_generator = self._generator
@@ -733,7 +740,7 @@ class SamplerRandom(Sampler):
         output = [self.next() for _ in range(num_samples)]
 
         self._iteration_number = save_last_index
-
+        self._current_sample = save_current_value
         self._generator = save_generator
         self._sampling_list = save_sampling_list
 
@@ -748,7 +755,8 @@ class SamplerRandom(Sampler):
         int
             The current sample of the sampler.
         """
-
+        if self._current_sample is None:
+            raise ValueError('The sampler has not yet been incremented. ')
         return self._current_sample
 
     def __str__(self):

--- a/Wrappers/Python/cil/optimisation/utilities/sampler.py
+++ b/Wrappers/Python/cil/optimisation/utilities/sampler.py
@@ -59,7 +59,8 @@ class Sampler():
     3
     >>> print(sampler.next())
     4
-
+    >>> print(sampler.get_current_sample())
+    4
 
     >>> sampler = Sampler.staggered(num_indices=21, stride=4)
     >>> print(next(sampler))
@@ -68,16 +69,24 @@ class Sampler():
     4
     >>> print(sampler.get_samples(5))
     [ 0  4  8 12 16]
+    >>> print(sampler.get_previous_samples())
+    [0 4]
 
     Example
     -------
     >>> sampler = Sampler.sequential(10)
+    >>> print(sampler.get_previous_samples())
+    []
     >>> print(sampler.get_samples(5))
+    [0 1 2 3 4]
     >>> print(next(sampler))
     0
-    [0 1 2 3 4]
     >>> print(sampler.next())
     1
+    >>> print(sampler.get_current_sample())
+    1
+    >>> print(sampler.get_previous_samples())
+    [0 1]
 
     Example
     -------
@@ -240,10 +249,12 @@ class Sampler():
         -------
         >>> sampler = Sampler.sequential(10)
         >>> print(sampler.get_samples(5))
+        [0 1 2 3 4]
         >>> print(next(sampler))
         0
-        [0 1 2 3 4]
         >>> print(sampler.next())
+        1
+        >>> print(sampler.get_current_sample())
         1
         """
         def function(x):
@@ -319,6 +330,9 @@ class Sampler():
         4
         >>> print(sampler.get_samples(5))
         [ 0  4  8 12 16]
+        >>> print(sampler.get_previous_samples())
+        [0 4]
+        
         Example
         -------
         >>> sampler = Sampler.staggered(num_indices=17, stride=8)
@@ -328,7 +342,10 @@ class Sampler():
         8
         >>> print(sampler.get_samples(10))
         [ 0  8  16 1 9 2 10 3 11 4]
-
+        >>> print(sampler.get_previous_samples())
+        [0 8]
+        >>> print(sampler.get_current_sample())
+        8
 
         """
 
@@ -371,10 +388,16 @@ class Sampler():
         3
         >>> print(sampler.next())
         4
-
+        >>> print(sampler.get_current_sample())
+        4
+        
+        Example
+        -------
         >>> sampler = Sampler.random_with_replacement(num_indices=4, prob=[0.7,0.1,0.1,0.1])
         >>> print(sampler.get_samples(10))
         [0 1 3 0 0 3 0 0 0 0]
+        >>> print(sampler.get_previous_samples())
+        []
         """
 
         sampler = SamplerRandom(

--- a/Wrappers/Python/cil/optimisation/utilities/sampler.py
+++ b/Wrappers/Python/cil/optimisation/utilities/sampler.py
@@ -28,12 +28,7 @@ class Sampler():
 
     Static methods to easily configure several samplers are provided, such as sequential, staggered, Herman-Mayer, random with and without replacement.
 
-
-
-
     Custom deterministic samplers can be created by using the `from_function` static method or by subclassing this sampler class.
-
-
 
     Parameters
     ----------
@@ -187,6 +182,30 @@ class Sampler():
         self._iteration_number = save_last_index
 
         return np.array(output)
+    
+    
+    def get_previous_samples(self):
+        """
+        Generates a list of the samples outputted by the sampler since it was initialised. Calling this does not increment the sampler index or affect the behaviour of the sampler .
+
+        Returns
+        --------
+        List
+            A list of the samples outputted by the sampler since it was initialised
+        """
+
+        return get_samples(self._iteration_number)
+    
+    def get_current_sample(self):
+        """
+        Returns the current sample of the sampler without incrementing the sampler index.
+
+        Returns
+        --------
+        int
+            The current sample of the sampler.
+        """
+        return self._function(self._iteration_number)
 
     def __str__(self):
         repres = "Sampler that selects from a list of indices {0, 1, …, N-1}, where N is the number of indices. \n"
@@ -688,8 +707,8 @@ class SamplerRandom(Sampler):
         if location == 0:
             self._sampling_list = self._generator.choice(
                 self._num_indices, self._num_indices, p=self._prob_weights, replace=self._replace)
-        out = self._sampling_list[location]
-        return out
+        self._current_sample = self._sampling_list[location]
+        return self._current_sample
 
     def get_samples(self,  num_samples):
         """
@@ -719,6 +738,18 @@ class SamplerRandom(Sampler):
         self._sampling_list = save_sampling_list
 
         return np.array(output)
+    
+    def get_current_sample(self):
+        """
+        Returns the current sample of the sampler without incrementing the sampler index.
+
+        Returns
+        --------
+        int
+            The current sample of the sampler.
+        """
+
+        return self._current_sample
 
     def __str__(self):
         repres = super().__str__()

--- a/Wrappers/Python/cil/optimisation/utilities/sampler.py
+++ b/Wrappers/Python/cil/optimisation/utilities/sampler.py
@@ -453,8 +453,8 @@ class Sampler():
         num_indices: int
             The sampler will select from a range of indices 0 to num_indices.
 
-    function : callable
-        A deterministic function that takes an integer as an argument, representing the iteration number, and returns an integer between 0 and num_indices. The function signature should be function(iteration_number: int) -> int
+        function : callable
+            A deterministic function that takes an integer as an argument, representing the iteration number, and returns an integer between 0 and num_indices. The function signature should be function(iteration_number: int) -> int
 
         prob_weights: list of floats of length num_indices that sum to 1. Default is [1 / num_indices] * num_indices
             Consider that the sampler is incremented a large number of times this argument holds the expected number of times each index would be outputted,  normalised to 1.

--- a/Wrappers/Python/test/test_sampler.py
+++ b/Wrappers/Python/test/test_sampler.py
@@ -141,6 +141,9 @@ class TestSamplers(CCPiTestClass):
         sampler = Sampler.sequential(10)
         self.assertNumpyArrayEqual(sampler.get_samples(20), np.array(
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+        
+        with self.assertRaises(ValueError):
+            sampler.get_current_sample()
 
         for i in range(337):
             self.assertEqual(next(sampler), i % 10)

--- a/Wrappers/Python/test/test_sampler.py
+++ b/Wrappers/Python/test/test_sampler.py
@@ -106,6 +106,7 @@ class TestSamplers(CCPiTestClass):
         sampler = Sampler.from_function(50, self.example_function)
         order = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
                  19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
+        self.assertNumpyArrayEqual(sampler.get_previous_samples(), np.array([]))
         self.assertNumpyArrayEqual(sampler.get_samples(20), np.array(
             order)[:20])
 

--- a/Wrappers/Python/test/test_sampler.py
+++ b/Wrappers/Python/test/test_sampler.py
@@ -112,12 +112,15 @@ class TestSamplers(CCPiTestClass):
         N = 25
         for i in range(N):
             self.assertEqual(next(sampler), order[i])
+            self.assertEqual(sampler.get_current_sample(), order[i])
 
         self.assertEqual(sampler._iteration_number, N)
         self.assertEqual(sampler.current_iter_number, N)
 
         self.assertEqual(sampler.get_samples(
             550)[519], self.example_function(519))
+        
+        self.assertNumpyArrayEqual(sampler.get_previous_samples(), np.array(order[:N]))
 
         sampler = Sampler.from_function(50, self.example_function)
         self.assertListEqual(sampler.prob_weights, [1/50] * 50)
@@ -141,6 +144,11 @@ class TestSamplers(CCPiTestClass):
 
         for i in range(337):
             self.assertEqual(next(sampler), i % 10)
+            self.assertEqual(sampler.get_current_sample(), i % 10)
+            self.assertEqual(sampler.get_current_sample(), i % 10)
+            
+        self.assertEqual(sampler.current_iter_number, 337)
+        self.assertEqual(len(sampler.get_previous_samples()), 337)
 
         self.assertNumpyArrayEqual(sampler.get_samples(20), np.array(
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
@@ -166,8 +174,12 @@ class TestSamplers(CCPiTestClass):
         self.assertNumpyArrayEqual(
             sampler.get_samples(25), np.array(order[:25]))
 
+        with self.assertRaises(ValueError):
+            sampler.get_current_sample()
+            
         for i in range(25):
             self.assertEqual(next(sampler), order[i])
+            self.assertEqual(sampler.get_current_sample(), order[i])
 
         self.assertNumpyArrayEqual(
             sampler.get_samples(25), np.array(order[:25]))
@@ -188,7 +200,12 @@ class TestSamplers(CCPiTestClass):
             sampler.get_samples(14), np.array(order[:14]))
 
         for i in range(25):
+            self.assertEqual(sampler.current_iter_number, i)
             self.assertEqual(sampler.next(), order[i % 12])
+            self.assertEqual(sampler.get_current_sample(), order[i % 12])
+            self.assertEqual(sampler.get_current_sample(), order[i % 12])
+            
+        self.assertNumpyArrayEqual(sampler.get_samples(25), sampler.get_previous_samples())
 
         self.assertNumpyArrayEqual(
             sampler.get_samples(14), np.array(order[:14]))
@@ -211,13 +228,21 @@ class TestSamplers(CCPiTestClass):
                  2, 0, 4, 1, 2, 1, 3, 2, 2, 1, 1, 1, 1]
         self.assertNumpyArrayEqual(
             sampler.get_samples(14), np.array(order[:14]))
+        
+        with self.assertRaises(ValueError):
+            sampler.get_current_sample()
 
         for i in range(25):
             self.assertEqual(next(sampler), order[i])
+            self.assertEqual(sampler.get_current_sample(), order[i])
+            self.assertEqual(sampler.get_current_sample(), order[i])
+            self.assertEqual(sampler.current_iter_number, i+1)
 
         self.assertNumpyArrayEqual(
             sampler.get_samples(14), np.array(order[:14]))
 
+        self.assertNumpyArrayEqual(sampler.get_samples(25), sampler.get_previous_samples())
+        
         sampler = Sampler.random_with_replacement(
             4, [0.7, 0.1, 0.1, 0.1], seed=5)
         order = [0, 2, 0, 3, 0, 0, 1, 0, 0, 0, 0, 1,
@@ -227,6 +252,11 @@ class TestSamplers(CCPiTestClass):
 
         for i in range(25):
             self.assertEqual(sampler.next(), order[i])
+            self.assertEqual(sampler.get_current_sample(), order[i])
+            self.assertEqual(sampler.get_current_sample(), order[i])
+            self.assertEqual(sampler.current_iter_number, i+1)
+            
+        self.assertNumpyArrayEqual(sampler.get_samples(25), sampler.get_previous_samples())
 
         self.assertNumpyArrayEqual(
             sampler.get_samples(14), np.array(order[:14]))
@@ -252,6 +282,12 @@ class TestSamplers(CCPiTestClass):
 
         for i in range(25):
             self.assertEqual(next(sampler), order[i % 21])
+            self.assertEqual(sampler.get_current_sample(), order[i % 21])
+            self.assertEqual(sampler.get_current_sample(), order[i % 21])
+            self.assertEqual(sampler.current_iter_number, i+1)
 
         self.assertNumpyArrayEqual(
             sampler.get_samples(10), np.array(order[:10]))
+        
+        self.assertNumpyArrayEqual(sampler.get_samples(25), sampler.get_previous_samples())
+

--- a/docs/source/optimisation.rst
+++ b/docs/source/optimisation.rst
@@ -587,13 +587,12 @@ For ease of use we provide the following static methods in `cil.optimisation.uti
 They will all instantiate a Sampler defined in the following class:
 
 .. autoclass:: cil.optimisation.utilities.Sampler
-   :members:
+   
 
-
-In addition, we provide a random sampling class which is a child class of  `cil.optimisation.utilities.sampler` and provides options for sampling with and without replacement:
+The random samplers are instantiated from a random sampling class which is a child class of  `cil.optimisation.utilities.sampler` and provides options for sampling with and without replacement:
 
 .. autoclass:: cil.optimisation.utilities.SamplerRandom
-   :members:
+   
 
 Callbacks
 ---------


### PR DESCRIPTION
## Description
Extra functionality for sampler: get_previous_samples() and get_current_sample().

Open to discussion on naming: get_current_sample() or get_previous_sample()? Should it be a property? 



## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links
Closes #2076 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


