### PR TITLE
Doc fixes for Cone3D_Flex

### DIFF
--- a/Wrappers/Python/cil/framework/acquisition_data.py
+++ b/Wrappers/Python/cil/framework/acquisition_data.py
@@ -172,10 +172,10 @@ class AcquisitionData(DataContainer, Partitioner):
         ----------
         channel: int, optional
             index on channel dimension to slice on. If None, does not slice on this dimension.
-        angle or projection: int, optional
+        angle/projection: int, optional
             index on angle or projection dimension to slice on. Dimension label depends on the geometry type:
-            - For CONE_FLEX geometry, use 'projection'.
-            - For all other geometries, use 'angle'.
+            For CONE_FLEX geometry, use 'projection'.
+            For all other geometries, use 'angle'.
         vertical: int, str, optional
             If int, index on vertical dimension to slice on. If str, can be 'centre' to return the slice at the center of the vertical dimension.
         horizontal: int, optional

--- a/Wrappers/Python/cil/framework/acquisition_geometry.py
+++ b/Wrappers/Python/cil/framework/acquisition_geometry.py
@@ -2276,7 +2276,7 @@ class AcquisitionGeometry(metaclass=BackwardCompat):
         Creates the AcquisitionGeometry for a parallel beam 2D tomographic system.
 
         After creating the AcquisitionGeometry object, the panel must be set using the `set_panel()` method and the angles must be set using the `set_angles()` method.
-        In addition,`set_channels()` can be used to set the number of channels and their labels. `set_labels()` can be used to set the order of the dimensions describing the data.
+        In addition, `set_channels()` can be used to set the number of channels and their labels. `set_labels()` can be used to set the order of the dimensions describing the data.
 
         See notes for default directions.
 
@@ -2612,10 +2612,10 @@ class AcquisitionGeometry(metaclass=BackwardCompat):
         ----------
         channel: int, optional
             index on channel dimension to slice on. If None, does not slice on this dimension.
-        angle or projection: int, optional
+        angle/projection: int, optional
             index on angle or projection dimension to slice on. Dimension label depends on the geometry type:
-            - For CONE_FLEX geometry, use 'projection'.
-            - For all other geometries, use 'angle'.
+            For CONE_FLEX geometry, use 'projection'.
+            For all other geometries, use 'angle'.
         vertical: int, str, optional
             If int, index on vertical dimension to slice on. If str, can be 'centre' to return the slice at the center of the vertical dimension.
         horizontal: int, optional


### PR DESCRIPTION
## Description
Fixes issues such as this issue where angle or projection kwarg can be used

<img width="963" height="268" alt="image" src="https://github.com/user-attachments/assets/a6fc607f-0c0e-4520-b426-7fbb3db5bd29" />


<!--overview of changes, reason/motivation, issue link(s), etc.-->

## Example Usage
<!--minimal working example-->

:heart: *Thanks for your contribution!*







<!-- please IGNORE the below if you aren't a CIL team member

blame GH for this text: https://github.com/orgs/community/discussions/81319

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

--->
