### PR TITLE
cmake version range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 if(APPLE)
-  cmake_minimum_required(VERSION 3.16...4.0)
+  cmake_minimum_required(VERSION 3.16...4.1)
 else()
-  cmake_minimum_required(VERSION 3.5...4.0)
+  cmake_minimum_required(VERSION 3.5...4.1)
 endif()
 
 if(NOT SKBUILD_PROJECT_NAME)


### PR DESCRIPTION
effectively this PR means "the cmake minimum required version is unchanged (3.5), but we have tested that there are no breaking changes in later versions (up to 4.1)"

- fixes #2181
- fixes https://github.com/SyneRBI/SIRF-SuperBuild/issues/947