### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/.github/ @TomographicImaging/cil-developers
+/recipe/ @TomographicImaging/cil-developers
+/scripts/ @TomographicImaging/cil-developers


### PR DESCRIPTION
Require @TomographicImaging/cil-developers review for potentially security-sensitive modifications, vis. [docs.github.com/about-code-owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

Might make it easier to catch issues like [CIL#2105#14](https://github.com/TomographicImaging/CIL/actions/runs/13914899253/job/38936065776)[^fn2105].

[^fn2105]: [CIL#2105#14](https://github.com/TomographicImaging/CIL/actions/runs/13914899253/job/38936065776) created a conda env without cleaning it up (the cleanup step was removed from the workflow).