### PR TITLE
data env var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,8 @@ jobs:
     - name: test
       run: |
         conda activate "${{ steps.reqs.outputs.envname }}"
-        TESTS_FORCE_GPU=1 python -m unittest discover -v -k tigre -k TIGRE -k astra -k ASTRA -k gpu -k GPU ./Wrappers/Python/test
+        test -d $HOME/.cache/cil || cp -r $(python -c 'import sys; print(sys.prefix)')/share/cil $HOME/.cache/
+        TESTS_FORCE_GPU=1 CIL_DATA_DIR=$HOME/.cache/cil python -m unittest discover -v -k tigre -k TIGRE -k astra -k ASTRA -k gpu -k GPU ./Wrappers/Python/test
     - if: always()
       name: Post Run conda-incubator/setup-miniconda@v3
       shell: bash
@@ -104,7 +105,7 @@ jobs:
         echo "Extracted Commit Message: $COMMIT_MESSAGE"
         echo "Extracted GITHUB_REF: $GITHUB_REF"
 
-        if [[ "$COMMIT_MESSAGE" == *"#all-tests"* || "$GITHUB_REF" == "refs/heads/master" || "$GITHUB_REF" == refs/tags/* ]]; then 
+        if [[ "$COMMIT_MESSAGE" == *"#all-tests"* || "$GITHUB_REF" == "refs/heads/master" || "$GITHUB_REF" == refs/tags/* ]]; then
           echo "python-version=['3.10', 3.11]" >> $GITHUB_OUTPUT
           echo "numpy-version=[1.23, 1.24, 1.25, 1.26]" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,7 @@ jobs:
     - name: test
       run: |
         conda activate "${{ steps.reqs.outputs.envname }}"
-        test -d $HOME/.cache/cil || cp -r $(python -c 'import sys; print(sys.prefix)')/share/cil $HOME/.cache/
-        TESTS_FORCE_GPU=1 CIL_DATA_DIR=$HOME/.cache/cil python -m unittest discover -v -k tigre -k TIGRE -k astra -k ASTRA -k gpu -k GPU ./Wrappers/Python/test
+        TESTS_FORCE_GPU=1 CIL_DATA_DIR=/opt/runner/hostedtoolcache/cil python -m unittest discover -v -k tigre -k TIGRE -k astra -k ASTRA -k gpu -k GPU ./Wrappers/Python/test
     - if: always()
       name: Post Run conda-incubator/setup-miniconda@v3
       shell: bash

--- a/Wrappers/Python/cil/utilities/dataexample.py
+++ b/Wrappers/Python/cil/utilities/dataexample.py
@@ -63,8 +63,9 @@ class REMOTEDATA(DATA):
 
         Parameters
         ----------
-        data_dir: str, optional
-           The path to the data directory where the downloaded data should be stored
+        data_dir: str
+           The path to the data directory where the downloaded data should be stored.
+           If unspecified, tries to use the CIL_DATA_DIR environment variable.
         '''
         cls.assert_dir(data_dir)
         if os.path.isdir(os.path.join(data_dir, cls.FOLDER)):

--- a/Wrappers/Python/cil/utilities/dataexample.py
+++ b/Wrappers/Python/cil/utilities/dataexample.py
@@ -34,7 +34,7 @@ class DATA(object):
         return None
 
 class CILDATA(DATA):
-    data_dir = os.getenv("CIL_DATA_DIR", os.path.abspath(os.path.join(sys.prefix, 'share','cil')))
+    data_dir = os.path.abspath(os.path.join(sys.prefix, 'share','cil'))
     @classmethod
     def get(cls, size=None, scale=(0,1), **kwargs):
         ddir = kwargs.get('data_dir', CILDATA.data_dir)
@@ -42,17 +42,22 @@ class CILDATA(DATA):
         return loader.load(cls.dfile(), size, scale, **kwargs)
 
 class REMOTEDATA(DATA):
-
     FOLDER = ''
     ZENODO_RECORD = ''
     ZIP_FILE = ''
+    CIL_DATA_DIR = os.getenv("CIL_DATA_DIR", None)
 
     @classmethod
-    def get(cls, data_dir):
-        return None
+    def assert_dir(cls, data_dir):
+        if data_dir is None:
+            raise NotADirectoryError("data_dir must be specified")
 
     @classmethod
-    def download_data(cls, data_dir, prompt=True):
+    def get(cls, data_dir=CIL_DATA_DIR):
+        raise NotImplementedError
+
+    @classmethod
+    def download_data(cls, data_dir=CIL_DATA_DIR, prompt=True):
         '''
         Download a dataset from a remote repository
 
@@ -60,10 +65,10 @@ class REMOTEDATA(DATA):
         ----------
         data_dir: str, optional
            The path to the data directory where the downloaded data should be stored
-
         '''
+        cls.assert_dir(data_dir)
         if os.path.isdir(os.path.join(data_dir, cls.FOLDER)):
-            print("Dataset folder already exists in " + data_dir)
+            print(f"Dataset folder already exists in {data_dir}")
         else:
             user_input = input("Are you sure you want to download {cls.ZIP_FILE} dataset from Zenodo record {cls.ZENODO_RECORD}? [Y/n]: ") if prompt else 'y'
             if user_input.lower() not in ('y', 'yes'):
@@ -206,7 +211,7 @@ class WALNUT(REMOTEDATA):
     ZIP_FILE = 'walnut.zip'
 
     @classmethod
-    def get(cls, data_dir):
+    def get(cls, data_dir=REMOTEDATA.CIL_DATA_DIR):
         '''
         Get the microcomputed tomography dataset of a walnut from https://zenodo.org/records/4822516
         This function returns the raw projection data from the .txrm file
@@ -221,6 +226,7 @@ class WALNUT(REMOTEDATA):
         ImageData
             The walnut dataset
         '''
+        cls.assert_dir(data_dir)
         filepath = os.path.join(data_dir, cls.FOLDER, 'valnut','valnut_2014-03-21_643_28','tomo-A','valnut_tomo-A.txrm')
         try:
             loader = ZEISSDataReader(file_name=filepath)
@@ -244,7 +250,7 @@ class USB(REMOTEDATA):
     ZIP_FILE = 'usb.zip'
 
     @classmethod
-    def get(cls, data_dir):
+    def get(cls, data_dir=REMOTEDATA.CIL_DATA_DIR):
         '''
         Get the microcomputed tomography dataset of a usb memory stick from https://zenodo.org/records/4822516
         This function returns the raw projection data from the .txrm file
@@ -259,6 +265,7 @@ class USB(REMOTEDATA):
         ImageData
             The usb dataset
         '''
+        cls.assert_dir(data_dir)
         filepath = os.path.join(data_dir, cls.FOLDER, 'gruppe 4','gruppe 4_2014-03-20_1404_12','tomo-A','gruppe 4_tomo-A.txrm')
         try:
             loader = ZEISSDataReader(file_name=filepath)
@@ -282,7 +289,7 @@ class KORN(REMOTEDATA):
     ZIP_FILE = 'korn.zip'
 
     @classmethod
-    def get(cls, data_dir):
+    def get(cls, data_dir=REMOTEDATA.CIL_DATA_DIR):
         '''
         Get the microcomputed tomography dataset of a sunflower seeds in a box from https://zenodo.org/records/6874123
         This function returns the raw projection data from the .xtekct file
@@ -298,6 +305,7 @@ class KORN(REMOTEDATA):
             The korn dataset
 
         '''
+        cls.assert_dir(data_dir)
         filepath = os.path.join(data_dir, cls.FOLDER, 'Korn i kasse','47209 testscan korn01_recon.xtekct')
         try:
             loader = NikonDataReader(file_name=filepath)
@@ -323,7 +331,7 @@ class SANDSTONE(REMOTEDATA):
     ZIP_FILE = 'small.zip'
 
     @classmethod
-    def get(cls, data_dir, filename):
+    def get(cls, data_dir=REMOTEDATA.CIL_DATA_DIR, filename=None):
         '''
         Get the synchrotron x-ray tomography dataset of sandstone from https://zenodo.org/records/4912435
         A small subset of the data containing selected projections and 4 slices of the reconstruction
@@ -340,6 +348,9 @@ class SANDSTONE(REMOTEDATA):
         ImageData
             The selected sandstone dataset
         '''
+        cls.assert_dir(data_dir)
+        if filename is None:
+            raise FileNotFoundError("filename must be specified")
         extension = os.path.splitext(filename)[1]
         if extension == '.mat':
             return loadmat(os.path.join(data_dir,filename))

--- a/Wrappers/Python/cil/utilities/dataexample.py
+++ b/Wrappers/Python/cil/utilities/dataexample.py
@@ -34,7 +34,7 @@ class DATA(object):
         return None
 
 class CILDATA(DATA):
-    data_dir = os.path.abspath(os.path.join(sys.prefix, 'share','cil'))
+    data_dir = os.getenv("CIL_DATA_DIR", os.path.abspath(os.path.join(sys.prefix, 'share','cil')))
     @classmethod
     def get(cls, size=None, scale=(0,1), **kwargs):
         ddir = kwargs.get('data_dir', CILDATA.data_dir)
@@ -344,7 +344,7 @@ class SANDSTONE(REMOTEDATA):
         if extension == '.mat':
             return loadmat(os.path.join(data_dir,filename))
         raise KeyError(f"Unknown extension: {extension}")
-        
+
 
 class TestData(object):
     '''Class to return test data

--- a/Wrappers/Python/test/test_io.py
+++ b/Wrappers/Python/test/test_io.py
@@ -64,7 +64,7 @@ if has_astra:
 # change basedir to point to the location of the walnut dataset which can
 # be downloaded from https://zenodo.org/record/4822516
 # basedir = os.path.abspath('/home/edo/scratch/Data/Walnut/valnut_2014-03-21_643_28/tomo-A/')
-basedir = data_dir = os.path.abspath(os.path.join(sys.prefix, 'share','cil'))
+basedir = data_dir = dataexample.CILDATA.data_dir
 filename = os.path.join(basedir, "valnut_tomo-A.txrm")
 has_file = os.path.isfile(filename)
 

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -19,6 +19,8 @@
 Utilities
 *********
 
+By default, CIL will look for data in the `CIL_DATA_DIR` environment variable (if present),
+or `{sys.prefix}/share/cil` otherwise.
 
 Test datasets
 =============

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -19,8 +19,8 @@
 Utilities
 *********
 
-By default, CIL will look for data in the `CIL_DATA_DIR` environment variable (if present),
-or `{sys.prefix}/share/cil` otherwise.
+By default, CIL will look for small (built-in) data in `{sys.prefix}/share/cil`,
+and larger remote (downloadable) data in the `CIL_DATA_DIR` environment variable (if present).
 
 Test datasets
 =============


### PR DESCRIPTION
- expose `CIL_DATA_DIR` (fixes #1708)
- update self-hosted CI to use cache
- update docs

Note: all notebook demos should be updated to use `cil.utilities.dataexample.{CILDATA.data_dir,REMOTEDATA.CIL_DATA_DIR}`