### PR TITLE
`DataContainer` agnostic on backend

### DIFF
--- a/Wrappers/Python/cil/framework/acquisition_data.py
+++ b/Wrappers/Python/cil/framework/acquisition_data.py
@@ -20,7 +20,8 @@ import numpy
 from .labels import AcquisitionDimension, Backend
 from .data_container import DataContainer
 from .partitioner import Partitioner
-
+import array_api_compat
+from array_api_compat import array_namespace # https://data-apis.org/array-api-compat/
 
 class AcquisitionData(DataContainer, Partitioner):
     '''DataContainer for holding 2D or 3D sinogram'''
@@ -49,7 +50,7 @@ class AcquisitionData(DataContainer, Partitioner):
                  geometry = None,
                  **kwargs):
 
-        dtype = kwargs.get('dtype', numpy.float32)
+        
 
         if geometry is None:
             raise AttributeError("AcquisitionData requires a geometry")
@@ -59,15 +60,18 @@ class AcquisitionData(DataContainer, Partitioner):
                 raise ValueError("Deprecated: 'dimension_labels' cannot be set with 'allocate()'. Use 'geometry.set_labels()' to modify the geometry before using allocate.")
 
         if array is None:
-            array = numpy.empty(geometry.shape, dtype=dtype)
+            xp = array_api_compat.numpy
+            dtype = kwargs.get('dtype', xp.float32)
+            array = xp.empty(geometry.shape, dtype=dtype)
         elif issubclass(type(array) , DataContainer):
             array = array.as_array()
-        elif issubclass(type(array) , numpy.ndarray):
-            # remove singleton dimensions
-            array = numpy.squeeze(array)
         else:
-            raise TypeError('array must be a CIL type DataContainer or numpy.ndarray got {}'.format(type(array)))
-
+            # xp = array_namespace(array)
+            # idx = numpy.where(numpy.asarray(array.shape) == 1)
+            # # remove singleton dimensions
+            # for axis in idx:    
+            #     array = xp.squeeze(array, axis=axis)
+            array = array.squeeze()
         if array.shape != geometry.shape:
             raise ValueError('Shape mismatch got {} expected {}'.format(array.shape, geometry.shape))
 

--- a/Wrappers/Python/cil/framework/acquisition_geometry.py
+++ b/Wrappers/Python/cil/framework/acquisition_geometry.py
@@ -2173,8 +2173,9 @@ class AcquisitionGeometry(object):
         :type dtype: numpy type, default numpy.float32
         '''
         dtype = kwargs.get('dtype', self.dtype)
-
-        out = AcquisitionData(geometry=self.copy(),
+        ng = self.copy()
+        ng.dtype = dtype
+        out = AcquisitionData(geometry=ng,
                               dtype=dtype,
                               suppress_warning=True)
 

--- a/Wrappers/Python/cil/framework/array_api_compat.py
+++ b/Wrappers/Python/cil/framework/array_api_compat.py
@@ -1,0 +1,64 @@
+# Updates to array API compatibility layer for CIL
+from array_api_compat import array_namespace
+
+def expand_dims(array, axis):
+    '''Expand dimensions of an array along specified axes.
+    
+    Parameters
+    ----------
+    array : array-like
+        The input array to expand.
+    axis : int or tuple of int
+        The axis or axes along which to expand the dimensions.
+        
+    Returns
+    -------
+    array-like
+        The array with expanded dimensions. It may be a new array or the same array with expanded dimensions.
+
+    Raises:
+    --------
+    IndexError If provided an invalid axis position, an IndexError should be raised.
+    
+    Notes:
+    This function recursively expands the dimensions of the input array along the specified axes if a list or tuple of ints is provided.
+    '''
+    xp = array_namespace(array)
+    
+    if isinstance(axis, int):
+        return xp.expand_dims(array, axis=axis)
+    axis = list(axis)
+    ax = axis.pop(0)
+    if len(axis) == 1:
+        axis = axis[0]
+    return expand_dims(xp.expand_dims(array, axis=ax), axis=axis)
+
+def squeeze(array, axis=None):
+    '''squeezes the array, removing all singleton dimensions recursively
+    
+    Parameters
+    ----------
+    array : array-like
+        The array to squeeze
+    axis : int or tuple of int, optional
+        The axis or axes to squeeze. If None, all singleton dimensions are removed.
+
+    Returns
+    -------
+    array-like
+        The squeezed array with all singleton dimensions removed. If the input array has no singleton dimensions, it is returned unchanged.
+    '''
+    xp = array_namespace(array)
+    # find and remove singleton dimensions
+    if axis is None:
+        s = xp.nonzero(xp.asarray(array.shape) == 1)[0]
+        axis = s.tolist()
+    if isinstance(axis, int):
+        return xp.squeeze(array, axis=axis)
+    # process from the largest axis to the smallest
+    axis = list(axis)
+    axis.sort(reverse=True)
+    ax = axis.pop(0)
+    if len(axis) == 1:
+        axis = axis[0]
+    return squeeze(xp.squeeze(array, axis=ax), axis=axis)

--- a/Wrappers/Python/cil/framework/array_api_compat.py
+++ b/Wrappers/Python/cil/framework/array_api_compat.py
@@ -74,8 +74,6 @@ def squeeze(array, axis=None):
         axis = axis[0]
     return squeeze(xp.squeeze(array, axis=ax), axis=axis)
 
-import pysnooper
-@pysnooper.snoop()
 def allclose(a, b, rtol=1e-5, atol=1e-6):
     """
     Check if two arrays are element-wise equal within a tolerance.allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False)[source]

--- a/Wrappers/Python/cil/framework/array_api_compat.py
+++ b/Wrappers/Python/cil/framework/array_api_compat.py
@@ -23,10 +23,13 @@ def expand_dims(array, axis):
     Notes:
     This function recursively expands the dimensions of the input array along the specified axes if a list or tuple of ints is provided.
     '''
+    print("axis", axis)
     xp = array_namespace(array)
     
     if isinstance(axis, int):
         return xp.expand_dims(array, axis=axis)
+    if len(axis) == 1:
+        return xp.expand_dims(array, axis=axis[0])
     axis = list(axis)
     ax = axis.pop(0)
     if len(axis) == 1:
@@ -53,8 +56,15 @@ def squeeze(array, axis=None):
     if axis is None:
         s = xp.nonzero(xp.asarray(array.shape) == 1)[0]
         axis = s.tolist()
+        if len(axis) == 1:
+            axis = axis[0]
+        elif len(axis) == 0:
+            return array
     if isinstance(axis, int):
         return xp.squeeze(array, axis=axis)
+    if len(axis) == 1:
+        return xp.squeeze(array, axis=axis[0])
+    
     # process from the largest axis to the smallest
     axis = list(axis)
     axis.sort(reverse=True)

--- a/Wrappers/Python/cil/framework/array_api_compat.py
+++ b/Wrappers/Python/cil/framework/array_api_compat.py
@@ -23,7 +23,6 @@ def expand_dims(array, axis):
     Notes:
     This function recursively expands the dimensions of the input array along the specified axes if a list or tuple of ints is provided.
     '''
-    print("axis", axis)
     xp = array_namespace(array)
     
     if isinstance(axis, int):
@@ -59,6 +58,7 @@ def squeeze(array, axis=None):
         if len(axis) == 1:
             axis = axis[0]
         elif len(axis) == 0:
+            # nothing to do
             return array
     if isinstance(axis, int):
         return xp.squeeze(array, axis=axis)

--- a/Wrappers/Python/cil/framework/array_api_compat.py
+++ b/Wrappers/Python/cil/framework/array_api_compat.py
@@ -1,5 +1,6 @@
 # Updates to array API compatibility layer for CIL
 from array_api_compat import array_namespace
+import sys
 
 def expand_dims(array, axis):
     '''Expand dimensions of an array along specified axes.
@@ -93,3 +94,25 @@ The relative difference (rtol * abs(b)) and the absolute difference atol are add
         print(f"Max difference: {diff.max()}")
         return False
     return True
+
+def dtype_namespace(dtype):
+    """
+    Get the namespace of a given dtype.
+    
+    Parameters
+    ----------
+    dtype : data-type
+        The data type to check.
+        
+    Returns
+    -------
+    str
+        The namespace of the dtype.
+        
+    Raises
+    ------
+    TypeError
+        If the dtype is not recognized.
+    """
+    xp = sys.modules[dtype.__module__]
+    return xp

--- a/Wrappers/Python/cil/framework/array_api_compat.py
+++ b/Wrappers/Python/cil/framework/array_api_compat.py
@@ -72,3 +72,24 @@ def squeeze(array, axis=None):
     if len(axis) == 1:
         axis = axis[0]
     return squeeze(xp.squeeze(array, axis=ax), axis=axis)
