### PR TITLE
Tried to make the step size property consistent across APGD, FISTA, I…

### DIFF
--- a/Wrappers/Python/cil/optimisation/algorithms/APGD.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/APGD.py
@@ -290,13 +290,17 @@ class APGD(Algorithm):
 
     @property
     def step_size(self):
+        '''
+        Returns the most recently used step size. Note, if the step-size is set by a non-constant step size rule, you must use the algorithm run or update method before this getter will return the most recently used step size. 
+        '''
+        
         if isinstance(self.step_size_rule, ConstantStepSize):
             return self.step_size_rule.step_size
         else:
-            try:
+            try: 
                 return self._step_size
-            except NameError:
-                return NotImplementedError("Note the step-size is set by a step-size rule and could change with each iteration. After running one update step, a step-size will be returned")
+            except AttributeError:
+                raise NotImplementedError("Note the step-size is set by a step-size rule and could change with each iteration. Call the algorithm run or update method first and then this function will give the most recently used step size.")
 
     @property
     def momentum(self):

--- a/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/FISTA.py
@@ -114,15 +114,19 @@ class ISTA(Algorithm):
 
     @property
     def step_size(self):
+        '''
+        Returns the most recently used step size. Note, if the step-size is set by a non-constant step size rule, you must use the algorithm run or update method before this getter will return the most recently used step size. 
+        '''
+        
         if isinstance(self.step_size_rule, ConstantStepSize):
             return self.step_size_rule.step_size
         else:
-            warnings.warn(
-                "Note the step-size is set by a step-size rule and could change wit each iteration")
-            return self.step_size_rule.get_step_size()
+            try: 
+                return self._step_size
+            except AttributeError:
+                raise NotImplementedError("Note the step-size is set by a step-size rule and could change with each iteration. Call the algorithm run or update method first and then this function will give the most recently used step size.")
 
     # Set default step size
-
     def _calculate_default_step_size(self):
         """ Calculates the default step size if a step size rule or a step size is not provided. 
         """
@@ -135,7 +139,6 @@ class ISTA(Algorithm):
     def __init__(self, initial, f, g, step_size=None, preconditioner=None, **kwargs):
 
         super(ISTA, self).__init__(**kwargs)
-        self._step_size = step_size
         self.set_up(initial=initial, f=f, g=g, step_size=step_size,
                     preconditioner=preconditioner, **kwargs)
 
@@ -190,14 +193,14 @@ class ISTA(Algorithm):
                 self, self.gradient_update, out=self.gradient_update)
 
         try:
-            step_size = self.step_size_rule.get_step_size(self)
+            self._step_size = self.step_size_rule.get_step_size(self)
         except NameError:
             raise NameError(msg='`step_size` must be `None`, a real float or a child class of :meth:`cil.optimisation.utilities.StepSizeRule`')
 
-        self.x_old.sapyb(1., self.gradient_update, -step_size, out=self.x_old)
+        self.x_old.sapyb(1., self.gradient_update, -self._step_size, out=self.x_old)
 
         # proximal step
-        self.g.proximal(self.x_old, step_size, out=self.x)
+        self.g.proximal(self.x_old, self._step_size, out=self.x)
 
     def _update_previous_solution(self):
         """ Swaps the references to current and previous solution based on the :func:`~Algorithm.update_previous_solution` of the base class :class:`Algorithm`.
@@ -348,11 +351,11 @@ class FISTA(ISTA):
             self.preconditioner.apply(
                 self, self.gradient_update, out=self.gradient_update)
 
-        step_size = self.step_size_rule.get_step_size(self)
+        self._step_size = self.step_size_rule.get_step_size(self)
 
-        self.y.sapyb(1., self.gradient_update, -step_size, out=self.y)
+        self.y.sapyb(1., self.gradient_update, -self._step_size, out=self.y)
 
-        self.g.proximal(self.y, step_size, out=self.x)
+        self.g.proximal(self.y, self._step_size, out=self.x)
 
         self.t = 0.5*(1 + numpy.sqrt(1 + 4*(self.t_old**2)))
 

--- a/Wrappers/Python/cil/optimisation/algorithms/GD.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/GD.py
@@ -36,7 +36,7 @@ class GD(Algorithm):
     f: CIL function (:meth:`~cil.optimisation.functions.Function`. ) with a defined gradient method 
         The function to be minimised. 
     step_size: positive real float or subclass of :meth:`~cil.optimisation.utilities.StepSizeRule`, default = None 
-        If you pass a float this will be used as a constant step size. If left as None and do not pass a step_size_rule then the Armijio rule will be used to perform backtracking to choose a step size at each iteration. If a child class of :meth:`cil.optimisation.utilities.StepSizeRule`' is passed then it's method `get_step_size` is called for each update. 
+        If you pass a float this will be used as a constant step size. If left as None and do not pass a step size rule then the Armijio rule will be used to perform backtracking to choose a step size at each iteration. If a child class of :meth:`cil.optimisation.utilities.StepSizeRule`' is passed then it's method `get_step_size` is called for each update. 
     preconditioner: class with a `apply` method or a function that takes an initialised CIL function as an argument and modifies a provided `gradient`.
             This could be a custom `preconditioner` or one provided in :meth:`~cil.optimisation.utilities.preconditioner`. If None is passed  then `self.gradient_update` will remain unmodified. 
 
@@ -119,9 +119,9 @@ class GD(Algorithm):
             self.preconditioner.apply(
                 self, self.gradient_update, out=self.gradient_update)
 
-        step_size = self.step_size_rule.get_step_size(self)
+        self._step_size = self.step_size_rule.get_step_size(self)
 
-        self.x.sapyb(1.0, self.gradient_update, -step_size, out=self.x)
+        self.x.sapyb(1.0, self.gradient_update, -self._step_size, out=self.x)
 
     def update_objective(self):
         self.loss.append(self._objective_function(self.solution))
@@ -137,11 +137,18 @@ class GD(Algorithm):
 
     @property
     def step_size(self):
+        '''
+        Returns the most recently used step size. Note, if the step-size is set by a non-constant step size rule, you must use the algorithm run or update method before this getter will return the most recently used step size. 
+        '''
+        
         if isinstance(self.step_size_rule, ConstantStepSize):
             return self.step_size_rule.step_size
         else:
-            raise TypeError(
-                "There is not a constant step size, it is set by a step-size rule")
+            try: 
+                return self._step_size
+            except AttributeError:
+                raise NotImplementedError("Note the step-size is set by a step-size rule and could change with each iteration. Call the algorithm run or update method first and then this function will give the most recently used step size.")
+
 
     def calculate_objective_function_at_point(self, x):
         """ Calculates the objective at a given point x


### PR DESCRIPTION

## Changes
Tried to make the step size property consistent across APGD, FISTA, ISTA and GD. Updated the tests
The getter should no longer increment the step size 


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links
Closes #2151 
## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

