### PR TITLE
Allow zeros in preview_configuration for FluxNormaliser

### DIFF
--- a/Wrappers/Python/cil/processors/FluxNormaliser.py
+++ b/Wrappers/Python/cil/processors/FluxNormaliser.py
@@ -22,6 +22,7 @@ from cil.utilities import multiprocessing as cil_mp
 import numpy
 import logging
 import numba
+import warnings
 
 log = logging.getLogger(__name__)
 
@@ -212,11 +213,6 @@ class FluxNormaliser(Processor):
                 raise ValueError("Flux must be a scalar or array with length \
                                     \n = number of projections, found {} and {}"
                                     .format(flux_size_flat, data_size_flat))
-            
-        # check if flux array contains 0s
-        if 0 in self.flux:
-            raise ValueError('Flux value can\'t be 0, provide a different flux\
-                                or region of interest with non-zero values')
           
     def _calculate_target(self):
         '''
@@ -278,6 +274,12 @@ class FluxNormaliser(Processor):
         import matplotlib.pyplot as plt
 
         self._calculate_flux()
+
+        # check if flux array contains 0s
+        if 0 in self.flux:
+            warnings.warn('Flux value can\'t be 0, provide a different flux\
+                                or region of interest with non-zero values')
+
         if self.roi_slice is None:
             raise ValueError('Preview available with roi, run `processor= FluxNormaliser(roi=roi)` then `set_input(data)`')
         else:
@@ -437,6 +439,10 @@ class FluxNormaliser(Processor):
     def process(self, out=None):
         self._calculate_flux()
         self._calculate_target()
+
+        if 0 in self.flux:
+            raise ValueError('Flux value can\'t be 0, provide a different flux\
+                                or region of interest with non-zero values')
 
         data = self.get_input()
         if out is None:

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -3240,22 +3240,22 @@ class TestFluxNormaliser(unittest.TestCase):
         processor = FluxNormaliser(flux = 0)
         processor.set_input(self.data_cone)
         with self.assertRaises(ValueError):
-            processor._calculate_flux()
+            processor.get_output()
 
         processor = FluxNormaliser(flux = 0.0)
         processor.set_input(self.data_cone)
         with self.assertRaises(ValueError):
-            processor._calculate_flux()
+            processor.get_output()
 
         processor = FluxNormaliser(flux=numpy.zeros(len(self.data_cone.geometry.angles)))
         processor.set_input(self.data_cone)
         with self.assertRaises(ValueError):
-            processor._calculate_flux()
+            processor.get_output()
 
         processor = FluxNormaliser(flux=numpy.zeros(len(self.data_cone.geometry.angles), dtype=numpy.uint16))
         processor.set_input(self.data_cone)
         with self.assertRaises(ValueError):
-            processor._calculate_flux()
+            processor.get_output()
 
     def test_calculate_target(self):
 


### PR DESCRIPTION
## Changes
We trigger an error if there are zeros in the flux array to prevent division by zero. But the error is also triggered when we try to use preview_configuration. However it would be better if it didn't fail here because it would be useful to use preview_configuration to check if there are zeros.

Move the error to process and instead show a warning in preview_configuration.

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links
Closes #2129 

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