+
+import pysnooper
+@pysnooper.snoop()
+def allclose(a, b, rtol=1e-5, atol=1e-6):
+    """
+    Check if two arrays are element-wise equal within a tolerance.allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False)[source]
+Returns True if two arrays are element-wise equal within a tolerance.
+
+The tolerance values are positive, typically very small numbers. 
+The relative difference (rtol * abs(b)) and the absolute difference atol are added together to compare against the absolute difference between a and b.
+    """
+    xp = array_namespace(a.as_array())
+    if array_namespace(b.as_array()) != xp:
+        raise TypeError('Can only compare arrays ' \
+        'with same namespace. Got {} and {}'.format(array_namespace(a), array_namespace(b)))
+    
+    diff = rtol * xp.abs(b) + atol
+    if xp.any(diff < xp.abs(a - b)):
+        print(f"Max difference: {diff.max()}")
+        return False
+    return True

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -22,6 +22,7 @@ from functools import reduce
 from numbers import Number
 
 import numpy
+from array_api_compat import array_namespace
 
 from .cilacc import cilacc
 from cil.utilities.multiprocessing import NUM_THREADS
@@ -94,14 +95,16 @@ class DataContainer(object):
     def __init__ (self, array, deep_copy=True, dimension_labels=None,
                   **kwargs):
         #if type(array) == numpy.ndarray:
-        if hasattr(array, "__array_interface__"):
-            if deep_copy:
-                self.array = array.copy()
-            else:
-                self.array = array
+        # if hasattr(array, "__array_interface__"):
+        if deep_copy:
+            # self.array = array.copy()
+            xp = array_namespace(array)
+            self.array = xp.asarray(array, copy=True)
         else:
-            raise TypeError('Array must be adhere to the array interface protocol {0}'\
-                            .format(type(array)))
+            self.array = array
+        # else:
+        #     raise TypeError('Array must be adhere to the array interface protocol {0}'\
+        #                     .format(type(array)))
 
         #Don't set for derived classes
         if type(self) is DataContainer:

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -93,13 +93,14 @@ class DataContainer(object):
     __container_priority__ = 1
     def __init__ (self, array, deep_copy=True, dimension_labels=None,
                   **kwargs):
-        if type(array) == numpy.ndarray:
+        #if type(array) == numpy.ndarray:
+        if hasattr(array, "__array_interface__"):
             if deep_copy:
                 self.array = array.copy()
             else:
                 self.array = array
         else:
-            raise TypeError('Array must be NumpyArray, passed {0}'\
+            raise TypeError('Array must be adhere to the array interface protocol {0}'\
                             .format(type(array)))
 
         #Don't set for derived classes

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -266,8 +266,11 @@ class DataContainer(object):
                                      self.shape,array.shape))
             else:
                 # raise TypeError('Can fill only with number, numpy array or DataContainer and subclasses. Got {}'.format(type(array)))
+                import warnings
+                warnings.filterwarnings('error')
                 xp = array_namespace(self.as_array())
                 self.array.__setitem__(slice(None, None, None), array)
+                warnings.resetwarnings()
         else:
             slices = []
             where = 0

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -27,6 +27,23 @@ from array_api_compat import array_namespace
 from .cilacc import cilacc
 from cil.utilities.multiprocessing import NUM_THREADS
 
+def squeeze_array(array):
+    '''squeezes the array, removing all singleton dimensions recursively
+    
+    Parameters
+    ----------
+    array : array-like
+        The array to squeeze
+    '''
+    xp = array_namespace(array)
+    # find and remove singleton dimensions
+    s = xp.nonzero(xp.asarray(array.shape) == 1)[0]
+    singletons = s.tolist()
+    if len(singletons) > 1:
+        # remove singleton dimension recursively
+        return squeeze_array(xp.squeeze(array, axis=singletons[0]))
+    return array
+
 
 class DataContainer(object):
     '''Generic class to hold data

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -185,7 +185,6 @@ class DataContainer(object):
                     new_array = self.as_array()
                 new_array = new_array.take(indices=value, axis=axis)
 
-        print ("new_array.shape", new_array.shape)
         # xp = array_namespace(new_array)
         # new_array = xp.squeeze(new_array, axis=tuple(squeeze_axes))
         if new_array.ndim > 1:

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -490,7 +490,6 @@ class DataContainer(object):
         xp = array_namespace(self.array)
         return self.pixel_wise_binary(xp.minimum, x2=x2, out=out, *args, **kwargs)
 
-
     def sapyb(self, a, y, b, out=None, num_threads=NUM_THREADS):
         '''performs a*self + b * y. Can be done in-place
 

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -414,10 +414,8 @@ class DataContainer(object):
                 out = pwop(self.as_array() , x2 , *args, **kwargs )
             elif issubclass(x2.__class__ , DataContainer):
                 out = pwop(self.as_array() , x2.as_array() , *args, **kwargs )
-            elif isinstance(x2, numpy.ndarray):
-                out = pwop(self.as_array() , x2 , *args, **kwargs )
             else:
-                raise TypeError('Expected x2 type as number or DataContainer, got {}'.format(type(x2)))
+                out = pwop(self.as_array() , x2 , *args, **kwargs )
             geom = self.geometry
             if geom is not None:
                 geom = self.geometry.copy()
@@ -438,17 +436,12 @@ class DataContainer(object):
                 #       geometry=self.geometry)
                 return out
             raise ValueError(f"Wrong size for data memory: out {out.shape} x2 {x2.shape} expected {self.shape}")
-        elif issubclass(type(out), DataContainer) and \
-             isinstance(x2, (Number, numpy.ndarray)):
-            if self.check_dimensions(out):
-                if isinstance(x2, numpy.ndarray) and\
-                    not (x2.shape == self.shape and x2.dtype == self.dtype):
-                    raise ValueError(f"Wrong size for data memory: out {out.shape} x2 {x2.shape} expected {self.shape}")
+        elif issubclass(type(out), DataContainer) and self.check_dimensions(out):
                 kwargs['out']=out.as_array()
                 pwop(self.as_array(), x2, *args, **kwargs )
                 return out
-            raise ValueError(f"Wrong size for data memory: {out.shape} {self.shape}")
-        elif issubclass(type(out), numpy.ndarray):
+        # elif issubclass(type(out), numpy.ndarray):
+        else:
             if self.array.shape == out.shape and self.array.dtype == out.dtype:
                 kwargs['out'] = out
                 pwop(self.as_array(), x2, *args, **kwargs)
@@ -456,41 +449,48 @@ class DataContainer(object):
                 #       deep_copy=False,
                 #       dimension_labels=self.dimension_labels,
                 #       geometry=self.geometry)
-        else:
-            raise ValueError(f"incompatible class: {pwop.__name__} {type(out)}")
+        # else:
+        #     raise ValueError(f"incompatible class: {pwop.__name__} {type(out)}")
 
     def add(self, other, *args, **kwargs):
         if hasattr(other, '__container_priority__') and \
            self.__class__.__container_priority__ < other.__class__.__container_priority__:
             return other.add(self, *args, **kwargs)
