### PR TITLE
Add a flag to show_geometry that allows for disabling the call to plt.show()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
     - Improved consistency of `step_size` property across GD, ISTA, FISTA and APGD algorithms (#2157)
     - In PDHG algorithm, we now have options to initialise the dual variable, as well as the primal variable (#2169)
     - Allow FluxNormaliser.preview_configuration() even if flux contains zeros (#2177)
+    - Added a flag to `show_geometry` that allows for disabling the call to `plt.show()` (#2194)
   - Testing:
     - Developers can now run the full CI matrix [via the web UI](https://github.com/TomographicImaging/CIL/actions/workflows/build.yml) (#2160)
     - Added tests for ProjectionOperator inputs that use `unittest-parametrize` module (#1990)

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -76,7 +76,8 @@ Emmanuel Ferdman (2025) - 14
 Mariam Demir (2025) - 1
 Satwik Pani (2025) - 15
 Hok Shing Wong (2025) - 7
-Francis M Watson (2025) - 3 
+Francis M Watson (2025) - 3
+Hussam Alhassan (2025) - 1
 
 CIL Advisory Board:
 Llion Evans - 9

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -420,6 +420,8 @@ class show2D(show_base):
         Sets the number of columns of subplots to display
     size: tuple
         Figure size in inches
+    show: bool
+        Show Matplotlib figure window, default=True
 
         
     Note
@@ -1059,9 +1061,6 @@ class show_geometry(show_base):
         Set figure size (inches), default (10,10)
     fontsize: int
         Set fontsize, default 10
-    show: bool
-        Show Matplotlib figure window, default=True
-
         
     Note
     ----

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -752,7 +752,7 @@ class _ShowGeometry(object):
         self.handles = []
         self.labels = []
 
-    def draw(self, elev=35, azim=35, view_distance=10, grid=False, figsize=(10,10), fontsize=10):
+    def draw(self, elev=35, azim=35, view_distance=10, grid=False, figsize=(10,10), fontsize=10, show=True):
 
         self.fig = plt.figure(figsize=figsize)
         self.ax = self.fig.add_subplot(111, projection='3d')
@@ -801,7 +801,10 @@ class _ShowGeometry(object):
 
         #plt.show() creates a new figure so we save a copy to return
         fig2 = plt.gcf()
-        plt.show()
+
+        if show:
+            plt.show()
+
         return fig2
 
     def display_world(self):
@@ -1055,6 +1058,8 @@ class show_geometry(show_base):
         Set figure size (inches), default (10,10)
     fontsize: int
         Set fontsize, default 10
+    show: bool
+        Show Matplotlib figure window, default=True
 
         
     Note
@@ -1068,10 +1073,10 @@ class show_geometry(show_base):
     '''
 
 
-    def __init__(self,acquisition_geometry, image_geometry=None, elevation=20, azimuthal=-35, view_distance=10, grid=False, figsize=(10,10), fontsize=10):
+    def __init__(self,acquisition_geometry, image_geometry=None, elevation=20, azimuthal=-35, view_distance=10, grid=False, figsize=(10,10), fontsize=10, show=True):
         if AcquisitionType.DIM2 & acquisition_geometry.dimension:
             elevation = 90
             azimuthal = 0
 
         self.display = _ShowGeometry(acquisition_geometry, image_geometry)
-        self.figure = self.display.draw(elev=elevation, azim=azimuthal, view_distance=view_distance, grid=grid, figsize=figsize, fontsize=fontsize)
+        self.figure = self.display.draw(elev=elevation, azim=azimuthal, view_distance=view_distance, grid=grid, figsize=figsize, fontsize=fontsize, show=show)

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -420,8 +420,6 @@ class show2D(show_base):
         Sets the number of columns of subplots to display
     size: tuple
         Figure size in inches
-    show: bool
-        Show Matplotlib figure window, default=True
 
         
     Note
@@ -1061,6 +1059,8 @@ class show_geometry(show_base):
         Set figure size (inches), default (10,10)
     fontsize: int
         Set fontsize, default 10
+    show: bool
+        Show Matplotlib figure window, default=True
         
     Note
     ----

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -16,6 +16,7 @@
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 # Kyle Pidgeon (UKRI-STFC)
+# Hussam Alhassan (UKRI-STFC)
 
 
 import matplotlib.lines as mlines


### PR DESCRIPTION
## Description

This change was requested by the Mantid Imaging project (https://github.com/mantidproject/mantidimaging)

The following changes have been made:
* Added the `show` flag to the `show_geometry` class with a default value of True
* Made the call to `plt.show()` conditional on the `show` flag
* Updated `show_geometry` docstring
* Changelog

## Example Usage
<!--minimal working example-->

Creating an instance of `show_geometry(show=False)` no longer spawns the Matplotlib figure window. 

## Checklist
- [x] I have performed a self-review of my code
- [x] CHANGELOG.md has been updated with any functionality change
- [ ] Change pull request label to 'Waiting for review'
- [x] I have updated docstrings in line with the guidance in the developer guide

<!-- please IGNORE the below if you aren't a CIL team member

blame GH for this text: https://github.com/orgs/community/discussions/81319

## Changes

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist


- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality


## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
