### PR TITLE
add pip required & optional dependencies 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,15 +68,12 @@ gpu = [
 [dependency-groups]
 test = [
     #"ccpi-regulariser=24.0.1", # [not osx] # missing from PyPI
+    "cvxpy",
     "matplotlib>=3.3.0",
     "packaging",
     "scikit-image",
     "unittest-parametrize",
     "wget",
-]
-test-linux = [
-    "cvxpy",
-    {include-group = "test"},
 ]
 docs = [
   "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,35 @@ maintainers = [{name="CIL developers", email="tomography+cil@stfc.ac.uk"}]
 requires-python = ">=3.10"
 readme = "README.md"
 keywords = ["tomography", "optimisation"]
+dependencies = [
+    #"cil-data>=22", # missing from PyPI
+    "dxchange",
+    "h5py",
+    #"ipp==2021.12.*", # PyPI conflicts with conda package
+    "ipywidgets",
+    "numba",
+    "numpy>=1.23",
+    "olefile>=0.46",
+    "pillow",
+    "pywavelets",
+    "scipy>=1.4.0",
+    "tqdm",
+    "zenodo_get>=1.6",
+]
+[project.optional-dependencies]
+test = [
+    #"ccpi-regulariser=24.0.1", # [not osx] # missing from PyPI
+    "matplotlib>=3.3.0",
+    "packaging",
+    "scikit-image",
+    #"tomophantom==2.0.0", # [linux] # missing from PyPI
+    "unittest-parametrize",
+    "wget",
+]
+gpu = [
+    "astra-toolbox>=1.9.9.dev5,<=2.1", # [not osx]
+    #"tigre>=2.4,<=2.6", # missing from PyPI
+]
+test-linux = [
+    "cvxpy",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
     "dxchange",
     "h5py",
     #"ipp==2021.12.*", # PyPI conflicts with conda package
-    "ipywidgets",
     "numba",
     "numpy>=1.23",
     "olefile>=0.46",
@@ -58,6 +57,10 @@ dependencies = [
     "zenodo_get>=1.6",
 ]
 [project.optional-dependencies]
+plugins = [
+    "ipywidgets",
+    #"tomophantom==2.0.0", # [linux] # missing from PyPI
+]
 gpu = [
     "astra-toolbox>=1.9.9.dev5,<=2.1", # [not osx]
     #"tigre>=2.4,<=2.6", # missing from PyPI
@@ -68,7 +71,6 @@ test = [
     "matplotlib>=3.3.0",
     "packaging",
     "scikit-image",
-    #"tomophantom==2.0.0", # [linux] # missing from PyPI
     "unittest-parametrize",
     "wget",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,11 @@ dependencies = [
     "zenodo_get>=1.6",
 ]
 [project.optional-dependencies]
+gpu = [
+    "astra-toolbox>=1.9.9.dev5,<=2.1", # [not osx]
+    #"tigre>=2.4,<=2.6", # missing from PyPI
+]
+[dependency-groups]
 test = [
     #"ccpi-regulariser=24.0.1", # [not osx] # missing from PyPI
     "matplotlib>=3.3.0",
@@ -67,10 +72,23 @@ test = [
     "unittest-parametrize",
     "wget",
 ]
-gpu = [
-    "astra-toolbox>=1.9.9.dev5,<=2.1", # [not osx]
-    #"tigre>=2.4,<=2.6", # missing from PyPI
-]
 test-linux = [
     "cvxpy",
+    {include-group = "test"},
+]
+docs = [
+  "jinja2",
+  #"pydata-sphinx-theme",
+  "recommonmark",
+  "sphinx",
+  "sphinx_rtd_theme",
+  "sphinx-autobuild",
+  "sphinx-click",
+  "sphinx-copybutton",
+  "sphinx-panels",
+  "sphinxcontrib-bibtex",
+  "nbsphinx",
+  "sphinx-gallery",
+  "sphinx-copybutton",
+  "notebook",
 ]


### PR DESCRIPTION
TL;DR: moving towards being able to `pip install cil[gpu]`, [`pip install . --group test`](https://github.com/pypa/pip/pull/13065), etc.

- fixes #2116
  + fixes #2074 (related: #2104)
- closes #2117
- part of #1875
- related to #1961
- related to #2090
- depends on https://github.com/pypa/pip/pull/13065 being released in `pip>25.0.1`

## Testing

1. setup a CIL build environment normally [as per the current README](https://github.com/TomographicImaging/CIL?tab=readme-ov-file#build-dependencies)
2. `pip install "cil[gpu]@git+https://github.com/TomographicImaging/CIL@pyproject-deps"` should say "Requirement already satisfied" for everything.

## Documentation

This PR is a stepping stone (and also will only become fully useful after the next `pip` release). Docs will be tackled later in #1875.