### PR TITLE
fix FBP.split_processing for astra ordered data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
       - Removed the deprecated usage of run method in test_SIRF.py (#2070)
       - Ensured CIL forward and back projectors always return, even when `out` is passed (#2059)
       - Made ProjectionOperator `device` input case-insensitive (#1990)
+      - Fix `recon.FBP` `split_processing` methods for `ASTRA` backend (#2114)
   - Documentation
       - Updated documentation for the ChannelWiseOperator including new example (#2096)
       - Updated documentation for LADMM (#2015)

--- a/Wrappers/Python/cil/recon/FBP.py
+++ b/Wrappers/Python/cil/recon/FBP.py
@@ -548,7 +548,7 @@ class FBP(GenericFilteredBackProjection):
         self.operator = self._PO_class(ig_slice,ag_slice)
 
     def _process_chunk(self, i, step):
-        self.data_slice.fill(np.squeeze(self.input.array[:,i:i+step,:]))
+        np.take(self.input.array, np.arange(i,i+step), axis=self.input.dimension_labels.index("vertical"), out=self.data_slice.array)
         if not self.filter_inplace:
             self._pre_filtering(self.data_slice)
 

--- a/Wrappers/Python/cil/recon/FBP.py
+++ b/Wrappers/Python/cil/recon/FBP.py
@@ -548,7 +548,7 @@ class FBP(GenericFilteredBackProjection):
         self.operator = self._PO_class(ig_slice,ag_slice)
 
     def _process_chunk(self, i, step):
-        np.take(self.input.array, np.arange(i,i+step), axis=self.input.dimension_labels.index("vertical"), out=self.data_slice.array)
+        np.take(self.input.array, np.arange(i,i+step), axis=self.input.get_dimension_axis("vertical"), out=self.data_slice.array)
         if not self.filter_inplace:
             self._pre_filtering(self.data_slice)
 

--- a/Wrappers/Python/test/test_reconstructors.py
+++ b/Wrappers/Python/test/test_reconstructors.py
@@ -36,9 +36,13 @@ import tempfile
 initialise_tests()
 
 if has_tigre:
-    from cil.plugins.tigre import ProjectionOperator as ProjectionOperator
+    from cil.plugins.tigre import ProjectionOperator as ProjectionOperator_tigre
     from cil.plugins.tigre import FBP as FBP_tigre
     from tigre.utilities.filtering import ramp_flat, filter
+
+if has_astra:
+    from cil.plugins.astra import ProjectionOperator as ProjectionOperator_astra
+    from cil.plugins.astra import FBP as FBP_astra
 
 if has_matplotlib:
     import matplotlib.testing.compare as compare
@@ -654,20 +658,8 @@ class Test_FBP_tigre_ipp(unittest.TestCase):
         self.ig = self.img_data.geometry
         self.ag = self.acq_data.geometry
 
-    def test_results_3D_tigre(self):
+    def test_results_3D(self):
         reconstructor = FBP(self.acq_data)
-
-        reco = reconstructor.run(verbose=0)
-        np.testing.assert_allclose(reco.as_array(), self.img_data.as_array(),atol=1e-3)
-
-        reco2 = reco.copy()
-        reco2.fill(0)
-        reconstructor.run(out=reco2, verbose=0)
-        np.testing.assert_allclose(reco.as_array(), reco2.as_array(), atol=1e-8)
-
-    def test_results_3D_astra(self):
-        self.acq_data.reorder('astra')
-        reconstructor = FBP(self.acq_data, backend='astra')
 
         reco = reconstructor.run(verbose=0)
         np.testing.assert_allclose(reco.as_array(), self.img_data.as_array(),atol=1e-3)
@@ -707,25 +699,11 @@ class Test_FBP_tigre_ipp(unittest.TestCase):
         reconstructor.run(out=reco2, verbose=0)
         np.testing.assert_allclose(reco.as_array(), reco2.as_array(), atol=1e-8)
 
-    def test_results_2D_tigre(self):
+    def test_results_2D(self):
         data2D = self.acq_data.get_slice(vertical='centre')
         img_data2D = self.img_data.get_slice(vertical='centre')
 
         reconstructor = FBP(data2D)
-        reco = reconstructor.run(verbose=0)
-        np.testing.assert_allclose(reco.as_array(), img_data2D.as_array(),atol=1e-3)
-
-        reco2 = reco.copy()
-        reco2.fill(0)
-        reconstructor.run(out=reco2, verbose=0)
-        np.testing.assert_allclose(reco.as_array(), reco2.as_array(), atol=1e-8)
-
-    def test_results_2D_astra(self):
-        data2D = self.acq_data.get_slice(vertical='centre')
-        data2D.reorder('astra')
-        img_data2D = self.img_data.get_slice(vertical='centre')
-
-        reconstructor = FBP(data2D, backend='astra')
         reco = reconstructor.run(verbose=0)
         np.testing.assert_allclose(reco.as_array(), img_data2D.as_array(),atol=1e-3)
 
@@ -762,3 +740,94 @@ class Test_FBP_tigre_ipp(unittest.TestCase):
 
         diff = (data_filtered - self.acq_data).abs().mean()
         self.assertGreater(diff,0.8)
+
+
+@unittest.skipUnless(has_astra and has_nvidia and has_ipp, "ASTRA or IPP not installed")
+class Test_FBP_astra_ipp(unittest.TestCase):
+    def setUp(self):
+        self.acq_data = SIMULATED_PARALLEL_BEAM_DATA.get()
+        self.img_data = SIMULATED_SPHERE_VOLUME.get()
+
+        self.acq_data=np.log(self.acq_data)
+        self.acq_data*=-1.0
+        self.acq_data.reorder('astra')
+
+        self.ig = self.img_data.geometry
+        self.ag = self.acq_data.geometry
+
+    def test_results_3D(self):
+        reconstructor = FBP(self.acq_data, backend='astra')
+
+        reco = reconstructor.run(verbose=0)
+        np.testing.assert_allclose(reco.as_array(), self.img_data.as_array(),atol=1e-3)
+
+        reco2 = reco.copy()
+        reco2.fill(0)
+        reconstructor.run(out=reco2, verbose=0)
+        np.testing.assert_allclose(reco.as_array(), reco2.as_array(), atol=1e-8)
+
+    def test_results_3D_split(self):
+
+        reconstructor = FBP(self.acq_data, backend='astra')
+        reconstructor.set_split_processing(8)
+
+        reco = reconstructor.run(verbose=0)
+        np.testing.assert_allclose(reco.as_array(), self.img_data.as_array(),atol=1e-3)
+
+        reco2 = reco.copy()
+        reco2.fill(0)
+        reconstructor.run(out=reco2, verbose=0)
+        np.testing.assert_allclose(reco.as_array(), reco2.as_array(), atol=1e-8)
+
+    def test_results_3D_split_reverse(self):
+        acq_data = self.acq_data.copy()
+        acq_data.geometry.config.panel.origin = 'top-left'
+
+        reconstructor = FBP(acq_data, backend='astra')
+        reconstructor.set_split_processing(8)
+
+        expected_image = np.flip(self.img_data.as_array(),0)
+
+        reco = reconstructor.run(verbose=0)
+        np.testing.assert_allclose(reco.as_array(), expected_image,atol=1e-3)
+
+        reco2 = reco.copy()
+        reco2.fill(0)
+        reconstructor.run(out=reco2, verbose=0)
+        np.testing.assert_allclose(reco.as_array(), reco2.as_array(), atol=1e-8)
+
+    def test_results_2D(self):
+        data2D = self.acq_data.get_slice(vertical='centre')
+        data2D.reorder('astra')
+        img_data2D = self.img_data.get_slice(vertical='centre')
+
+        reconstructor = FBP(data2D, backend='astra')
+        reco = reconstructor.run(verbose=0)
+        np.testing.assert_allclose(reco.as_array(), img_data2D.as_array(),atol=1e-3)
+
+        reco2 = reco.copy()
+        reco2.fill(0)
+        reconstructor.run(out=reco2, verbose=0)
+        np.testing.assert_allclose(reco.as_array(), reco2.as_array(), atol=1e-8)
+
+    def test_results_with_astra(self):
+        fbp_astra = FBP_astra(self.ig, self.ag)
+        reco_astra = fbp_astra(self.acq_data)
+
+        reconstructor_cil = FBP(self.acq_data, backend='astra')
+        reco_cil = reconstructor_cil.run(verbose=0)
+
+        np.testing.assert_allclose(reco_cil.as_array(), reco_astra.as_array(),atol=1e-4)
+
+    def test_results_inplace_filtering(self):
+        reconstructor = FBP(self.acq_data, backend='astra')
+        reco = reconstructor.run(verbose=0)
+
+        data_filtered= self.acq_data.copy()
+        reconstructor_inplace = FBP(data_filtered, backend='astra')
+        reconstructor_inplace.set_filter_inplace(True)
+        reconstructor_inplace.run(out=reco, verbose=0)
+
+        diff = (data_filtered - self.acq_data).abs().mean()
+        self.assertGreater(diff,0.8)
+


### PR DESCRIPTION
## Changes

Previously tried to slice the data on the wrong axis for `astra` ordered data and raised a `ValueError` due to array shape.


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

```python
from cil.utilities import dataexample
from cil.recon import FBP
from cil.utilities.display import show2D

data = dataexample.SIMULATED_PARALLEL_BEAM_DATA.get()
data.log(out=data)
data *= -1.0

print(data.dimension_labels, data.shape)
print(data.geometry.dimension_labels, data.geometry.shape)

data.reorder('astra')

print(data.dimension_labels, data.shape)
print(data.geometry.dimension_labels, data.geometry.shape)


fbp = FBP(data, backend='astra')
out = fbp.run()


fbp.set_split_processing(2)
out2 = fbp.run()

show2D([out,out2],slice_list=('horizontal_x',64),title=['FBP','FBP split'])
```

```
FBP recon

Input Data:
	vertical: 128
	angle: 300
	horizontal: 128

Reconstruction Volume:
	vertical: 128
	horizontal_y: 128
	horizontal_x: 128

Reconstruction Options:
	Backend: astra
	Filter: ram-lak
	Filter cut-off frequency: 1.0
	FFT order: 8
	Filter_inplace: False
	Split processing: 2

Reconstructing in 64 chunk(s):

100%|██████████| 64/64 [00:02<00:00, 22.60it/s]
```
![image](https://github.com/user-attachments/assets/b26aacfc-1976-453a-9de0-be2da419d951)

## Related issues/links

closes #2115

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties
