### PR TITLE
Sampler: rename "get_samples" to "view_samples"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
       - Added option for a random seed in the power method in the linear operator (#1585)
       - Improved efficiency of `Normaliser` processor. Reduced memory use and increased speed (#2111)
       - Extra functionality for sampler: `get_previous_samples()` and `get_current_sample()` (#2079)
+      - Renamed Sampler's `get_samples` to `view_samples` (deprecating `get_samples`) #2128 
   - Testing
       - Developers can now add `#all-tests` to their commit message on a PR to run the full matrix of GitHub actions tests (#2081)
       - Added tests for ProjectionOperator inputs that use `unittest-parametrize` module (#1990)

--- a/Wrappers/Python/cil/optimisation/utilities/sampler.py
+++ b/Wrappers/Python/cil/optimisation/utilities/sampler.py
@@ -20,6 +20,7 @@ import math
 from functools import partial
 import time
 import numbers
+from warnings import warn 
 
 class Sampler():
     # TODO: Work out how to make the examples testable
@@ -53,7 +54,7 @@ class Sampler():
     Example
     -------
     >>> sampler = Sampler.random_with_replacement(5)
-    >>> print(sampler.get_samples(20))
+    >>> print(sampler.view_samples(20))
     [3 4 0 0 2 3 3 2 2 1 1 4 4 3 0 2 4 4 2 4]
     >>> print(next(sampler))
     3
@@ -69,7 +70,7 @@ class Sampler():
     0
     >>> print(sampler.next())
     4
-    >>> print(sampler.get_samples(5))
+    >>> print(sampler.view_samples(5))
     [ 0  4  8 12 16]
     >>> print(sampler.get_previous_samples())
     [0 4]
@@ -79,7 +80,7 @@ class Sampler():
     >>> sampler = Sampler.sequential(10)
     >>> print(sampler.get_previous_samples())
     []
-    >>> print(sampler.get_samples(5))
+    >>> print(sampler.view_samples(5))
     [0 1 2 3 4]
     >>> print(next(sampler))
     0
@@ -93,7 +94,7 @@ class Sampler():
     Example
     -------
     >>> sampler = Sampler.herman_meyer(12)
-    >>> print(sampler.get_samples(16))
+    >>> print(sampler.view_samples(16))
     [ 0  6  3  9  1  7  4 10  2  8  5 11  0  6  3  9]
 
 
@@ -108,7 +109,7 @@ class Sampler():
     >>>     return (iteration_number+1)%10
     >>>
     >>> sampler = Sampler.from_function(num_indices=num_indices, function=my_sampling_function)
-    >>> print(list(sampler.get_samples(25)))
+    >>> print(list(sampler.view_samples(25)))
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5]
 
 
@@ -175,8 +176,13 @@ class Sampler():
 
     def __next__(self):
         return self.next()
+    
+    def get_samples(self, num_samples):
+        
+        warn("use 'view_samples' instead of 'get_samples'", DeprecationWarning, stacklevel=2)
+        return self.view_samples(num_samples)
 
-    def get_samples(self,  num_samples):
+    def view_samples(self,  num_samples):
         """
         Generates a numpy array of the first num_samples output by the sampler. Calling this does not increment the sampler index or affect the behaviour of the sampler .
 
@@ -211,7 +217,7 @@ class Sampler():
             A list of the samples outputted by the sampler since it was initialised
         """
 
-        return self.get_samples(self._iteration_number)
+        return self.view_samples(self._iteration_number)
     
     def get_current_sample(self):
         """
@@ -253,7 +259,7 @@ class Sampler():
         Example
         -------
         >>> sampler = Sampler.sequential(10)
-        >>> print(sampler.get_samples(5))
+        >>> print(sampler.view_samples(5))
         [0 1 2 3 4]
         >>> print(next(sampler))
         0
@@ -333,7 +339,7 @@ class Sampler():
         0
         >>> print(sampler.next())
         4
-        >>> print(sampler.get_samples(5))
+        >>> print(sampler.view_samples(5))
         [ 0  4  8 12 16]
         >>> print(sampler.get_previous_samples())
         [0 4]
@@ -345,7 +351,7 @@ class Sampler():
         0
         >>> print(sampler.next())
         8
-        >>> print(sampler.get_samples(10))
+        >>> print(sampler.view_samples(10))
         [ 0  8  16 1 9 2 10 3 11 4]
         >>> print(sampler.get_previous_samples())
         [0 8]
@@ -387,7 +393,7 @@ class Sampler():
         Example
         -------
         >>> sampler = Sampler.random_with_replacement(5)
-        >>> print(sampler.get_samples(10))
+        >>> print(sampler.view_samples(10))
         [3 4 0 0 2 3 3 2 2 1]
         >>> print(next(sampler))
         3
@@ -399,7 +405,7 @@ class Sampler():
         Example
         -------
         >>> sampler = Sampler.random_with_replacement(num_indices=4, prob=[0.7,0.1,0.1,0.1])
-        >>> print(sampler.get_samples(10))
+        >>> print(sampler.view_samples(10))
         [0 1 3 0 0 3 0 0 0 0]
         >>> print(sampler.get_previous_samples())
         []
@@ -435,7 +441,7 @@ class Sampler():
         Example
         -------
         >>> sampler=Sampler.randomWithoutReplacement(num_indices=7, seed=1)
-        >>> print(sampler.get_samples(16))
+        >>> print(sampler.view_samples(16))
         [6 2 1 0 4 3 5 1 0 4 2 5 6 3 3 2]
 
         """
@@ -480,7 +486,7 @@ class Sampler():
         >>>     return 2
         >>>
         >>> sampler = Sampler.from_function(num_indices=num_indices, function=my_sampling_function, prob_weights=[0, 0, 1])
-        >>> print(list(sampler.get_samples(12)))
+        >>> print(list(sampler.view_samples(12)))
         [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
 
 
@@ -494,7 +500,7 @@ class Sampler():
         >>>     return (iteration_number+1)%10
         >>>
         >>> sampler = Sampler.from_function(num_indices=num_indices, function=my_sampling_function)
-        >>> print(list(sampler.get_samples(25)))
+        >>> print(list(sampler.view_samples(25)))
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5]
 
 
@@ -510,7 +516,7 @@ class Sampler():
         >>>    return(custom_list[iteration_number%len(custom_list)])
         >>>
         >>> sampler = Sampler.from_function(num_indices=num_indices, function=my_sampling_function, prob_weights=[0.6, 0.1, 0.1, 0.1, 0.1, 0.0])
-        >>> print(list(sampler.get_samples(25)))
+        >>> print(list(sampler.view_samples(25)))
         [0, 0, 0, 0, 0, 0, 3, 2, 1, 4, 0, 0, 0, 0, 0, 0, 3, 2, 1, 4, 0, 0, 0, 0, 0]
         >>> print(sampler)
         Sampler that wraps a function that takes an iteration number and selects from a list of indices {0, 1, …, N-1}, where N is the number of indices.
@@ -629,7 +635,7 @@ class Sampler():
         Example
         -------
         >>> sampler=Sampler.herman_meyer(12)
-        >>> print(sampler.get_samples(16))
+        >>> print(sampler.view_samples(16))
         [ 0  6  3  9  1  7  4 10  2  8  5 11  0  6  3  9]
         """
 
@@ -702,13 +708,13 @@ class SamplerRandom(Sampler):
     Example
     -------
     >>> sampler = Sampler.random_with_replacement(5)
-    >>> print(sampler.get_samples(20))
+    >>> print(sampler.view_samples(20))
     [3 4 0 0 2 3 3 2 2 1 1 4 4 3 0 2 4 4 2 4]
 
     Example
     -------
     >>> sampler=Sampler.randomWithoutReplacement(num_indices=7, seed=1)
-    >>> print(sampler.get_samples(16))
+    >>> print(sampler.view_samples(16))
     [6 2 1 0 4 3 5 1 0 4 2 5 6 3 3 2]
 
     """
@@ -742,8 +748,13 @@ class SamplerRandom(Sampler):
                 self._num_indices, self._num_indices, p=self._prob_weights, replace=self._replace)
         self._current_sample = self._sampling_list[location]
         return self._current_sample
+    
+    def get_samples(self, num_samples):
+        
+        warn("use 'view_samples' instead of 'get_samples'", DeprecationWarning, stacklevel=2)
+        return self.view_samples(num_samples)
 
-    def get_samples(self,  num_samples):
+    def view_samples(self,  num_samples):
         """
         Generates a list of the first num_samples output by the sampler. Calling this does not increment the sampler index or affect the behaviour of the sampler .
 

--- a/Wrappers/Python/test/test_sampler.py
+++ b/Wrappers/Python/test/test_sampler.py
@@ -107,7 +107,7 @@ class TestSamplers(CCPiTestClass):
         order = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
                  19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
         self.assertNumpyArrayEqual(sampler.get_previous_samples(), np.array([]))
-        self.assertNumpyArrayEqual(sampler.get_samples(20), np.array(
+        self.assertNumpyArrayEqual(sampler.view_samples(20), np.array(
             order)[:20])
 
         N = 25
@@ -118,8 +118,13 @@ class TestSamplers(CCPiTestClass):
         self.assertEqual(sampler._iteration_number, N)
         self.assertEqual(sampler.current_iter_number, N)
 
-        self.assertEqual(sampler.get_samples(
+        self.assertEqual(sampler.view_samples(
             550)[519], self.example_function(519))
+        
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(sampler.get_samples(
+            550)[519], self.example_function(519))
+            
         
         self.assertNumpyArrayEqual(sampler.get_previous_samples(), np.array(order[:N]))
 
@@ -132,7 +137,8 @@ class TestSamplers(CCPiTestClass):
         self.assertListEqual(sampler.prob_weights,  [1]+[0]*39)
         self.assertEqual(sampler.num_indices, 40)
         self.assertEqual(sampler._type, 'from_function')
-    def test_sequential_iterator_and_get_samples(self):
+        
+    def test_sequential_iterator_and_view_samples(self):
 
         sampler = Sampler.sequential(10)
         self.assertEqual(sampler.num_indices, 10)
@@ -140,7 +146,7 @@ class TestSamplers(CCPiTestClass):
         self.assertListEqual(sampler.prob_weights, [1/10]*10)
 
         sampler = Sampler.sequential(10)
-        self.assertNumpyArrayEqual(sampler.get_samples(20), np.array(
+        self.assertNumpyArrayEqual(sampler.view_samples(20), np.array(
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
         
         with self.assertRaises(ValueError):
@@ -154,10 +160,10 @@ class TestSamplers(CCPiTestClass):
         self.assertEqual(sampler.current_iter_number, 337)
         self.assertEqual(len(sampler.get_previous_samples()), 337)
 
-        self.assertNumpyArrayEqual(sampler.get_samples(20), np.array(
+        self.assertNumpyArrayEqual(sampler.view_samples(20), np.array(
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
 
-    def test_random_without_replacement_iterator_and_get_samples(self):
+    def test_random_without_replacement_iterator_and_view_samples(self):
 
         sampler = Sampler.random_without_replacement(8, seed=1)
         self.assertEqual(sampler.num_indices, 8)
@@ -176,7 +182,7 @@ class TestSamplers(CCPiTestClass):
         order = [2, 5, 0, 1, 4, 3, 6, 1, 6, 0, 4, 2, 3, 5, 5, 6, 2, 4, 0, 1, 3, 0,
                  2, 6, 3]
         self.assertNumpyArrayEqual(
-            sampler.get_samples(25), np.array(order[:25]))
+            sampler.view_samples(25), np.array(order[:25]))
 
         with self.assertRaises(ValueError):
             sampler.get_current_sample()
@@ -186,9 +192,13 @@ class TestSamplers(CCPiTestClass):
             self.assertEqual(sampler.get_current_sample(), order[i])
 
         self.assertNumpyArrayEqual(
+            sampler.view_samples(25), np.array(order[:25]))
+        
+        with self.assertWarns(DeprecationWarning):
+            self.assertNumpyArrayEqual(
             sampler.get_samples(25), np.array(order[:25]))
 
-    def test_herman_meyer_iterator_and_get_samples(self):
+    def test_herman_meyer_iterator_and_view_samples(self):
 
         sampler = Sampler.herman_meyer(12)
         self.assertEqual(sampler.num_indices, 12)
@@ -201,7 +211,7 @@ class TestSamplers(CCPiTestClass):
         order = [0, 6, 3, 9, 1, 7, 4, 10, 2, 8, 5,
                  11, 0, 6, 3, 9, 1, 7, 4, 10, 2, 8, 5, 11]
         self.assertNumpyArrayEqual(
-            sampler.get_samples(14), np.array(order[:14]))
+            sampler.view_samples(14), np.array(order[:14]))
 
         for i in range(25):
             self.assertEqual(sampler.current_iter_number, i)
@@ -209,12 +219,12 @@ class TestSamplers(CCPiTestClass):
             self.assertEqual(sampler.get_current_sample(), order[i % 12])
             self.assertEqual(sampler.get_current_sample(), order[i % 12])
             
-        self.assertNumpyArrayEqual(sampler.get_samples(25), sampler.get_previous_samples())
+        self.assertNumpyArrayEqual(sampler.view_samples(25), sampler.get_previous_samples())
 
         self.assertNumpyArrayEqual(
-            sampler.get_samples(14), np.array(order[:14]))
+            sampler.view_samples(14), np.array(order[:14]))
 
-    def test_random_with_replacement_iterator_and_get_samples(self):
+    def test_random_with_replacement_iterator_and_view_samples(self):
 
         sampler = Sampler.random_with_replacement(5)
         self.assertEqual(sampler.num_indices, 5)
@@ -231,7 +241,7 @@ class TestSamplers(CCPiTestClass):
         order = [1, 4, 1, 4, 2, 3, 3, 2, 1, 0, 0, 3,
                  2, 0, 4, 1, 2, 1, 3, 2, 2, 1, 1, 1, 1]
         self.assertNumpyArrayEqual(
-            sampler.get_samples(14), np.array(order[:14]))
+            sampler.view_samples(14), np.array(order[:14]))
         
         with self.assertRaises(ValueError):
             sampler.get_current_sample()
@@ -243,16 +253,16 @@ class TestSamplers(CCPiTestClass):
             self.assertEqual(sampler.current_iter_number, i+1)
 
         self.assertNumpyArrayEqual(
-            sampler.get_samples(14), np.array(order[:14]))
+            sampler.view_samples(14), np.array(order[:14]))
 
-        self.assertNumpyArrayEqual(sampler.get_samples(25), sampler.get_previous_samples())
+        self.assertNumpyArrayEqual(sampler.view_samples(25), sampler.get_previous_samples())
         
         sampler = Sampler.random_with_replacement(
             4, [0.7, 0.1, 0.1, 0.1], seed=5)
         order = [0, 2, 0, 3, 0, 0, 1, 0, 0, 0, 0, 1,
                  0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         self.assertNumpyArrayEqual(
-            sampler.get_samples(14), np.array(order[:14]))
+            sampler.view_samples(14), np.array(order[:14]))
 
         for i in range(25):
             self.assertEqual(sampler.next(), order[i])
@@ -260,12 +270,12 @@ class TestSamplers(CCPiTestClass):
             self.assertEqual(sampler.get_current_sample(), order[i])
             self.assertEqual(sampler.current_iter_number, i+1)
             
-        self.assertNumpyArrayEqual(sampler.get_samples(25), sampler.get_previous_samples())
+        self.assertNumpyArrayEqual(sampler.view_samples(25), sampler.get_previous_samples())
 
         self.assertNumpyArrayEqual(
-            sampler.get_samples(14), np.array(order[:14]))
+            sampler.view_samples(14), np.array(order[:14]))
 
-    def test_staggered_iterator_and_get_samples(self):
+    def test_staggered_iterator_and_view_samples(self):
 
         sampler = Sampler.staggered(21, 4)
         self.assertEqual(sampler.num_indices, 21)
@@ -282,7 +292,7 @@ class TestSamplers(CCPiTestClass):
         order = [0, 4, 8, 12, 16, 20, 1, 5, 9, 13,
                  17, 2, 6, 10, 14, 18, 3, 7, 11, 15, 19]
         self.assertNumpyArrayEqual(
-            sampler.get_samples(10), np.array(order[:10]))
+            sampler.view_samples(10), np.array(order[:10]))
 
         for i in range(25):
             self.assertEqual(next(sampler), order[i % 21])
@@ -291,7 +301,7 @@ class TestSamplers(CCPiTestClass):
             self.assertEqual(sampler.current_iter_number, i+1)
 
         self.assertNumpyArrayEqual(
-            sampler.get_samples(10), np.array(order[:10]))
+            sampler.view_samples(10), np.array(order[:10]))
         
-        self.assertNumpyArrayEqual(sampler.get_samples(25), sampler.get_previous_samples())
+        self.assertNumpyArrayEqual(sampler.view_samples(25), sampler.get_previous_samples())
 


### PR DESCRIPTION
## Description
- Deprecated `get_samples`
- Introduced `view_samples`
- Updated documentation and tests 

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links
Closes #2127 

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


