### PR TITLE
Make zenodo_get an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   - Dependencies
       - matplotlib-base is an optional dependency, instead of required (#2093)
       - `unittest-parametrize has been added as a dependency for tests (#1990)
+      - zenodo_get is an optional dependency, instead of required (#2146)
 
 
 * 24.3.0

--- a/Wrappers/Python/cil/utilities/dataexample.py
+++ b/Wrappers/Python/cil/utilities/dataexample.py
@@ -27,10 +27,6 @@ import sys
 from zipfile import ZipFile
 from scipy.io import loadmat
 from cil.io import NEXUSDataReader, NikonDataReader, ZEISSDataReader
-try:
-    from zenodo_get import zenodo_get
-except ImportError:
-    zenodo_get = None
 
 class DATA(object):
     @classmethod
@@ -73,8 +69,10 @@ class REMOTEDATA(DATA):
             if user_input.lower() not in ('y', 'yes'):
                 print('Download cancelled')
                 return False
-
-            if zenodo_get is None:
+            
+            try:
+                from zenodo_get import zenodo_get
+            except ImportError as ie:
                 raise ImportError(f"Please install optional dependency zenodo_get to use dataexample.REMOTEDATA.download_data")
             
             zenodo_get([cls.ZENODO_RECORD, '-g', cls.ZIP_FILE, '-o', data_dir])

--- a/Wrappers/Python/cil/utilities/dataexample.py
+++ b/Wrappers/Python/cil/utilities/dataexample.py
@@ -27,7 +27,6 @@ import sys
 from zipfile import ZipFile
 from scipy.io import loadmat
 from cil.io import NEXUSDataReader, NikonDataReader, ZEISSDataReader
-from zenodo_get import zenodo_get
 
 class DATA(object):
     @classmethod
@@ -70,7 +69,12 @@ class REMOTEDATA(DATA):
             if user_input.lower() not in ('y', 'yes'):
                 print('Download cancelled')
                 return False
-
+            try:
+                from zenodo_get import zenodo_get
+            except ImportError as exc:
+                msg = "zenodo_get (e.g. `conda install conda-forge::zenodo_get`)"
+                raise ImportError(f"Please install {msg}") from exc
+            
             zenodo_get([cls.ZENODO_RECORD, '-g', cls.ZIP_FILE, '-o', data_dir])
             with ZipFile(os.path.join(data_dir, cls.ZIP_FILE), 'r') as zip_ref:
                 zip_ref.extractall(os.path.join(data_dir, cls.FOLDER))

--- a/Wrappers/Python/cil/utilities/dataexample.py
+++ b/Wrappers/Python/cil/utilities/dataexample.py
@@ -69,12 +69,8 @@ class REMOTEDATA(DATA):
             if user_input.lower() not in ('y', 'yes'):
                 print('Download cancelled')
                 return False
-            
-            try:
-                from zenodo_get import zenodo_get
-            except ImportError as ie:
-                raise ImportError(f"Please install optional dependency zenodo_get to use dataexample.REMOTEDATA.download_data")
-            
+
+            from zenodo_get import zenodo_get
             zenodo_get([cls.ZENODO_RECORD, '-g', cls.ZIP_FILE, '-o', data_dir])
             with ZipFile(os.path.join(data_dir, cls.ZIP_FILE), 'r') as zip_ref:
                 zip_ref.extractall(os.path.join(data_dir, cls.FOLDER))

--- a/Wrappers/Python/cil/utilities/dataexample.py
+++ b/Wrappers/Python/cil/utilities/dataexample.py
@@ -27,6 +27,10 @@ import sys
 from zipfile import ZipFile
 from scipy.io import loadmat
 from cil.io import NEXUSDataReader, NikonDataReader, ZEISSDataReader
+try:
+    from zenodo_get import zenodo_get
+except ImportError:
+    zenodo_get = None
 
 class DATA(object):
     @classmethod
@@ -69,11 +73,9 @@ class REMOTEDATA(DATA):
             if user_input.lower() not in ('y', 'yes'):
                 print('Download cancelled')
                 return False
-            try:
-                from zenodo_get import zenodo_get
-            except ImportError as exc:
-                msg = "zenodo_get (e.g. `conda install conda-forge::zenodo_get`)"
-                raise ImportError(f"Please install {msg}") from exc
+
+            if zenodo_get is None:
+                raise ImportError(f"Please install optional dependency zenodo_get to use dataexample.REMOTEDATA.download_data")
             
             zenodo_get([cls.ZENODO_RECORD, '-g', cls.ZIP_FILE, '-o', data_dir])
             with ZipFile(os.path.join(data_dir, cls.ZIP_FILE), 'r') as zip_ref:

--- a/Wrappers/Python/test/test_dataexample.py
+++ b/Wrappers/Python/test/test_dataexample.py
@@ -25,7 +25,7 @@ import os, sys, shutil
 from testclass import CCPiTestClass
 import platform
 import numpy as np
-from unittest.mock import patch 
+from unittest.mock import patch
 from zipfile import ZipFile
 from io import StringIO
 import uuid
@@ -241,7 +241,4 @@ class TestRemoteData(unittest.TestCase):
         
         with self.assertRaises(ValueError):
             remote_data.download_data('.')
-
-    def test_a(self):
-        from cil.utilities.dataexample import WALNUT
             

--- a/Wrappers/Python/test/test_dataexample.py
+++ b/Wrappers/Python/test/test_dataexample.py
@@ -29,8 +29,6 @@ from unittest.mock import patch
 from zipfile import ZipFile
 from io import StringIO
 import uuid
-if has_zenodo_get:
-    from zenodo_get import zenodo_get
 
 initialise_tests()
 
@@ -169,7 +167,7 @@ class TestRemoteData(unittest.TestCase):
 
             
     @patch('cil.utilities.dataexample.input', return_value='y')
-    @patch('cil.utilities.dataexample.zenodo_get', side_effect=mock_zenodo_get)
+    @patch('zenodo_get.zenodo_get', side_effect=mock_zenodo_get)
     @unittest.skipUnless(has_zenodo_get, "zenodo_get not installed")
     def test_download_data_input_y(self, mock_zenodo_get, input):
         '''
@@ -198,7 +196,7 @@ class TestRemoteData(unittest.TestCase):
 
 
     @patch('cil.utilities.dataexample.input', return_value='n')
-    @patch('cil.utilities.dataexample.zenodo_get', side_effect=mock_zenodo_get)   
+    @patch('zenodo_get.zenodo_get', side_effect=mock_zenodo_get)
     def test_download_data_input_n(self, mock_zenodo_get, input):
         '''
         Test the download_data function, when the user input is 'n' to 'are you sure you want to download data'

--- a/Wrappers/Python/test/test_dataexample.py
+++ b/Wrappers/Python/test/test_dataexample.py
@@ -17,7 +17,7 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 
 import unittest
-from utils import initialise_tests
+from utils import initialise_tests, has_zenodo_get
 from cil.framework import ImageGeometry, AcquisitionGeometry
 from cil.utilities import dataexample
 from cil.utilities import noise
@@ -29,7 +29,8 @@ from unittest.mock import patch
 from zipfile import ZipFile
 from io import StringIO
 import uuid
-from zenodo_get import zenodo_get
+if has_zenodo_get:
+    from zenodo_get import zenodo_get
 
 initialise_tests()
 
@@ -169,6 +170,7 @@ class TestRemoteData(unittest.TestCase):
             
     @patch('cil.utilities.dataexample.input', return_value='y')
     @patch('cil.utilities.dataexample.zenodo_get', side_effect=mock_zenodo_get)
+    @unittest.skipUnless(has_zenodo_get, "zenodo_get not installed")
     def test_download_data_input_y(self, mock_zenodo_get, input):
         '''
         Test the download_data function, when the user input is 'y' to 'are you sure you want to download data'

--- a/Wrappers/Python/test/utils.py
+++ b/Wrappers/Python/test/utils.py
@@ -134,6 +134,13 @@ else:
     has_matplotlib = True
 system_state['has_matplotlib'] = has_matplotlib
 
+#has_zenodo_get
+module_info = importlib.util.find_spec("zenodo_get")
+if module_info is None:
+    has_zenodo_get = False
+else:
+    has_zenodo_get = True
+system_state['has_zenodo_get'] = has_zenodo_get
 
 # to disable prints from 3rd part libraries and tests
 def disable_print():

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ test:
     - ccpi-regulariser=24.0.1 # [not osx]
     - astra-toolbox=2.1=cuda* # [not osx]
     - matplotlib-base >=3.3.0
+    - zenodo_get >=1.6
 
   source_files:
     - ./Wrappers/Python/test
@@ -71,7 +72,6 @@ requirements:
     - {{ pin_compatible('ipp', min_pin='x.x', max_pin='x.x') }}
     - tqdm
     - numba
-    - zenodo_get >=1.6
 
   #optional packages with version dependancies
   run_constrained:


### PR DESCRIPTION

## Changes

- Make zenodo_get an optional dependency.
- Only import when it's used

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc
zenodo_get remains as a test dependency, functionality using zenodo_get is tested in TestRemoteData

## Related issues/links
Closes #2113 

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

