### PR TITLE
Switch to ASTRA direct_FP3D/BP3D interface

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -35,6 +35,7 @@ Institutions Key:
 12 - Australian e-Health Research, Australia
 13 - KU Leuven
 14 - Independent Contributor
+15 - Universiteit Leiden
 
 CIL Developers in date order:
 Edoardo Pasca (2017 – present) - 1
@@ -72,6 +73,7 @@ Nicholas Whyatt (2024) - 1
 Rasmia Kulan (2024) - 1
 Emmanuel Ferdman (2025) - 14
 Mariam Demir (2025) - 1
+Willem Jan Palenstijn (2025) - 15
 
 CIL Advisory Board:
 Llion Evans - 9

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
@@ -19,7 +19,7 @@ from cil.framework import DataProcessor, ImageData
 from cil.framework.labels import AcquisitionDimension, ImageDimension
 from cil.plugins.astra.utilities import convert_geometry_to_astra_vec_3D
 import astra
-from astra import astra_dict, algorithm, data3d
+import astra.experimental
 import numpy as np
 
 
@@ -44,8 +44,7 @@ class AstraBackProjector3D(DataProcessor):
         kwargs = {
                   'volume_geometry'  : volume_geometry,
                   'sinogram_geometry'  : sinogram_geometry,
-                  'proj_geom'  : None,
-                  'vol_geom'  : None}
+                  'projector_id'  : None}
 
         #DataProcessor.__init__(self, **kwargs)
         super(AstraBackProjector3D, self).__init__(**kwargs)
@@ -53,7 +52,11 @@ class AstraBackProjector3D(DataProcessor):
         self.set_ImageGeometry(volume_geometry)
         self.set_AcquisitionGeometry(sinogram_geometry)
 
-        self.vol_geom, self.proj_geom = convert_geometry_to_astra_vec_3D(self.volume_geometry, self.sinogram_geometry)
+        vol_geom, proj_geom = convert_geometry_to_astra_vec_3D(self.volume_geometry, self.sinogram_geometry)
+        self.projector_id = astra.create_projector('cuda3d', proj_geom, vol_geom)
+
+    def __del__(self):
+        astra.projector3d.delete(self.projector_id)
 
     def check_input(self, dataset):
 
@@ -95,20 +98,15 @@ class AstraBackProjector3D(DataProcessor):
         new_shape_ag = [self.sinogram_geometry.pixel_num_v,self.sinogram_geometry.num_projections,self.sinogram_geometry.pixel_num_h]
         data_temp = DATA.as_array().reshape(new_shape_ag)
 
+        new_shape_ig = [self.volume_geometry.voxel_num_z,self.volume_geometry.voxel_num_y,self.volume_geometry.voxel_num_x]
+        new_shape_ig = [x if x>0 else 1 for x in new_shape_ig]
+
         if out is None:
-            rec_id, arr_out = astra.create_backprojection3d_gpu(data_temp,
-                            self.proj_geom,
-                            self.vol_geom)
+            arr_out = np.zeros(new_shape_ig, dtype=np.float32)
         else:
-            new_shape_ig = [self.volume_geometry.voxel_num_z,self.volume_geometry.voxel_num_y,self.volume_geometry.voxel_num_x]
-            new_shape_ig = [x if x>0 else 1 for x in new_shape_ig]
             arr_out = out.as_array().reshape(new_shape_ig)
 
-            rec_id = astra.data3d.link('-vol', self.vol_geom, arr_out)
-            self.create_backprojection3d_gpu( data_temp, self.proj_geom, self.vol_geom, False, rec_id)
-
-        # delete the GPU copy
-        astra.data3d.delete(rec_id)
+        astra.experimental.direct_BP3D(self.projector_id, arr_out, data_temp)
 
         arr_out = np.squeeze(arr_out)
 
@@ -117,62 +115,3 @@ class AstraBackProjector3D(DataProcessor):
         else:
             out.fill(arr_out)
         return out
-
-    def create_backprojection3d_gpu(self, data, proj_geom, vol_geom, returnData=True, vol_id=None):
-
-        """
-        Call to ASTRA to create a backward projection of an image (3D)
-
-        Parameters
-        ----------
-
-        data : numpy.ndarray or int
-            Image data or ID.
-
-        proj_geom : dict
-            Projection geometry.
-
-        vol_geom : dict
-            Volume geometry.
-
-        returnData : bool
-            If False, only return the ID of the forward projection.
-
-        vol_id : int, default None
-            ID of the np array linked with astra.
-
-        Returns
-        -------
-
-        proj_geom : int or (int, numpy.ndarray)
-            If ``returnData=False``, returns the ID of the back projection. Otherwise returns a tuple containing the ID of the back projection and the back projection itself.
-        """
-
-        if isinstance(data, np.ndarray):
-            sino_id = data3d.create('-sino', proj_geom, data)
-        else:
-            sino_id = data
-
-        if vol_id is None:
-            vol_id = data3d.create('-vol', vol_geom, 0)
-
-        cfg = astra_dict('BP3D_CUDA')
-        cfg['ProjectionDataId'] = sino_id
-        cfg['ReconstructionDataId'] = vol_id
-        alg_id = algorithm.create(cfg)
-        algorithm.run(alg_id)
-        algorithm.delete(alg_id)
-
-        if isinstance(data, np.ndarray):
-            data3d.delete(sino_id)
-
-        if vol_id is not None:
-            if returnData:
-                return vol_id, data3d.get_shared(vol_id)
-            else:
-                return vol_id
-        else:
-            if returnData:
-                return vol_id, data3d.get(vol_id)
-            else:
-                return vol_id


### PR DESCRIPTION
## Description

Switch the Astra wrapper to use Astra's `direct_FP3D` and `direct_BP3D` functions for 3D Astra geometries. These functions provide a more concise interface and avoid unnecessary data copies.

This interface is supported from Astra 2.0. Starting from Astra 2.3, these functions also transparently accept DLPack tensors (including torch cpu/cuda tensors).


## Example Usage

All unit tests pass for me. This is a result from the CIL PyTorch integration hackathon, and has therefore only seen limited further testing.







<!-- please IGNORE the below if you aren't a CIL team member

blame GH for this text: https://github.com/orgs/community/discussions/81319

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
