### PR TITLE
CoR sharpness, for binned data, the data is now smoothed before binning 

### DIFF
--- a/Wrappers/Python/cil/processors/CofR_image_sharpness.py
+++ b/Wrappers/Python/cil/processors/CofR_image_sharpness.py
@@ -287,13 +287,13 @@ class CofR_image_sharpness(Processor):
             sampling_points = np.mgrid[-self.initial_binning*new_half_panel:self.initial_binning*new_half_panel+1:self.initial_binning]
             initial_coordinates = np.mgrid[-half_panel:half_panel+1:1]
 
-            new_geom = data.geometry.copy()
+            new_geom = data_temp.geometry.copy()
             new_geom.config.panel.num_pixels[0] = num_pix_new
             new_geom.config.panel.pixel_size[0] *= self.initial_binning
             data_binned = new_geom.allocate()
 
-            for i in range(data.shape[0]):
-                data_binned.fill(np.interp(sampling_points, initial_coordinates, data.array[i,:]),angle=i)
+            for i in range(data_temp.shape[0]):
+                data_binned.fill(np.interp(sampling_points, initial_coordinates, data_temp.array[i,:]),angle=i)
 
             #filter
             data_binned_filtered = data_binned.copy()


### PR DESCRIPTION
## Description


Fixed a bug where the smoothed data was created but then not used. 


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review'

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions.

- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties


