### PR TITLE
Added `@unittest.skipUnless(has_cvxpy, "cvxpy not available")` to APGD convergence test 

### DIFF
--- a/Wrappers/Python/test/test_algorithm_convergence.py
+++ b/Wrappers/Python/test/test_algorithm_convergence.py
@@ -146,7 +146,7 @@ class TestAlgorithmConvergence(CCPiTestClass):
         self.assertNumpyArrayAlmostEqual(apgd.solution.as_array(), b.as_array(), decimal=3)
         
     
-
+    @unittest.skipUnless(has_cvxpy, "cvxpy not available")
     def test_APGD_dossal_chambolle(self):
         
         np.random.seed(10)


### PR DESCRIPTION
## Related issues/links
Closes #2152 

## Checklist

- [x] I have performed a self-review of my code
~~[ ] I have added docstrings in line with the guidance in the developer guide~~
 ~~[ ] I have updated the relevant documentation~~
- [x] I have implemented unit tests that cover any new or modified functionality
~~[ ] CHANGELOG.md has been updated with any functionality change~~
- [x] Request review from all relevant developers
- [x] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


