### PR TITLE
Fix argument order for subtract and divide between different container types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
       - Ensured the same approximate gradient is used within each iteration for PD3O with a stochastic function `f` (#2043)
       - Fix `recon.FBP` `split_processing` methods for `ASTRA` backend (#2114)
       - Copy geometry in the creation of a DataContainer (#2108)
+      - Fix order of operations for subtraction and division between a BlockDataContainer and DataContainer (#2133)
   - Documentation:
       - Updated documentation for the ChannelWiseOperator including new example (#2096)
       - Updated documentation for LADMM (#2015)

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -466,7 +466,7 @@ class DataContainer(object):
     def subtract(self, other, *args, **kwargs):
         if hasattr(other, '__container_priority__') and \
            self.__class__.__container_priority__ < other.__class__.__container_priority__:
-            return other.sapyb(-1,self,1, out=kwargs.get('out', None})
+            return other.sapyb(-1,self,1, out=kwargs.get('out', None))
         return self.pixel_wise_binary(numpy.subtract, other, *args, **kwargs)
 
     def multiply(self, other, *args, **kwargs):

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -464,7 +464,7 @@ class DataContainer(object):
     def subtract(self, other, *args, **kwargs):
         if hasattr(other, '__container_priority__') and \
            self.__class__.__container_priority__ < other.__class__.__container_priority__:
-            return (-other).add(self, *args, **kwargs)
+            return other.sapyb(-1,self,1, out=kwargs.get('out', None})
         return self.pixel_wise_binary(numpy.subtract, other, *args, **kwargs)
 
     def multiply(self, other, *args, **kwargs):
@@ -476,7 +476,9 @@ class DataContainer(object):
     def divide(self, other, *args, **kwargs):
         if hasattr(other, '__container_priority__') and \
            self.__class__.__container_priority__ < other.__class__.__container_priority__:
-            return other.power(-1).multiply(self, *args, **kwargs)
+            _out = other.divide(self, *args, **kwargs)
+            _out.power(-1, out=_out)
+            return _out
         return self.pixel_wise_binary(numpy.divide, other, *args, **kwargs)
 
     def power(self, other, *args, **kwargs):

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -464,7 +464,7 @@ class DataContainer(object):
     def subtract(self, other, *args, **kwargs):
         if hasattr(other, '__container_priority__') and \
            self.__class__.__container_priority__ < other.__class__.__container_priority__:
-            return other.subtract(self, *args, **kwargs)
+            return (-other).add(self, *args, **kwargs)
         return self.pixel_wise_binary(numpy.subtract, other, *args, **kwargs)
 
     def multiply(self, other, *args, **kwargs):
@@ -476,7 +476,7 @@ class DataContainer(object):
     def divide(self, other, *args, **kwargs):
         if hasattr(other, '__container_priority__') and \
            self.__class__.__container_priority__ < other.__class__.__container_priority__:
-            return other.divide(self, *args, **kwargs)
+            return other.power(-1).multiply(self, *args, **kwargs)
         return self.pixel_wise_binary(numpy.divide, other, *args, **kwargs)
 
     def power(self, other, *args, **kwargs):

--- a/Wrappers/Python/test/test_BlockDataContainer.py
+++ b/Wrappers/Python/test/test_BlockDataContainer.py
@@ -648,9 +648,12 @@ class TestBlockDataContainer(BDCUnittest):
     def test_BlockDataContainer_mixed_arithmetic(self):
         a = numpy.ones([2, 2], dtype=numpy.float32) * 2
         b = numpy.ones([2, 2], dtype=numpy.float32) * 4
+        c = numpy.ones([2, 2], dtype=numpy.float32) * 3
 
         bdc = BlockDataContainer(DataContainer(a))
+        bdc2 = BlockDataContainer(DataContainer(a), DataContainer(b))
         dc = DataContainer(b)
+        dc2 = DataContainer(c)
 
         sub1 = bdc - dc # 2 - 4
         self.assertIsInstance(sub1, BlockDataContainer)
@@ -659,6 +662,11 @@ class TestBlockDataContainer(BDCUnittest):
         sub2 = dc - bdc # 4 - 2
         self.assertIsInstance(sub2, BlockDataContainer)
         np.testing.assert_almost_equal(sub2.get_item(0).as_array(), 2, decimal=5)
+
+        sub3 = dc2 - bdc2 # 3 - (2, 4)
+        self.assertIsInstance(sub3, BlockDataContainer)
+        np.testing.assert_almost_equal(sub3.get_item(0).as_array(), 1, decimal=5)
+        np.testing.assert_almost_equal(sub3.get_item(1).as_array(), -1, decimal=5)
 
         div1 = bdc / dc # 2 / 4
         self.assertIsInstance(div1, BlockDataContainer)

--- a/Wrappers/Python/test/test_BlockDataContainer.py
+++ b/Wrappers/Python/test/test_BlockDataContainer.py
@@ -17,7 +17,6 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 import unittest
-
 from utils import initialise_tests
 import numpy as np
 from cil.framework import ImageGeometry, AcquisitionGeometry, VectorGeometry, ImageData, Partitioner, AcquisitionData, DataContainer

--- a/Wrappers/Python/test/test_BlockDataContainer.py
+++ b/Wrappers/Python/test/test_BlockDataContainer.py
@@ -17,9 +17,10 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 import unittest
+
 from utils import initialise_tests
 import numpy as np
-from cil.framework import ImageGeometry, AcquisitionGeometry, VectorGeometry, ImageData, Partitioner, AcquisitionData
+from cil.framework import ImageGeometry, AcquisitionGeometry, VectorGeometry, ImageData, Partitioner, AcquisitionData, DataContainer
 from cil.framework import BlockDataContainer, BlockGeometry
 import functools
 
@@ -643,7 +644,31 @@ class TestBlockDataContainer(BDCUnittest):
         out = cp0.sapyb(a,data1,b, num_threads=4)
         
         self.assertBlockDataContainerEqual(out, res)
-        
+
+    def test_BlockDataContainer_mixed_arithmetic(self):
+        a = numpy.ones([2, 2], dtype=numpy.float32) * 2
+        b = numpy.ones([2, 2], dtype=numpy.float32) * 4
+
+        bdc = BlockDataContainer(DataContainer(a))
+        dc = DataContainer(b)
+
+        sub1 = bdc - dc # 2 - 4
+        self.assertIsInstance(sub1, BlockDataContainer)
+        np.testing.assert_almost_equal(sub1.get_item(0).as_array(), -2, decimal=5)
+
+        sub2 = dc - bdc # 4 - 2
+        self.assertIsInstance(sub2, BlockDataContainer)
+        np.testing.assert_almost_equal(sub2.get_item(0).as_array(), 2, decimal=5)
+
+        div1 = bdc / dc # 2 / 4
+        self.assertIsInstance(div1, BlockDataContainer)
+        np.testing.assert_almost_equal(div1.get_item(0).as_array(), 0.5, decimal=5)
+
+        div2 = dc / bdc # 4 / 2
+        self.assertIsInstance(div2, BlockDataContainer)
+        np.testing.assert_almost_equal(div2.get_item(0).as_array(), 2, decimal=5)
+
+
 class TestOutParameter(BDCUnittest):
     def setUp(self):
         ig0 = ImageGeometry(2,3,4)


### PR DESCRIPTION
## Description

When doing an operation the `__container_priority__` is compared with other. If other has a higher priority, then the operator is called from other with self as the argument. This is fine for commutative operations, but not for sub and divide.

Use -other + self and other^-1 * self to ensure correct result

Add a test for these cases

## Example Usage

Can also test with the example on #2130





## Related issues/links
Closes #2130

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