-        return self.pixel_wise_binary(numpy.add, other, *args, **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_binary(xp.add, other, *args, **kwargs)
 
     def subtract(self, other, *args, **kwargs):
         if hasattr(other, '__container_priority__') and \
            self.__class__.__container_priority__ < other.__class__.__container_priority__:
             return other.subtract(self, *args, **kwargs)
-        return self.pixel_wise_binary(numpy.subtract, other, *args, **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_binary(xp.subtract, other, *args, **kwargs)
 
     def multiply(self, other, *args, **kwargs):
         if hasattr(other, '__container_priority__') and \
            self.__class__.__container_priority__ < other.__class__.__container_priority__:
             return other.multiply(self, *args, **kwargs)
-        return self.pixel_wise_binary(numpy.multiply, other, *args, **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_binary(xp.multiply, other, *args, **kwargs)
 
     def divide(self, other, *args, **kwargs):
         if hasattr(other, '__container_priority__') and \
            self.__class__.__container_priority__ < other.__class__.__container_priority__:
             return other.divide(self, *args, **kwargs)
-        return self.pixel_wise_binary(numpy.divide, other, *args, **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_binary(xp.divide, other, *args, **kwargs)
 
     def power(self, other, *args, **kwargs):
-        return self.pixel_wise_binary(numpy.power, other, *args, **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_binary(xp.power, other, *args, **kwargs)
 
     def maximum(self, x2, *args, **kwargs):
-        return self.pixel_wise_binary(numpy.maximum, x2, *args, **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_binary(xp.maximum, x2, *args, **kwargs)
 
     def minimum(self,x2, out=None, *args, **kwargs):
-        return self.pixel_wise_binary(numpy.minimum, x2=x2, out=out, *args, **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_binary(xp.minimum, x2=x2, out=out, *args, **kwargs)
 
 
     def sapyb(self, a, y, b, out=None, num_threads=NUM_THREADS):
@@ -658,32 +658,39 @@ class DataContainer(object):
                 pwop(self.as_array(), *args, **kwargs )
             else:
                 raise ValueError(f"Wrong size for data memory: {out.shape} {self.shape}")
-        elif issubclass(type(out), numpy.ndarray):
+        # elif issubclass(type(out), numpy.ndarray):
+        else:
             if self.array.shape == out.shape and self.array.dtype == out.dtype:
                 kwargs['out'] = out
                 pwop(self.as_array(), *args, **kwargs)
-        else:
-            raise ValueError("incompatible class: {pwop.__name__} {type(out)}")
+        # else:
+        #     raise ValueError("incompatible class: {pwop.__name__} {type(out)}")
 
     def abs(self, *args,  **kwargs):
-        return self.pixel_wise_unary(numpy.abs, *args,  **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_unary(xp.abs, *args,  **kwargs)
 
     def sign(self, *args,  **kwargs):
-        return self.pixel_wise_unary(numpy.sign, *args,  **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_unary(xp.sign, *args,  **kwargs)
 
     def sqrt(self, *args,  **kwargs):
-        return self.pixel_wise_unary(numpy.sqrt, *args,  **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_unary(xp.sqrt, *args,  **kwargs)
 
     def conjugate(self, *args,  **kwargs):
-        return self.pixel_wise_unary(numpy.conjugate, *args,  **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_unary(xp.conjugate, *args,  **kwargs)
 
     def exp(self, *args, **kwargs):
         '''Applies exp pixel-wise to the DataContainer'''
-        return self.pixel_wise_unary(numpy.exp, *args, **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_unary(xp.exp, *args, **kwargs)
 
     def log(self, *args, **kwargs):
         '''Applies log pixel-wise to the DataContainer'''
-        return self.pixel_wise_unary(numpy.log, *args, **kwargs)
+        xp = array_namespace(self.array)
+        return self.pixel_wise_unary(xp.log, *args, **kwargs)
 
     ## reductions
     def squared_norm(self, **kwargs):

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -260,15 +260,14 @@ class DataContainer(object):
             self.array.__setitem__(slice(None, None, None), array)
             warnings.resetwarnings()
         else:
-            slices = []
-            where = [] * self.number_of_dimensions
+            slices = [slice(None, None, None)] * self.number_of_dimensions
+            where = []
             for i,el in enumerate(self.dimension_labels):
                 for k,v in dimension.items():
                     if el == k:
-                        slices.append(slice(v,v+1,None))
-                        where[i] = 1
-                    else:
-                        slices.append(slice(None, None, None))
+                        slices[i] = slice(v,v+1,None)
+                        where.append(i)
+
             # give new shape to the array to insert so that it fits
             # the shape of the target data
             try:

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -480,7 +480,11 @@ class DataContainer(object):
 
     def maximum(self, x2, *args, **kwargs):
         xp = array_namespace(self.array)
-        return self.pixel_wise_binary(xp.maximum, x2, *args, **kwargs)
+        try:
+            return self.pixel_wise_binary(xp.maximum, x2, *args, **kwargs)
+        except TypeError as te:
+            tmp = xp.ones_like(self.as_array()) * x2
+            return self.pixel_wise_binary(xp.maximum, tmp, *args, **kwargs)
 
     def minimum(self,x2, out=None, *args, **kwargs):
         xp = array_namespace(self.array)
@@ -693,7 +697,12 @@ class DataContainer(object):
 
     def conjugate(self, *args,  **kwargs):
         xp = array_namespace(self.array)
-        return self.pixel_wise_unary(xp.conjugate, *args,  **kwargs)
+        try:
+            return self.pixel_wise_unary(xp.conjugate, *args,  **kwargs)
+        except AttributeError:
+            # torch has conj instead
+            import torch
+            return torch.conj(self.as_array())
 
     def exp(self, *args, **kwargs):
         '''Applies exp pixel-wise to the DataContainer'''

--- a/Wrappers/Python/cil/framework/image_data.py
+++ b/Wrappers/Python/cil/framework/image_data.py
@@ -17,7 +17,8 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 import numpy as np
 
-from .data_container import DataContainer, squeeze_array
+from .data_container import DataContainer
+from .array_api_compat import squeeze as cil_squeeze 
 from .labels import ImageDimension, Backend
 
 from array_api_compat import array_namespace # https://data-apis.org/array-api-compat/
@@ -61,7 +62,7 @@ class ImageData(DataContainer):
         elif issubclass(type(array) , DataContainer):
             # this is a reference so we might make a mess modifying both ends
             array = array.as_array()
-            xp = array_namespace(array)
+            array = cil_squeeze(array)
         # elif issubclass(type(array) , np.ndarray):
             # remove singleton dimensions
             # array = np.squeeze(array)
@@ -69,7 +70,7 @@ class ImageData(DataContainer):
             # Consider array as an object is compliant to the array API
             # https://docs.scipy.org/doc/scipy-1.15.2/dev/api-dev/array_api.html 
             # this might raise an exception but that's fine
-            array = squeeze_array(array)
+            array = cil_squeeze(array)
         # else:
         #     raise TypeError('array must be a CIL type DataContainer or np.ndarray got {}'.format(type(array)))
 

--- a/Wrappers/Python/cil/framework/image_data.py
+++ b/Wrappers/Python/cil/framework/image_data.py
@@ -17,7 +17,7 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 import numpy as np
 
-from .data_container import DataContainer
+from .data_container import DataContainer, squeeze_array
 from .labels import ImageDimension, Backend
 
 from array_api_compat import array_namespace # https://data-apis.org/array-api-compat/
@@ -69,10 +69,7 @@ class ImageData(DataContainer):
             # Consider array as an object is compliant to the array API
             # https://docs.scipy.org/doc/scipy-1.15.2/dev/api-dev/array_api.html 
             # this might raise an exception but that's fine
-            xp = array_namespace(array)
-            # remove singleton dimensions
-            array = xp.squeeze(array)
-            
+            array = squeeze_array(array)
         # else:
         #     raise TypeError('array must be a CIL type DataContainer or np.ndarray got {}'.format(type(array)))
 

--- a/Wrappers/Python/cil/framework/image_data.py
+++ b/Wrappers/Python/cil/framework/image_data.py
@@ -113,8 +113,9 @@ class ImageData(DataContainer):
     def __eq__(self, other):
         '''
         Check if two ImageData objects are equal. This is done by checking if the geometry, data and dtype are equal.
-        Also, if the other object is a np.ndarray, it will check if the data and dtype are equal.
-        
+        Also, if the other object is a ndarray, it will check if the data and dtype are equal.
+        This will check equality as numpy allclose.
+
         Parameters
         ----------
         other: ImageData or np.ndarray
@@ -124,14 +125,17 @@ class ImageData(DataContainer):
         -------
         bool
             True if the two objects are equal, False otherwise.
-        '''
-
+        ''' 
+        from .array_api_compat import allclose as cil_allclose
         if isinstance(other, ImageData):
-            if np.array_equal(self.as_array(), other.as_array()) \
-                and self.geometry == other.geometry \
-                and self.dtype == other.dtype:
+            xp = array_namespace(self.array)
+            if self.geometry == other.geometry \
+                and self.dtype == other.dtype \
+                and self.shape == other.shape \
+                and cil_allclose(self.as_array(), other.as_array()):
                 return True 
-        elif np.array_equal(self.as_array(), other) and self.dtype==other.dtype:
+            return False
+        elif self.dtype==other.dtype and cil_allclose(self.as_array(), other):
             return True
         else:
             return False

--- a/Wrappers/Python/cil/framework/image_data.py
+++ b/Wrappers/Python/cil/framework/image_data.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from .data_container import DataContainer
 from .array_api_compat import squeeze as cil_squeeze 
+from .array_api_compat import dtype_namespace
 from .labels import ImageDimension, Backend
 
 from array_api_compat import array_namespace # https://data-apis.org/array-api-compat/
@@ -61,7 +62,7 @@ class ImageData(DataContainer):
     def dimension_labels(self, val):
         if val is not None:
             raise ValueError("Unable to set the dimension_labels directly. Use geometry.set_labels() instead")
-
+    
     def __init__(self,
                  array = None,
                  deep_copy=False,
@@ -75,9 +76,15 @@ class ImageData(DataContainer):
                     raise TypeError('dtype must match the array dtype got {} expected {}'.format(dtype, array.dtype))
         # TODO: change
         if array is None:
-            # defaults to a np array
-            xp = np
-            dtype = kwargs.get('dtype', xp.float32)
+            dtype = kwargs.get('dtype', None)
+            if dtype is not None:
+                # tries to infer the namespace from the dtype
+                xp = dtype_namespace(dtype)
+            else:
+                # defaults to a np array
+                xp = np
+                dtype = np.float32
+                
             array = xp.empty(geometry.shape, dtype=dtype)
         elif issubclass(type(array) , DataContainer):
             # this is a reference so we might make a mess modifying both ends

--- a/Wrappers/Python/cil/framework/image_geometry.py
+++ b/Wrappers/Python/cil/framework/image_geometry.py
@@ -262,8 +262,9 @@ class ImageGeometry:
 
         if kwargs.get('dimension_labels', None) is not None:
             raise ValueError("Deprecated: 'dimension_labels' cannot be set with 'allocate()'. Use 'geometry.set_labels()' to modify the geometry before using allocate.")
-
-        out = ImageData(geometry=self.copy(),
+        ng = self.copy()
+        ng.dtype = dtype
+        out = ImageData(geometry=ng,
                             dtype=dtype,
                             suppress_warning=True)
 

--- a/Wrappers/Python/cil/framework/image_geometry.py
+++ b/Wrappers/Python/cil/framework/image_geometry.py
@@ -270,7 +270,7 @@ class ImageGeometry:
 
         if isinstance(value, Number):
             # it's created empty, so we make it 0
-            out.array.fill(value)
+            out.fill(value)
         elif value in FillType:
             if value == FillType.RANDOM:
                 seed = kwargs.get('seed', None)

--- a/Wrappers/Python/cil/optimisation/functions/IndicatorBox.py
+++ b/Wrappers/Python/cil/optimisation/functions/IndicatorBox.py
@@ -21,6 +21,7 @@ import numpy as np
 import numba
 from cil.utilities import multiprocessing as cil_mp
 import logging
+from array_api_compat import array_namespace
 
 log = logging.getLogger(__name__)
 
@@ -278,11 +279,12 @@ class IndicatorBox_numpy(IndicatorBox):
     def evaluate(self, x):
         '''Evaluates IndicatorBox at x'''
 
-        if (np.all(x.as_array() >= self.lower)
-                and np.all(x.as_array() <= self.upper)):
+        xp = array_namespace(x.as_array())
+        if (xp.all(x.as_array() >= self.lower)
+                and xp.all(x.as_array() <= self.upper)):
             val = 0
         else:
-            val = np.inf
+            val = xp.inf
         return val
 
     def convex_conjugate(self, x):
@@ -290,7 +292,8 @@ class IndicatorBox_numpy(IndicatorBox):
         return x.maximum(0).sum()
 
     def _proximal(self, outarr):
-        np.clip(outarr,
+        xp = array_namespace(outarr)
+        xp.clip(outarr,
                 None if self.orig_lower is None else self.lower,
                 None if self.orig_upper is None else self.upper,
                 out=outarr)

--- a/Wrappers/Python/cil/optimisation/functions/TotalVariation.py
+++ b/Wrappers/Python/cil/optimisation/functions/TotalVariation.py
@@ -271,7 +271,7 @@ class TotalVariation(Function):
             tau *= strongly_convex_factor
 
         return solution
-
+    
     def _fista_on_dual_rof(self, x, tau, out=None):
         r""" Runs the Fast Gradient Projection (FGP) algorithm to solve the dual problem
         of the Total Variation Denoising problem (ROF).
@@ -306,7 +306,10 @@ class TotalVariation(Function):
             tau.multiply(-self.regularisation_parameter, out=tau_reg_neg)
 
         if out is None:
-            out = self.gradient_operator.domain_geometry().allocate(0)
+            # out = self.gradient_operator.domain_geometry().allocate(0)
+            from cil.framework import ImageData
+            import cupy as cp
+            out = ImageData(cp.empty(x.shape, dtype=cp.float32), geometry=self.gradient_operator.domain_geometry().copy(), dtype=cp.float32)
 
         for k in range(self.iterations):
 

--- a/Wrappers/Python/cil/optimisation/functions/TotalVariation.py
+++ b/Wrappers/Python/cil/optimisation/functions/TotalVariation.py
@@ -163,7 +163,8 @@ class TotalVariation(Function):
                  isotropic=True,
                  split=False,
                  strong_convexity_constant=0,
-                 warm_start=True):
+                 warm_start=True, 
+                 indicator_accelerated=False):
 
         super(TotalVariation, self).__init__(L=None)
 
@@ -188,7 +189,7 @@ class TotalVariation(Function):
             upper = np.inf
         self.lower = lower
         self.upper = upper
-        self.projection_C = IndicatorBox(lower, upper).proximal
+        self.projection_C = IndicatorBox(lower, upper, accelerated=indicator_accelerated).proximal
 
         # Setup GradientOperator as None. This is to avoid domain argument in the __init__
         self._gradient = None

--- a/Wrappers/Python/cil/optimisation/operators/FiniteDifferenceOperator.py
+++ b/Wrappers/Python/cil/optimisation/operators/FiniteDifferenceOperator.py
@@ -21,6 +21,8 @@ import numpy as np
 from cil.optimisation.operators import LinearOperator
 from cil.utilities.errors import InPlaceError
 
+from array_api_compat import array_namespace
+
 class FiniteDifferenceOperator(LinearOperator):
 
     r'''
@@ -90,6 +92,7 @@ class FiniteDifferenceOperator(LinearOperator):
             raise InPlaceError(message="FiniteDifferenceOperator.direct cannot be used in place")
 
         x_asarr = x.as_array()
+        xp = array_namespace(x_asarr)
 
         outnone = False
         if out is None:
@@ -107,14 +110,14 @@ class FiniteDifferenceOperator(LinearOperator):
         if self.method == 'forward':
 
             # interior nodes
-            np.subtract( x_asarr[tuple(self.get_slice(2, None))], \
+            xp.subtract( x_asarr[tuple(self.get_slice(2, None))], \
                              x_asarr[tuple(self.get_slice(1,-1))], \
                              out = outa[tuple(self.get_slice(1, -1))])
 
             if self.boundary_condition == 'Neumann':
 
                 # left boundary
-                np.subtract(x_asarr[tuple(self.get_slice(1,2))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(1,2))],\
                             x_asarr[tuple(self.get_slice(0,1))],
                             out = outa[tuple(self.get_slice(0,1))])
 
@@ -122,12 +125,12 @@ class FiniteDifferenceOperator(LinearOperator):
             elif self.boundary_condition == 'Periodic':
 
                 # left boundary
-                np.subtract(x_asarr[tuple(self.get_slice(1,2))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(1,2))],\
                             x_asarr[tuple(self.get_slice(0,1))],
                             out = outa[tuple(self.get_slice(0,1))])
 
                 # right boundary
-                np.subtract(x_asarr[tuple(self.get_slice(0,1))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(0,1))],\
                             x_asarr[tuple(self.get_slice(-1,None))],
                             out = outa[tuple(self.get_slice(-1,None))])
 
@@ -141,26 +144,26 @@ class FiniteDifferenceOperator(LinearOperator):
         elif self.method == 'backward':
 
             # interior nodes
-            np.subtract( x_asarr[tuple(self.get_slice(1, -1))], \
+            xp.subtract( x_asarr[tuple(self.get_slice(1, -1))], \
                              x_asarr[tuple(self.get_slice(0,-2))], \
                              out = outa[tuple(self.get_slice(1, -1))])
 
             if self.boundary_condition == 'Neumann':
 
                     # right boundary
-                    np.subtract( x_asarr[tuple(self.get_slice(-1, None))], \
+                    xp.subtract( x_asarr[tuple(self.get_slice(-1, None))], \
                                  x_asarr[tuple(self.get_slice(-2,-1))], \
                                  out = outa[tuple(self.get_slice(-1, None))])
 
             elif self.boundary_condition == 'Periodic':
 
                 # left boundary
-                np.subtract(x_asarr[tuple(self.get_slice(0,1))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(0,1))],\
                             x_asarr[tuple(self.get_slice(-1,None))],
                             out = outa[tuple(self.get_slice(0,1))])
 
                 # right boundary
-                np.subtract(x_asarr[tuple(self.get_slice(-1,None))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(-1,None))],\
                             x_asarr[tuple(self.get_slice(-2,-1))],
                             out = outa[tuple(self.get_slice(-1,None))])
 
@@ -175,7 +178,7 @@ class FiniteDifferenceOperator(LinearOperator):
         elif self.method == 'centered':
 
             # interior nodes
-            np.subtract( x_asarr[tuple(self.get_slice(2, None))], \
+            xp.subtract( x_asarr[tuple(self.get_slice(2, None))], \
                              x_asarr[tuple(self.get_slice(0,-2))], \
                              out = outa[tuple(self.get_slice(1, -1))])
 
@@ -184,13 +187,13 @@ class FiniteDifferenceOperator(LinearOperator):
             if self.boundary_condition == 'Neumann':
 
                 # left boundary
-                np.subtract( x_asarr[tuple(self.get_slice(1, 2))], \
+                xp.subtract( x_asarr[tuple(self.get_slice(1, 2))], \
                                  x_asarr[tuple(self.get_slice(0,1))], \
                                  out = outa[tuple(self.get_slice(0, 1))])
                 outa[tuple(self.get_slice(0, 1))] /=2.
 
                 # left boundary
-                np.subtract( x_asarr[tuple(self.get_slice(-1, None))], \
+                xp.subtract( x_asarr[tuple(self.get_slice(-1, None))], \
                                  x_asarr[tuple(self.get_slice(-2,-1))], \
                                  out = outa[tuple(self.get_slice(-1, None))])
                 outa[tuple(self.get_slice(-1, None))] /=2.
@@ -199,14 +202,14 @@ class FiniteDifferenceOperator(LinearOperator):
                 pass
 
                # left boundary
-                np.subtract( x_asarr[tuple(self.get_slice(1, 2))], \
+                xp.subtract( x_asarr[tuple(self.get_slice(1, 2))], \
                                  x_asarr[tuple(self.get_slice(-1,None))], \
                                  out = outa[tuple(self.get_slice(0, 1))])
                 outa[tuple(self.get_slice(0, 1))] /= 2.
 
 
                 # left boundary
-                np.subtract( x_asarr[tuple(self.get_slice(0, 1))], \
+                xp.subtract( x_asarr[tuple(self.get_slice(0, 1))], \
                                  x_asarr[tuple(self.get_slice(-2,-1))], \
                                  out = outa[tuple(self.get_slice(-1, None))])
                 outa[tuple(self.get_slice(-1, None))] /= 2.
@@ -235,6 +238,7 @@ class FiniteDifferenceOperator(LinearOperator):
         # Adjoint operation defined as
 
         x_asarr = x.as_array()
+        xp = array_namespace(x_asarr)
 
         outnone = False
         if out is None:
@@ -254,7 +258,7 @@ class FiniteDifferenceOperator(LinearOperator):
         if self.method == 'forward':
 
             # interior nodes
-            np.subtract( x_asarr[tuple(self.get_slice(1, -1))], \
+            xp.subtract( x_asarr[tuple(self.get_slice(1, -1))], \
                              x_asarr[tuple(self.get_slice(0,-2))], \
                              out = outa[tuple(self.get_slice(1, -1))])
 
@@ -269,11 +273,11 @@ class FiniteDifferenceOperator(LinearOperator):
             elif self.boundary_condition == 'Periodic':
 
                 # left boundary
-                np.subtract(x_asarr[tuple(self.get_slice(0,1))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(0,1))],\
                             x_asarr[tuple(self.get_slice(-1,None))],
                             out = outa[tuple(self.get_slice(0,1))])
                 # right boundary
-                np.subtract(x_asarr[tuple(self.get_slice(-1,None))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(-1,None))],\
                             x_asarr[tuple(self.get_slice(-2,-1))],
                             out = outa[tuple(self.get_slice(-1,None))])
 
@@ -287,7 +291,7 @@ class FiniteDifferenceOperator(LinearOperator):
         elif self.method == 'backward':
 
             # interior nodes
-            np.subtract( x_asarr[tuple(self.get_slice(2, None))], \
+            xp.subtract( x_asarr[tuple(self.get_slice(2, None))], \
                              x_asarr[tuple(self.get_slice(1,-1))], \
                              out = outa[tuple(self.get_slice(1, -1))])
 
@@ -303,12 +307,12 @@ class FiniteDifferenceOperator(LinearOperator):
             elif self.boundary_condition == 'Periodic':
 
                 # left boundary
-                np.subtract(x_asarr[tuple(self.get_slice(1,2))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(1,2))],\
                             x_asarr[tuple(self.get_slice(0,1))],
                             out = outa[tuple(self.get_slice(0,1))])
 
                 # right boundary
-                np.subtract(x_asarr[tuple(self.get_slice(0,1))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(0,1))],\
                             x_asarr[tuple(self.get_slice(-1,None))],
                             out = outa[tuple(self.get_slice(-1,None))])
 
@@ -323,7 +327,7 @@ class FiniteDifferenceOperator(LinearOperator):
         elif self.method == 'centered':
 
             # interior nodes
-            np.subtract( x_asarr[tuple(self.get_slice(2, None))], \
+            xp.subtract( x_asarr[tuple(self.get_slice(2, None))], \
                              x_asarr[tuple(self.get_slice(0,-2))], \
                              out = outa[tuple(self.get_slice(1, -1))])
             outa[tuple(self.get_slice(1, -1))] /= 2.0
@@ -332,13 +336,13 @@ class FiniteDifferenceOperator(LinearOperator):
             if self.boundary_condition == 'Neumann':
 
                 # left boundary
-                np.add(x_asarr[tuple(self.get_slice(0,1))],\
+                xp.add(x_asarr[tuple(self.get_slice(0,1))],\
                             x_asarr[tuple(self.get_slice(1,2))],
                             out = outa[tuple(self.get_slice(0,1))])
                 outa[tuple(self.get_slice(0,1))] /= 2.0
 
                 # right boundary
-                np.add(x_asarr[tuple(self.get_slice(-1,None))],\
+                xp.add(x_asarr[tuple(self.get_slice(-1,None))],\
                             x_asarr[tuple(self.get_slice(-2,-1))],
                             out = outa[tuple(self.get_slice(-1,None))])
 
@@ -348,13 +352,13 @@ class FiniteDifferenceOperator(LinearOperator):
             elif self.boundary_condition == 'Periodic':
 
                 # left boundary
-                np.subtract(x_asarr[tuple(self.get_slice(1,2))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(1,2))],\
                             x_asarr[tuple(self.get_slice(-1,None))],
                             out = outa[tuple(self.get_slice(0,1))])
                 outa[tuple(self.get_slice(0,1))] /= 2.0
 
                 # right boundary
-                np.subtract(x_asarr[tuple(self.get_slice(0,1))],\
+                xp.subtract(x_asarr[tuple(self.get_slice(0,1))],\
                             x_asarr[tuple(self.get_slice(-2,-1))],
                             out = outa[tuple(self.get_slice(-1,None))])
                 outa[tuple(self.get_slice(-1,None))] /= 2.0

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -746,7 +746,8 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         try:
             data1.fill(r)
             self.assertTrue(False)
-        except numpy.exceptions.ComplexWarning as err:
+        # except numpy.exceptions.ComplexWarning as err:
+        except Exception as err:
             log.info(str(err))
             self.assertTrue(True)
 

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -79,14 +79,22 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         ds1 = ds.clone()
         self.assertNotEqual(aid(ds), aid(ds1))
 
-    def test_ndim(self):
-        x_np = np.arange(0, 60).reshape(3,4,5)
+    @parametrize("xp, raise_error, err_type", 
+        [param(numpy, None, None, id="numpy"), 
+         param(torch, None, None, id="torch"),
+         ]) 
+    def test_ndim(self, xp, raise_error, err_type):
+        x_np = xp.arange(0, 60).reshape(3,4,5)
         x_cil = DataContainer(x_np)
         self.assertEqual(x_np.ndim, x_cil.ndim)
         self.assertEqual(3, x_cil.ndim)
 
-    def test_DataContainer_equal(self):
-        array = np.linspace(-1, 1, 32, dtype=np.float32).reshape(4, 8)
+    @parametrize("xp, raise_error, err_type", 
+        [param(numpy, None, None, id="numpy"), 
+         param(torch, None, None, id="torch"),
+         ]) 
+    def test_DataContainer_equal(self, xp, raise_error, err_type):
+        array = xp.linspace(-1, 1, 32, dtype=xp.float32).reshape(4, 8)
         data = DataContainer(array)
         data1 = data.copy()
 
@@ -99,8 +107,12 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         data1 += 1
         self.assertFalse((data ==  data1).all())
 
-    def test_AcquisitionData_equal(self):
-        array = np.linspace(-1, 1, 32, dtype=np.float32).reshape(4, 8)
+    @parametrize("xp, raise_error, err_type", 
+        [param(numpy, None, None, id="numpy"), 
+         param(torch, None, None, id="torch"),
+         ]) 
+    def test_AcquisitionData_equal(self, xp, raise_error, err_type):
+        array = xp.linspace(-1, 1, 32, dtype=xp.float32).reshape(4, 8)
         geom = AcquisitionGeometry.create_Parallel3D().set_panel((8, 4)).set_channels(1).set_angles([1])
         data = AcquisitionData(array, geometry=geom)
 
@@ -123,8 +135,9 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
 
         # Check the equality of two AcquisitionData with different dtypes
         data_different_dtype = data.copy()
-        data_different_dtype.array = data_different_dtype.array.astype(np.float64)
-        self.assertFalse(data == data_different_dtype)
+        # data_different_dtype.array = data_different_dtype.array.astype(np.float64)
+        arr = xp.asarray(data_different_dtype.array, dtype=xp.float64)
+        self.assertFalse(data == arr)
 
 
         # Check the equality of two AcquisitionData with different labels
@@ -133,8 +146,12 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         data_different_labels.geometry.set_labels([AcquisitionDimension("ANGLE"), AcquisitionDimension("CHANNEL") ])
         self.assertFalse(data == data_different_labels)
 
-    def test_ImageData_equal(self):
-        array = np.linspace(-1, 1, 32, dtype=np.float32).reshape(4, 8)
+    @parametrize("xp, device, raise_error, err_type", 
+        [param(numpy, None, None, None, id="numpy"), 
+         param(torch, None, None, None, id="torch_cpu"),
+         ]) 
+    def test_ImageData_equal(self, xp, device, raise_error, err_type):
+        array = xp.linspace(-1, 1, 32, dtype=xp.float32).reshape(4, 8)
         geom = ImageGeometry(voxel_num_x=8, voxel_num_y=4)
         data = ImageData(array, geometry=geom)
 
@@ -166,8 +183,11 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         data_different_labels.geometry.set_labels([ImageDimension("VERTICAL"), ImageDimension("HORIZONTAL_X")])
         self.assertFalse(data == data_different_labels)
 
-
-    def testInlineAlgebra(self):
+    @parametrize("xp, device, raise_error, err_type", 
+        [param(numpy, None, None, None, id="numpy"), 
+         param(torch, None, None, None, id="torch_cpu"),
+         ]) 
+    def testInlineAlgebra(self, xp, device, raise_error, err_type):
         X, Y, Z = 8, 16, 32
         a = np.ones((X, Y, Z), dtype='float32')
         b = np.ones((X, Y, Z), dtype='float32')
@@ -202,10 +222,14 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         np.testing.assert_array_almost_equal(ds.as_array(), b)
         # self.assertEqual(ds.as_array()[0][0][0], 1.)
 
-    def test_unary_operations(self):
+    @parametrize("xp, device, raise_error, err_type", 
+        [param(numpy, None, None, None, id="numpy"), 
+         param(torch, None, None, None, id="torch_cpu"),
+         ])
+    def test_unary_operations(self, xp, device, raise_error, err_type):
         X, Y, Z = 8, 16, 32
-        a = -np.ones((X, Y, Z), dtype='float32')
-        b = np.ones((X, Y, Z), dtype='float32')
+        a = -xp.ones((X, Y, Z), dtype=xp.float32)
+        b = xp.ones((X, Y, Z), dtype=xp.float32)
         ds = DataContainer(a, False, ['X', 'Y', 'Z'])
 
         ds.sign(out=ds)
@@ -1319,11 +1343,14 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
 
         np.testing.assert_array_equal(ds.as_array(), -a)
 
-
-    def test_fill_dimension_ImageData(self):
+    @parametrize("xp, device, raise_error, err_type", 
+        [param(numpy, None, None, None, id="numpy"), 
+         param(torch, None, None, None, id="torch_cpu"),
+         ])
+    def test_fill_dimension_ImageData(self, xp, device, raise_error, err_type):
         ig = ImageGeometry(2,3,4)
         u = ig.allocate(0)
-        a = np.ones((4,2))
+        a = xp.ones((4,2))
         # default_labels = [ImageDimension["VERTICAL"], ImageDimension["HORIZONTAL_Y"], ImageDimension["HORIZONTAL_X"]]
 
         data = u.as_array()

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -32,8 +32,11 @@ from utils import initialise_tests
 import array_api_compat
 from unittest_parametrize import param, parametrize, ParametrizedTestCase
 import numpy
-import torch
-
+try:
+    import torch
+except ImportError:
+    torch = None
+import unittest
 
 log = logging.getLogger(__name__)
 initialise_tests()
@@ -50,7 +53,8 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         #print("a refcount " , sys.getrefcount(a))
         ds = DataContainer(a, False, ['X', 'Y', 'Z'])
         return ds
-
+    
+    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, raise_error, err_type", 
         [param(numpy, None, None, id="numpy"), 
          param(torch, None, None, id="torch"),
@@ -79,6 +83,7 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         ds1 = ds.clone()
         self.assertNotEqual(aid(ds), aid(ds1))
 
+    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, raise_error, err_type", 
         [param(numpy, None, None, id="numpy"), 
          param(torch, None, None, id="torch"),
@@ -89,6 +94,7 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         self.assertEqual(x_np.ndim, x_cil.ndim)
         self.assertEqual(3, x_cil.ndim)
 
+    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, raise_error, err_type", 
         [param(numpy, None, None, id="numpy"), 
          param(torch, None, None, id="torch"),
@@ -107,6 +113,7 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         data1 += 1
         self.assertFalse((data ==  data1).all())
 
+    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, raise_error, err_type", 
         [param(numpy, None, None, id="numpy"), 
          param(torch, None, None, id="torch"),
@@ -146,6 +153,7 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         data_different_labels.geometry.set_labels([AcquisitionDimension("ANGLE"), AcquisitionDimension("CHANNEL") ])
         self.assertFalse(data == data_different_labels)
 
+    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, device, raise_error, err_type", 
         [param(numpy, None, None, None, id="numpy"), 
          param(torch, None, None, None, id="torch_cpu"),
@@ -182,6 +190,7 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         data_different_labels.geometry.set_labels([ImageDimension("VERTICAL"), ImageDimension("HORIZONTAL_X")])
         self.assertFalse(data == data_different_labels)
 
+    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, device, raise_error, err_type", 
         [param(numpy, None, None, None, id="numpy"), 
          param(torch, None, None, None, id="torch_cpu"),
@@ -221,6 +230,7 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         np.testing.assert_array_almost_equal(ds.as_array(), b)
         # self.assertEqual(ds.as_array()[0][0][0], 1.)
 
+    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, device, raise_error, err_type", 
         [param(numpy, None, None, None, id="numpy"), 
          param(torch, None, None, None, id="torch_cpu"),
@@ -1344,6 +1354,7 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
 
         np.testing.assert_array_equal(ds.as_array(), -a)
 
+    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, device, raise_error, err_type", 
         [param(numpy, None, None, None, id="numpy"), 
          param(torch, None, None, None, id="torch_cpu"),

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -54,12 +54,13 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         ds = DataContainer(a, False, ['X', 'Y', 'Z'])
         return ds
     
-    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, raise_error, err_type", 
         [param(numpy, None, None, id="numpy"), 
          param(torch, None, None, id="torch"),
          ]) 
     def test_creation_nocopy(self, xp, raise_error, err_type):
+        if xp is None:
+            self.skipTest("torch not available")
         shape = 2, 3, 4, 5
         size = xp.prod(xp.asarray(shape))
         a = xp.arange(size)
@@ -83,23 +84,25 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         ds1 = ds.clone()
         self.assertNotEqual(aid(ds), aid(ds1))
 
-    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, raise_error, err_type", 
         [param(numpy, None, None, id="numpy"), 
          param(torch, None, None, id="torch"),
          ]) 
     def test_ndim(self, xp, raise_error, err_type):
+        if xp is None:
+            self.skipTest("torch not available")
         x_np = xp.arange(0, 60).reshape(3,4,5)
         x_cil = DataContainer(x_np)
         self.assertEqual(x_np.ndim, x_cil.ndim)
         self.assertEqual(3, x_cil.ndim)
 
-    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, raise_error, err_type", 
         [param(numpy, None, None, id="numpy"), 
          param(torch, None, None, id="torch"),
          ]) 
     def test_DataContainer_equal(self, xp, raise_error, err_type):
+        if xp is None:
+            self.skipTest("torch not available")
         array = xp.linspace(-1, 1, 32, dtype=xp.float32).reshape(4, 8)
         data = DataContainer(array)
         data1 = data.copy()
@@ -113,12 +116,13 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         data1 += 1
         self.assertFalse((data ==  data1).all())
 
-    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, raise_error, err_type", 
         [param(numpy, None, None, id="numpy"), 
          param(torch, None, None, id="torch"),
          ]) 
     def test_AcquisitionData_equal(self, xp, raise_error, err_type):
+        if xp is None:
+            self.skipTest("torch not available")
         array = xp.linspace(-1, 1, 32, dtype=xp.float32).reshape(4, 8)
         geom = AcquisitionGeometry.create_Parallel3D().set_panel((8, 4)).set_channels(1).set_angles([1])
         data = AcquisitionData(array, geometry=geom)
@@ -153,12 +157,13 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         data_different_labels.geometry.set_labels([AcquisitionDimension("ANGLE"), AcquisitionDimension("CHANNEL") ])
         self.assertFalse(data == data_different_labels)
 
-    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, device, raise_error, err_type", 
         [param(numpy, None, None, None, id="numpy"), 
          param(torch, None, None, None, id="torch_cpu"),
          ]) 
     def test_ImageData_equal(self, xp, device, raise_error, err_type):
+        if xp is None:
+            self.skipTest("torch not available")
         array = xp.linspace(-1, 1, 32, dtype=xp.float32).reshape(4, 8)
         geom = ImageGeometry(voxel_num_x=8, voxel_num_y=4)
         data = ImageData(array, geometry=geom)
@@ -190,12 +195,13 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         data_different_labels.geometry.set_labels([ImageDimension("VERTICAL"), ImageDimension("HORIZONTAL_X")])
         self.assertFalse(data == data_different_labels)
 
-    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, device, raise_error, err_type", 
         [param(numpy, None, None, None, id="numpy"), 
          param(torch, None, None, None, id="torch_cpu"),
          ]) 
     def testInlineAlgebra(self, xp, device, raise_error, err_type):
+        if xp is None:
+            self.skipTest("torch not available")
         X, Y, Z = 8, 16, 32
         a = np.ones((X, Y, Z), dtype='float32')
         b = np.ones((X, Y, Z), dtype='float32')
@@ -230,12 +236,13 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         np.testing.assert_array_almost_equal(ds.as_array(), b)
         # self.assertEqual(ds.as_array()[0][0][0], 1.)
 
-    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, device, raise_error, err_type", 
         [param(numpy, None, None, None, id="numpy"), 
          param(torch, None, None, None, id="torch_cpu"),
          ])
     def test_unary_operations(self, xp, device, raise_error, err_type):
+        if xp is None:
+            self.skipTest("torch not available")
         X, Y, Z = 8, 16, 32
         a = -xp.ones((X, Y, Z), dtype=xp.float32)
         b = xp.ones((X, Y, Z), dtype=xp.float32)
@@ -1354,12 +1361,13 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
 
         np.testing.assert_array_equal(ds.as_array(), -a)
 
-    @unittest.skipIf(torch is None, "torch not available")
     @parametrize("xp, device, raise_error, err_type", 
         [param(numpy, None, None, None, id="numpy"), 
          param(torch, None, None, None, id="torch_cpu"),
          ])
     def test_fill_dimension_ImageData(self, xp, device, raise_error, err_type):
+        if xp is None:
+            self.skipTest("torch not available")
         ig = ImageGeometry(2,3,4)
         u = ig.allocate(0)
         a = xp.ones((4,2))

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -173,8 +173,7 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         self.assertFalse(data == data_different_shape)
 
         # Check the equality of two ImageData with different dtypes
-        data_different_dtype = data.copy()
-        data_different_dtype.array = data_different_dtype.array.astype(np.float64)
+        data_different_dtype = data.geometry.allocate(0, dtype=np.float64)
         self.assertFalse(data == data_different_dtype)
 
 
@@ -1354,9 +1353,6 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         u = ig.allocate(0)
         a = xp.ones((4,2))
         # default_labels = [ImageDimension["VERTICAL"], ImageDimension["HORIZONTAL_Y"], ImageDimension["HORIZONTAL_X"]]
-
-        data = u.as_array()
-        axis_number = u.get_dimension_axis('horizontal_y')
 
         u.fill(a, horizontal_y=0)
         np.testing.assert_array_equal(u.get_slice(horizontal_y=0).as_array(), a)

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -719,7 +719,9 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
 
     def complex_allocate_geometry_test(self, geometry):
         data = geometry.allocate(dtype=np.complex64)
-        r = (1 + 1j*1)* np.ones(data.shape, dtype=data.dtype)
+        from array_api_compat import array_namespace
+        xp = array_namespace(data.array)
+        r = (1 + 1j*1)* xp.ones(data.shape, dtype=data.dtype)
         data.fill(r)
         self.assertAlmostEqual(data.squared_norm(), data.size * 2)
         np.testing.assert_almost_equal(data.abs().array, np.abs(r))
@@ -728,7 +730,7 @@ class TestDataContainer(ParametrizedTestCase, CCPiTestClass):
         try:
             data1.fill(r)
             self.assertTrue(False)
-        except TypeError as err:
+        except numpy.exceptions.ComplexWarning as err:
             log.info(str(err))
             self.assertTrue(True)
 

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -1139,7 +1139,8 @@ class TestL1Norm (CCPiTestClass):
         tau = -1.
         with self.assertWarns(UserWarning):
             ret = soft_shrinkage(-0.5 *x, tau)
-            np.testing.assert_allclose(ret.as_array(), -1.5 * np.ones_like(x.as_array()))
+            np.testing.assert_allclose(ret.as_array(), -1.5 * np.ones_like(x.as_array()), 
+                                       atol=3e-7, rtol=2e-7)
         tau = -3j
         with self.assertRaises(ValueError):
             ret = soft_shrinkage(-0.5 *x, tau)
@@ -1162,7 +1163,8 @@ class TestL1Norm (CCPiTestClass):
         np.testing.assert_allclose(ret.as_array(), -1 * np.zeros_like(x.as_array()))
         tau = -1.* np.ones_like(x.as_array())
         ret = soft_shrinkage(-0.5 *x, tau)
-        np.testing.assert_allclose(ret.as_array(), -1.5 * np.ones_like(x.as_array()))
+        np.testing.assert_allclose(ret.as_array(), -1.5 * np.ones_like(x.as_array()),
+                                   rtol=3e-7, atol=2e-7)
 
         # tau DataContainer
         tau = 1. * x
@@ -1182,7 +1184,8 @@ class TestL1Norm (CCPiTestClass):
         np.testing.assert_allclose(ret.as_array(), -1 * np.zeros_like(x.as_array()))
         tau = -1. * x
         ret = soft_shrinkage(-0.5 *x, tau)
-        np.testing.assert_allclose(ret.as_array(), -1.5 * np.ones_like(x.as_array()))
+        np.testing.assert_allclose(ret.as_array(), -1.5 * np.ones_like(x.as_array()),
+                                   rtol=3e-7, atol=2e-7)
 
         np.testing.assert_allclose(ret.as_array().imag, np.zeros_like(ret.as_array().imag), atol=1e-6, rtol=1e-6)
 

--- a/Wrappers/Python/test/torch_test.py
+++ b/Wrappers/Python/test/torch_test.py
@@ -1,0 +1,9 @@
+import torch
+from cil.framework import DataContainer
+
+a = torch.zeros([2, 4], dtype=torch.float32)
+
+print (a[0], a[1])
+
+cil_a = DataContainer
+

--- a/Wrappers/Python/test/torch_test.py
+++ b/Wrappers/Python/test/torch_test.py
@@ -104,3 +104,21 @@ numpy.testing.assert_allclose(cil_np[2].as_array(),
                               (res).as_array())
 
 print(res.array)
+
+torch.squeeze(a[0])
+
+shape = [3,5,1,5]
+
+print (numpy.where(numpy.asarray(shape) == 1))
+
+tt = torch.asarray([1,2,-1,10])
+print(torch.sign(tt))
+ts = tt*0
+torch.sign(tt, out=ts)
+print (ts)
+ts = tt*0
+xp = array_namespace(tt)
+# xp.sign(tt, out=ts)
+print (ts)
+tt.sign(out=ts)
+print (ts)

--- a/Wrappers/Python/test/torch_test.py
+++ b/Wrappers/Python/test/torch_test.py
@@ -9,14 +9,66 @@ cil_np1 = DataContainer(b, deep_copy=False)
 
 numpy.testing.assert_allclose(numpy.zeros([2,4], dtype=numpy.float32), 
                               (cil_np0-cil_np1).as_array())
-a = torch.zeros([2, 4], dtype=torch.float32)
+
+
+
+a = [ torch.ones([2, 4], dtype=torch.float32),
+      torch.ones([2, 4], dtype=torch.float32),
+      torch.ones([2, 4], dtype=torch.float32)]
+
 
 print (f"torch array has __array_interface__? {hasattr(a, '__array_interface__')}")
 # https://github.com/pytorch/pytorch/issues/54138
 
 # print (a[0], a[1])
-cil_tc0 = DataContainer(a, deep_copy=True)
-cil_tc1 = DataContainer(a, deep_copy=False)
+cil_tc0 = DataContainer(a[0], deep_copy=True)
+cil_tc1 = DataContainer(a[0], deep_copy=False)
 
 numpy.testing.assert_allclose(numpy.zeros([2,4], dtype=numpy.float32), 
                               (cil_tc0-cil_tc1).as_array().numpy())
+
+# Torch - NumPy = Torch
+c = a[0] - b
+print(c)
+
+# NumPy - Torch = TypeError: unsupported operand type(s) for -: 'numpy.ndarray' and 'Tensor'
+# d = b - a = TypeError: unsupported operand type(s) for -: 'numpy.ndarray' and 'Tensor'
+# in CIL we do subtraction as below and it works
+d = numpy.subtract(b,a[0])
+print("d", d)
+
+# CIL DataContainer and mixed stuff
+mixed_diff = cil_np0.subtract(cil_tc0)
+print (mixed_diff.array)
+print(f"Type of mixed_diff cil_np0.subtract(cil_tc0) {type(mixed_diff.array)}")
+numpy.testing.assert_allclose(numpy.zeros([2,4], dtype=numpy.float32), 
+                              (mixed_diff).as_array().numpy())
+
+cil_tc2 = DataContainer(a[1], deep_copy=False)
+print(f"cil_tc2.array ype of mixed_diff {type(cil_tc2.array)}")
+
+# cil_tc0.subtract(cil_tc1, out=cil_tc2.array)
+from array_api_compat import array_namespace
+# array_namespace will raise a TypeError if multiple namespaces for array input
+xp = array_namespace(*a)
+print(xp)
+xp.subtract(a[1], a[0], out=a[2])
+print ("after subtract", a[2])
+
+cil_tc2 = DataContainer(a[2], deep_copy=False)
+cil_tc2 += 1
+
+print("################")
+print (cil_tc2.array)
+cil_tc0.subtract(cil_tc1, out=cil_tc2)
+
+print (cil_tc2.array)
+# from array_api_compat import array_namespace
+# array_namespace([1,2])
+cil_tc2+=1
+# mixed types with output
+# output must match the type of the first array
+print("################")
+print (cil_np1.array)
+mixed_diff = cil_np0.subtract(cil_tc0, out=cil_np1)
+print (cil_np1.array)

--- a/Wrappers/Python/test/torch_test.py
+++ b/Wrappers/Python/test/torch_test.py
@@ -72,3 +72,35 @@ print("################")
 print (cil_np1.array)
 mixed_diff = cil_np0.subtract(cil_tc0, out=cil_np1)
 print (cil_np1.array)
+
+print("########## test sapyb with pytorch ########## ")
+a = [ torch.ones([2, 4], dtype=torch.float32),
+      torch.ones([2, 4], dtype=torch.float32),
+      torch.ones([2, 4], dtype=torch.float32)]
+
+cil_tc = [ DataContainer(el, deep_copy=False) for el in a]
+
+# 2 * 1 + 3 * 1
+res = cil_tc[1].sapyb(2, cil_tc[1], 3)
+cil_tc[1].sapyb(2, cil_tc[1], 3, out=cil_tc[2])
+
+numpy.testing.assert_allclose(cil_tc[2].as_array().numpy(), 
+                              (res).as_array().numpy())
+
+print(res.array)
+
+print("########## test sapyb with numpy ########## ")
+b = [ numpy.ones([2, 4], dtype=numpy.float32),
+      numpy.ones([2, 4], dtype=numpy.float32),
+      numpy.ones([2, 4], dtype=numpy.float32)]
+
+cil_np = [ DataContainer(el, deep_copy=False) for el in b]
+
+# 2 * 1 + 3 * 1
+res = cil_np[1].sapyb(2, cil_np[1], 3)
+cil_np[1].sapyb(2, cil_np[1], 3, out=cil_np[2])
+
+numpy.testing.assert_allclose(cil_np[2].as_array(), 
+                              (res).as_array())
+
+print(res.array)

--- a/Wrappers/Python/test/torch_test.py
+++ b/Wrappers/Python/test/torch_test.py
@@ -1,9 +1,22 @@
 import torch
+import numpy 
 from cil.framework import DataContainer
 
+
+b = numpy.ones([2,4], dtype=numpy.float32)
+cil_np0 = DataContainer(b, deep_copy=True)
+cil_np1 = DataContainer(b, deep_copy=False)
+
+numpy.testing.assert_allclose(numpy.zeros([2,4], dtype=numpy.float32), 
+                              (cil_np0-cil_np1).as_array())
 a = torch.zeros([2, 4], dtype=torch.float32)
 
-print (a[0], a[1])
+print (f"torch array has __array_interface__? {hasattr(a, '__array_interface__')}")
+# https://github.com/pytorch/pytorch/issues/54138
 
-cil_a = DataContainer
+# print (a[0], a[1])
+cil_tc0 = DataContainer(a, deep_copy=True)
+cil_tc1 = DataContainer(a, deep_copy=False)
 
+numpy.testing.assert_allclose(numpy.zeros([2,4], dtype=numpy.float32), 
+                              (cil_tc0-cil_tc1).as_array().numpy())

--- a/experiments/cupy_TV.py
+++ b/experiments/cupy_TV.py
@@ -1,0 +1,97 @@
+#%%
+from cil.utilities import dataexample
+from cil.optimisation.functions import TotalVariation
+from cil.plugins.ccpi_regularisation.functions import FGP_TV
+from cil.utilities.display import show2D
+
+import time
+
+N = 10
+num_iter = 1000
+isotropic = True
+
+#%%
+# get an example image
+
+data = {'numpy': dataexample.CAMERA.get(size=(128, 128))}
+geom = data['numpy'].geometry.copy()
+
+import numpy as np
+import torch as to
+import cupy as cp
+from cil.framework import ImageData
+
+
+data['torch'] = ImageData(to.from_numpy(data['numpy'].as_array()), 
+                          geometry=geom.copy())
+
+
+data['cupy'] = ImageData(cp.asarray(data['numpy'].as_array()), 
+                          geometry=geom.copy())
+
+data['c'] = data['numpy']
+
+#%% create a TotalVariation object
+TV = {}
+TV['cupy']  = TotalVariation(max_iteration=num_iter, isotropic=isotropic, backend='numpy')
+TV['torch'] = TotalVariation(max_iteration=num_iter, isotropic=isotropic, backend='numpy')
+TV['numpy'] = TotalVariation(max_iteration=num_iter, isotropic=isotropic, backend='numpy')
+TV['c'] = TotalVariation(max_iteration=num_iter, isotropic=isotropic, backend='c')
+
+
+
+#%%
+fgp = FGP_TV(max_iteration=num_iter, isotropic=isotropic, device='gpu')
+
+#%%
+d1 = fgp.proximal(data['numpy'], tau=1)
+t0 = time.time()
+for _ in range(N):
+    d1 = fgp.proximal(data['numpy'], tau=1, out=d1)
+t1 = time.time()
+dt_fgp = t1-t0
+print (f"Elapsed time: {dt_fgp:.6f} seconds")
+
+#%%
+# d3 = cTV.proximal(x, tau=1)
+
+#%%
+# cupy
+
+def run_TV(data, TV, backend, tau=1, N=10):
+    d = TV[backend].proximal(data[backend], tau=tau)
+    t0 = time.time()
+    for _ in range(N):
+        d = TV[backend].proximal(data[backend], tau=tau, out=d)
+    t1 = time.time()
+    dt = t1-t0
+    print (f"Elapsed time: {dt:.6f} seconds")
+    return ( d.as_array(), dt )
+
+
+#%%
+
+d2 , dt_2 = run_TV(data, TV, 'cupy', tau=1, N=N)
+#%%
+# d3 , dt_3 = run_TV(data, TV, 'torch', tau=1, N=N)
+# #%%
+# d4 , dt_4 = run_TV(data, TV, 'numpy', tau=1, N=N)
+# #%%
+# d5 , dt_5 = run_TV(data, TV, 'c', tau=1, N=N)
+
+# #%%
+# show2D(d4, title=f'np TotalVariation {dt_4}', origin='upper', cmap='inferno')
+
+# #%%
+# show2D([d1, d5, d4, d3.numpy(), cp.asnumpy(d2)], title=[f'FGP_TV {dt_fgp/N:.3f}s', 
+#                                  f'C TotalVariation {dt_5/N:.3f}s',
+#                                  f'np TotalVariation {dt_4/N:.3f}s',
+#                                  f'torch TotalVariation {dt_3/N:.3f}s',
+#                                  f'cp TotalVariation {dt_2/N:.3f}s',
+#                                  ], origin='upper', cmap='inferno',
+#                                  num_cols=2)
+# # %%
+# import array_api_compat
+# np_array = array_api_compat.to_numpy(data['cupy'].as_array())
+
+# # %%

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,6 +72,7 @@ requirements:
     - tqdm
     - numba
     - zenodo_get >=1.6
+    - array-api-compat
 
   #optional packages with version dependancies
   run_constrained:

--- a/scripts/requirements-test.yml
+++ b/scripts/requirements-test.yml
@@ -49,5 +49,6 @@ dependencies:
   - tqdm
   - zenodo_get >=1.6
   - pip
+  - array-api-compat
   - pip:
     - unittest-parametrize


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->

Removes all the checks on the array wrapped by the `DataContainer`



## Example Usage
<!--minimal working example-->

:heart: *Thanks for your contribution!*







<!-- please IGNORE the below if you aren't a CIL team member

blame GH for this text: https://github.com/orgs/community/discussions/81319

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
