### PR TITLE
CI: drop numpy conda matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,16 +87,13 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       python-version: ${{ steps.matrix.outputs.python-version }}
-      numpy-version: ${{ steps.matrix.outputs.numpy-version }}
     steps:
     - id: matrix
       run: |
         if ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') || github.event_name == 'workflow_dispatch' }}; then
-          echo "python-version=['3.10', 3.11]" >> $GITHUB_OUTPUT
-          echo "numpy-version=[1.23, 1.24, 1.25, 1.26]" >> $GITHUB_OUTPUT
+          echo "python-version=['3.10', 3.11, 3.12]" >> $GITHUB_OUTPUT
         else
           echo "python-version=['3.10']" >> $GITHUB_OUTPUT
-          echo "numpy-version=[1.23]" >> $GITHUB_OUTPUT
         fi
   conda:
     defaults: {run: {shell: 'bash -el {0}'}}
@@ -105,10 +102,6 @@ jobs:
     strategy:
       matrix:
         python-version: ${{ fromJson(needs.conda-matrix.outputs.python-version) }}
-        numpy-version: ${{ fromJson(needs.conda-matrix.outputs.numpy-version) }}
-        include:
-        - python-version: 3.12
-          numpy-version: 1.26
     steps:
     - uses: actions/checkout@v4
       with:
@@ -125,10 +118,10 @@ jobs:
       working-directory: recipe
       run: |
         conda install boa
-        conda mambabuild . -c conda-forge -c https://tomography.stfc.ac.uk/conda --override-channels --python=${{ matrix.python-version }} --numpy=${{ matrix.numpy-version }} --output-folder .
+        conda mambabuild . -c conda-forge -c https://tomography.stfc.ac.uk/conda --override-channels --python=${{ matrix.python-version }} --output-folder .
     - uses: actions/upload-artifact@v4
       with:
-        name: cil-package-py${{ matrix.python-version }}-np${{ matrix.numpy-version }}
+        name: cil-package-py${{ matrix.python-version }}
         path: recipe/linux-64/cil*
     - name: anaconda upload -c ccpi
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
Fix failing CI due to redundant numpy builds no longer needed after #2156.

Also saves ~1h GHA CI usage per merge.
