### PR TITLE
Use fixed norm for bb step size test

### DIFF
--- a/Wrappers/Python/test/test_algorithm_convergence.py
+++ b/Wrappers/Python/test/test_algorithm_convergence.py
@@ -108,7 +108,6 @@ class TestAlgorithmConvergence(CCPiTestClass):
         
         
     def test_bb_step_size_gd_converge(self):
-        np.random.seed(2)
         n = 10
         m = 10
         A = np.array(range(1,n*m+1)).reshape(n,m).astype('float32')
@@ -116,8 +115,10 @@ class TestAlgorithmConvergence(CCPiTestClass):
         x = (np.array(range(n)).astype('float32')-n/2)/n
         b=A@x
 
-
+        
         Aop = MatrixOperator(A)
+        norm = Aop.PowerMethod(Aop, method="composed_with_adjoint", seed=4)
+        Aop.set_norm(norm)
         bop = VectorData(b)
         ig=Aop.domain
         


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->

## Example Usage
<!--minimal working example-->

:heart: *Thanks for your contribution!*







<!-- please IGNORE the below if you aren't a CIL team member

blame GH for this text: https://github.com/orgs/community/discussions/81319

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
