### PR TITLE
Load and render user showcase notebooks in docs

### DIFF
--- a/docs/mkdemos.py
+++ b/docs/mkdemos.py
@@ -12,8 +12,8 @@ from tqdm import tqdm
 
 # URLS of the notebooks to render
 NOTEBOOKS_load_links = [
-    "https://tomography.stfc.ac.uk/how-tos/ZeissDataReader.ipynb",
-    "https://tomography.stfc.ac.uk/how-tos/NikonDataReader.ipynb"
+    # "https://tomography.stfc.ac.uk/how-tos/ZeissDataReader.ipynb",
+    # "https://tomography.stfc.ac.uk/how-tos/NikonDataReader.ipynb"
 ]
 
 NOTEBOOKS_geometry_links = [
@@ -21,8 +21,27 @@ NOTEBOOKS_geometry_links = [
 ]
 
 NOTEBOOKS_advanced_links = [
-    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/003_1D_integral_inverse_problem/deriv2_cgls.ipynb",
     "https://github.com/TomographicImaging/CIL-Demos/raw/main/misc/callback_demonstration.ipynb"
+]
+
+NOTEBOOKS_usershowcase_links = [
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/001_multibang_regularisation/Multibang_Hackathon2023.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/002_Deblurring/Showcase_of_the_algorithms_for_deblurring_and_denoising.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/003_1D_integral_inverse_problem/deriv2_cgls.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/004_STEMPO-DynamicCT/stempo2d_v2_1.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/005_dynamic_mr_recon/dynamic_mr_recon.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/006_gVXR2CIL/CBCT-acquisition-with-noise-and-reconstruction.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/007_Hyperspectral_regularisation/Hyperspectral_regularisation.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/008_KL_divergence_and_weighted_least_squares/LS_WLS_KL_TotalVariation.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/009_offset_CT_apple/Apple_offset_reconstruction.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/010_reconstruct_BrukerSkyscan_data/bruker2cil.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/011_phasecontrast_exciscope/recon_phasecontrast_exciscope.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/012_wavelet_sparsity_controlled_regularization/controlledWaveletSparsity_2d.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/012_wavelet_sparsity_controlled_regularization/controlledWaveletSparsity_3d.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/013_anisotropic_regularization_for_FILD_measurements/013_Anisotropic_regularisation_FILD_measurements.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/014_GVXR_simulation_and_CIL_CPU_reconstruction/Simulation_and_CPU_reconstruction.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/015_Memory_Profiling_LSQR_CGLS/memory_profiling_sandstone.ipynb",
+    "https://github.com/TomographicImaging/CIL-User-Showcase/raw/main/016_cil_torch_fista_pnp/fista_with_denoiser.ipynb"
 ]
 
 SOURCE = Path(__file__).parent / "source" # sphinx documentation dir
@@ -48,6 +67,7 @@ def download_notebooks(urls):
 notebooks_load = download_notebooks(NOTEBOOKS_load_links)
 notebooks_geometry = download_notebooks(NOTEBOOKS_geometry_links)
 notebooks_advanced = download_notebooks(NOTEBOOKS_advanced_links)
+notebooks_usershowcase = download_notebooks(NOTEBOOKS_usershowcase_links)
 
 # load template
 tmp = Template((SOURCE / '..' / 'demos-template.rst').read_text())
@@ -55,5 +75,12 @@ tmp = Template((SOURCE / '..' / 'demos-template.rst').read_text())
 (SOURCE / 'demos.rst').write_text(tmp.safe_substitute(
     notebooks_load=notebooks_load,
     notebooks_geometry=notebooks_geometry,
-    notebooks_advanced=notebooks_advanced
+    notebooks_advanced=notebooks_advanced,
+    notebooks_usershowcase=notebooks_usershowcase
+))
+
+tmp = Template((SOURCE / '..' / 'usershowcase-template.rst').read_text())
+# write to usershowcase.rst
+(SOURCE / 'usershowcase.rst').write_text(tmp.safe_substitute(
+    notebooks_usershowcase=notebooks_usershowcase
 ))

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,6 +68,7 @@ Table of Contents
    plugins
    developer_guide
    demos
+   usershowcase
 
 .. Indices and tables
 .. ==================

--- a/docs/usershowcase-template.rst
+++ b/docs/usershowcase-template.rst
@@ -1,0 +1,6 @@
+User showcase
+*************
+This page contains example notebooks demonstrating how CIL users have solved a variety of interesting problems using CIL tools. Click below to see the rendered notebooks, or access and run the code yourself from https://github.com/TomographicImaging/CIL-User-Showcase/tree/main 
+
+.. nbgallery::
+${notebooks_usershowcase}


### PR DESCRIPTION
## Changes
Create page in documentation for rendered user showcase notebooks
<img width="697" height="900" alt="image" src="https://github.com/user-attachments/assets/9210fa2e-94c9-4f13-93d0-248d362eaa43" />


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties


