### PR TITLE
Readers import simple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@
   - Enhancements:
       - Made the call to next() in algorithm iteration loop explicit (#2069)
       - Added option for a random seed in the power method in the linear operator (#1585)
+      - Defer import of olefile and dxchange (#2098)
   - Testing
       - Developers can now add `#all-tests` to their commit message on a PR to run the full matrix of GitHub actions tests (#2081)
+      - Fixed ZeissDataReader unit tests (#2098)
+  - Dependencies
+      - olefile and dxchange are an optional dependency, instead of required (#2098)
       
 
 

--- a/Wrappers/Python/cil/io/ZEISSDataReader.py
+++ b/Wrappers/Python/cil/io/ZEISSDataReader.py
@@ -160,12 +160,11 @@ class ZEISSDataReader(object):
 
     def read_metadata(self):
         # defer import
-        import olefile
         import dxchange
-
         # Read one image to get the metadata
         _,metadata = dxchange.read_txrm(self.file_name,((0,1),(None),(None)))
 
+        import olefile
         with olefile.OleFileIO(self.file_name) as ole:
             #Configure beam geometry
             xray_geometry = dxchange.reader._read_ole_value(ole, 'ImageInfo/XrayGeometry', '<i')

--- a/Wrappers/Python/cil/io/ZEISSDataReader.py
+++ b/Wrappers/Python/cil/io/ZEISSDataReader.py
@@ -22,13 +22,10 @@ from cil.framework import AcquisitionData, AcquisitionGeometry, ImageData, Image
 from cil.framework.labels import AngleUnit, AcquisitionDimension, ImageDimension
 import numpy as np
 import os
-import olefile
 import logging
+
 dxchange_logger = logging.getLogger('dxchange')
 dxchange_logger.setLevel(logging.ERROR)
-
-import dxchange
-import warnings
 
 
 class ZEISSDataReader(object):
@@ -162,6 +159,10 @@ class ZEISSDataReader(object):
             self._setup_image_geometry()
 
     def read_metadata(self):
+        # defer import
+        import olefile
+        import dxchange
+
         # Read one image to get the metadata
         _,metadata = dxchange.read_txrm(self.file_name,((0,1),(None),(None)))
 
@@ -258,6 +259,8 @@ class ZEISSDataReader(object):
         '''
         Reads projections and return Acquisition (TXRM) or Image (TXM) Data container
         '''
+        # defer imports
+        import dxchange
         # Load projections or slices from file
         slice_range = None
         if self._roi:

--- a/Wrappers/Python/test/test_io.py
+++ b/Wrappers/Python/test/test_io.py
@@ -105,17 +105,18 @@ class TestZeissDataReader(unittest.TestCase):
     def setUp(self):
         self.data_dir = tempfile.mkdtemp()
         print (f"Creating temp dir {self.data_dir}")
-
-        if has_file:
-            self.reader = ZEISSDataReader()           
         
-            self.reader.set_up(file_name=test_txrm_file)
+
 
     
     @unittest.skipIf(not (has_file and has_olefile and has_dxchange), 
                      f"Missing prerequisites: has_file {has_file}, has_olefile {has_olefile} has_dxchange {has_dxchange}")
     def test_geometry(self):
-        geometry = self.reader.get_geometry()
+        
+        reader = ZEISSDataReader()           
+        reader.set_up(file_name=test_txrm_file)
+
+        geometry = reader.get_geometry()
         # print (geometry)
         assert geometry is not None
         assert geometry.geom_type == 'CONE'
@@ -133,7 +134,9 @@ class TestZeissDataReader(unittest.TestCase):
         assert _geometry == geometry
 
     def read_data(self):
-        data = self.reader.read()
+        reader = ZEISSDataReader()           
+        reader.set_up(file_name=test_txrm_file)
+        data = reader.read()
         
         # Choose the number of voxels to reconstruct onto as number of detector pixels
         N = data.geometry.pixel_num_h
@@ -175,10 +178,12 @@ class TestZeissDataReader(unittest.TestCase):
         reader.set_up(file_name=test_2d_recon_file)
         gt = reader.read()
 
-        self.read_data()
+        zreader = ZEISSDataReader()           
+        zreader.set_up(file_name=test_txrm_file)
+        data = zreader.read()
 
         # get central slice
-        data2d = self.data.get_slice(vertical='centre')
+        data2d = data.get_slice(vertical='centre')
         # d512 = self.data.subset(vertical=512)
         # data2d.fill(d512.as_array())
         # neg log
@@ -205,8 +210,17 @@ class TestZeissDataReader(unittest.TestCase):
         
 
     def test_file_not_found_error(self):
+        reader = ZEISSDataReader()           
+        
         with self.assertRaises(FileNotFoundError):
-            reader = ZEISSDataReader(file_name='no-file')
+            reader.set_up(file_name='no-file')
+
+    @unittest.skipIf(not has_file, "Missing prerequisites: has_file")
+    def test_import_error(self):
+        reader = ZEISSDataReader()
+        with self.assertRaises(ImportError):
+            reader.set_up(file_name=test_txrm_file)
+            
 
 
 class TestTIFF(unittest.TestCase):

--- a/Wrappers/Python/test/test_io.py
+++ b/Wrappers/Python/test/test_io.py
@@ -123,7 +123,7 @@ class TestZeissDataReader(unittest.TestCase):
         assert geometry.dimension == '3D'
         
         from cil.framework import AcquisitionGeometry
-        metadata = self.reader.get_metadata()
+        metadata = reader.get_metadata()
         _geometry = AcquisitionGeometry.create_Cone3D(
                 [0,-metadata['dist_source_center'],0],[0,metadata['dist_center_detector'],0] \
                 ) \
@@ -191,11 +191,6 @@ class TestZeissDataReader(unittest.TestCase):
         data2d *= -1
 
         ig2d = data2d.geometry.get_ImageGeometry()
-        # Construct the appropriate ImageGeometry
-        ig2d = ImageGeometry(voxel_num_x=self.N,
-                            voxel_num_y=self.N,
-                            voxel_size_x=self.voxel_size_h,
-                            voxel_size_y=self.voxel_size_h)
         assert data2d.geometry is not None, "data2d geometry is None"
         fbpalg = FBP(ig2d,data2d.geometry)
         fbpalg.set_input(data2d)
@@ -215,7 +210,7 @@ class TestZeissDataReader(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             reader.set_up(file_name='no-file')
 
-    @unittest.skipIf(not has_file, "Missing prerequisites: has_file")
+    @unittest.skipIf(has_dxchange, f"Missing prerequisites: has_dxchange {has_dxchange}")
     def test_import_error(self):
         reader = ZEISSDataReader()
         with self.assertRaises(ImportError):


### PR DESCRIPTION
## Changes
Import changes from https://github.com/TomographicImaging/CIL/pull/2098
Defer the import of dxchange and olefile to when the functionality is used. This will enable importing from the io package even if olefile and/or dxchange are not available.
Separate this import from new tests suggested in https://github.com/TomographicImaging/CIL/pull/2098

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links
- closes #2088


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

