### PR TITLE
CI: fix conda upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,19 +121,19 @@ jobs:
         mamba-version: "*"
         channels: conda-forge
         conda-remove-defaults: "true"
+    - run: conda install boa anaconda-client
     - name: conda build & test
       working-directory: recipe
       run: |
-        conda install boa
         conda mambabuild . -c conda-forge -c https://tomography.stfc.ac.uk/conda --override-channels --python=${{ matrix.python-version }} --numpy=${{ matrix.numpy-version }} --output-folder .
     - uses: actions/upload-artifact@v4
       with:
         name: cil-package-py${{ matrix.python-version }}-np${{ matrix.numpy-version }}
         path: recipe/linux-64/cil*
     - name: anaconda upload -c ccpi
-      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      if: >
+        (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) && matrix.numpy-version == '1.26'
       run: |
-        conda install anaconda-client
         anaconda -v -t ${{ secrets.CCPI_CONDA_TOKEN }} upload --force --label ${{ startsWith(github.ref, 'refs/tags') && 'main' || 'dev' }} recipe/linux-64/cil*
     - name: conda upload -c tomography.stfc.ac.uk/conda
       if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
- Fix failing CI due to redundant numpy builds no longer needed after #2156
- Lightweight alternative to #2196
- move `conda` build deps a little to reduce step log output verbosity