### PR TITLE
Improve normaliser efficiency and added unittests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
       - Add accelerated version to TransmissionAbsorption processor, controlled by `accelerated` parameter, default is True (#2036)
       - Made the call to next() in algorithm iteration loop explicit (#2069)
       - Added option for a random seed in the power method in the linear operator (#1585)
+      - Improved efficiency of `Normaliser` processor. Reduced memory use and increased speed (#2111)
   - Testing
       - Developers can now add `#all-tests` to their commit message on a PR to run the full matrix of GitHub actions tests (#2081)
       - Added tests for ProjectionOperator inputs that use `unittest-parametrize` module (#1990)
+      - Added tests for Normaliser processor
   - Dependencies
       - matplotlib-base is an optional dependency, instead of required (#2093)
       - `unittest-parametrize has been added as a dependency for tests (#1990)

--- a/Wrappers/Python/cil/processors/Normaliser.py
+++ b/Wrappers/Python/cil/processors/Normaliser.py
@@ -164,7 +164,7 @@ class Normaliser(Processor):
             numpy.multiply(input_arr, denom_inv, out=out_array)
 
         if zero_err:
-            warnings.warn("Divide by zero detected. These values will be substitued by the set tolerance. Please check your data for bad pixels.", UserWarning, stacklevel=2)
+            warnings.warn("Divide by zero detected. These values will be substituted by the set tolerance. Please check your data for bad pixels.", UserWarning, stacklevel=2)
             # create map of zeros in scale array
             zero_map = numpy.where(scale == 0)
             # set these to the tolerance value in all projections

--- a/Wrappers/Python/cil/processors/Normaliser.py
+++ b/Wrappers/Python/cil/processors/Normaliser.py
@@ -139,22 +139,21 @@ class Normaliser(Processor):
                 raise ValueError('Dark field and projections size do not match.')
             offset = self.dark_field
 
-        if self.flat_field is None:
-            scale = 1
-        else:
+        zero_err = False
+        if self.flat_field is not None:
             if input_arr.shape[-len(self.flat_field.shape)::]!=self.flat_field.shape:
                 raise ValueError('Flat field and projections size do not match.')
+            
             scale = self.flat_field - offset
 
-        zero_err = False
-        numpy.seterr(divide='warn')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+            numpy.seterr(divide='warn')
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
 
-            denom_inv = 1.0 / scale
-            # Check if any warnings were raised
-            if len(w) > 0 and issubclass(w[-1].category, RuntimeWarning):
-                zero_err = True
+                denom_inv = 1.0 / scale
+                # Check if any warnings were raised and handle these later
+                if len(w) > 0 and issubclass(w[-1].category, RuntimeWarning):
+                    zero_err = True
         
         if self.dark_field is not None:
             numpy.subtract(input_arr, offset, out=out_array)

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -3571,6 +3571,25 @@ class TestNormaliser(unittest.TestCase):
         normaliser(self.data, out=self.data)
         numpy.testing.assert_allclose(self.data.array, normalised_data.array)
 
+    def test_bad_input(self):
+        arr = numpy.ones((5)) 
+        normaliser = Normaliser(flat_field=arr, dark_field=None)
+        normaliser.set_input(self.data)
+
+        with self.assertRaises(ValueError):
+            out = normaliser.get_output()
+
+        arr = numpy.ones((5,6)) 
+        normaliser.set_flat_field(arr)
+        with self.assertRaises(ValueError):
+            out = normaliser.get_output()      
+
+        arr = numpy.ones((5,6)) 
+        normaliser.set_dark_field(arr)
+        normaliser.set_flat_field(None)
+        with self.assertRaises(ValueError):
+            out = normaliser.get_output()     
+
     def test_no_offset(self):
         #test with no dark-field
         flat_field = numpy.ones(self.data.shape[1::]) * 2.0

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -35,7 +35,7 @@ from cil.recon import FBP
 from cil.processors import CentreOfRotationCorrector
 from cil.processors.CofR_xcorrelation import CofR_xcorrelation
 from cil.processors import TransmissionAbsorptionConverter, AbsorptionTransmissionConverter
-from cil.processors import Slicer, Binner, MaskGenerator, Masker, Padder, PaganinProcessor, FluxNormaliser
+from cil.processors import Slicer, Binner, MaskGenerator, Masker, Padder, PaganinProcessor, FluxNormaliser, Normaliser
 import gc
 
 from utils import has_numba
@@ -3549,7 +3549,80 @@ class TestFluxNormaliser(unittest.TestCase):
         numpy.testing.assert_allclose(data.array, self.data_cone.array)
 
 
-if __name__ == "__main__":
+class TestNormaliser(unittest.TestCase):
 
-    d = TestDataProcessor()
-    d.test_DataProcessorChaining()
+    def setUp(self):
+        self.data = dataexample.SIMULATED_PARALLEL_BEAM_DATA.get()
+
+    def test_normaliser_standard(self):
+        flat_field = numpy.ones(self.data.shape[1::]) * 1.5
+        dark_field = numpy.ones(self.data.shape[1::]) * 0.5
+        normaliser = Normaliser(flat_field=flat_field, dark_field=dark_field)
+        normalised_data = normaliser(self.data)
+        test_out =  self.data.array-normalised_data.array
+        numpy.testing.assert_allclose(test_out, 0.5)
+
+        # test default with out
+        out = self.data.geometry.allocate(None)
+        normaliser(self.data, out=out)
+        numpy.testing.assert_allclose(out.array, normalised_data.array)
+
+        # test default inplace
+        normaliser(self.data, out=self.data)
+        numpy.testing.assert_allclose(self.data.array, normalised_data.array)
+
+    def test_no_offset(self):
+        #test with no dark-field
+        flat_field = numpy.ones(self.data.shape[1::]) * 2.0
+        dark_field = None
+        normaliser = Normaliser(flat_field=flat_field, dark_field=dark_field)
+        normalised_data = normaliser(self.data)
+        test_out =  normalised_data.array/self.data.array
+        numpy.testing.assert_allclose(test_out, 0.5)
+
+        # test default with out
+        out = self.data.geometry.allocate(None)
+        normaliser(self.data, out=out)
+        numpy.testing.assert_allclose(out.array, normalised_data.array)
+
+        # test default inplace
+        normaliser(self.data, out=self.data)
+        numpy.testing.assert_allclose(self.data.array, normalised_data.array)
+
+    def test_no_flat(self): 
+        #test with no flat-field
+        flat_field = None
+        dark_field = numpy.ones(self.data.shape[1::]) * 0.5
+        normaliser = Normaliser(flat_field=flat_field, dark_field=dark_field)
+        normalised_data = normaliser(self.data)
+        test_out =  self.data.array-normalised_data.array
+        numpy.testing.assert_allclose(test_out, 0.5)
+
+        # test default with out
+        out = self.data.geometry.allocate(None)
+        normaliser(self.data, out=out)
+        numpy.testing.assert_allclose(out.array, normalised_data.array)
+
+        # test default inplace
+        normaliser(self.data, out=self.data)
+        numpy.testing.assert_allclose(self.data.array, normalised_data.array)
+
+    def test_no_flat_no_dark(self):
+        #test with no flat or dark-field
+        flat_field = None
+        dark_field = None
+        normaliser = Normaliser(flat_field=flat_field, dark_field=dark_field)
+        with self.assertRaises(ValueError):
+            normalised_data = normaliser(self.data)
+
+    def test_zeros_in_flat(self):
+        # test with zeros in flat field
+        flat_field = numpy.ones(self.data.shape[1::])
+        flat_field[0,0] = 0
+        dark_field = None
+        normaliser = Normaliser(flat_field=flat_field, dark_field=dark_field)
+        with numpy.testing.assert_warns(UserWarning):
+            normalised_data = normaliser(self.data)
+        test_out = self.data.array.copy()
+        test_out[:,0,0] = 1e-5
+        numpy.testing.assert_allclose(normalised_data.array, test_out)


### PR DESCRIPTION
## Changes
 - Improved how normaliser processes the data whilst preserving current functionality.
   - Previously was always copying and dividing many times over.
 - Added unittests.
 - Now handles cases where only flat-field or dark-field are passed.
  
## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

Tested locally, added unit tests of functionality.
Tested sandstone preprocessing notebook.

## Related issues/links
closes #2110

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
