### PR TITLE
Skip rendering notebooks in documentation if URL inaccessible

### DIFF
--- a/docs/mkdemos.py
+++ b/docs/mkdemos.py
@@ -40,9 +40,18 @@ def download_notebooks(urls):
         for url in nb_urls :
             notebook = Path(urlparse(url).path)
             nb_urls.set_description(notebook.stem)
-            with urlopen(url) as response:
-                (SOURCE / NBDIR / notebook.name).write_bytes(response.read())
-            notebooks.append(f"    {NBDIR}/{notebook.stem}")
+            dest_path = SOURCE / NBDIR / notebook.name
+            try:
+                with urlopen(url) as response:
+                    dest_path.write_bytes(response.read())
+            
+            except Exception as e:
+                print(f"Warning: Could not download {url}. Error: {e}")
+                if not dest_path.exists():
+                    print(f"  No existing file found for {notebook.name}, skipping.")
+                    continue  # Skip adding to the list if no file exists
+
+                notebooks.append(f"    {NBDIR}/{notebook.stem}")
     return "\n".join(notebooks)
 
 notebooks_load = download_notebooks(NOTEBOOKS_load_links)


### PR DESCRIPTION
## Changes
When we render example notebooks in the documentation, don't fail if a notebook URL is inaccessible

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties
