### PR TITLE
remove constraint on optional dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,6 +74,12 @@ requirements:
     - tqdm
     - numba
 
+  # version constraints of optional dependencies
+  run_constrained:
+    - tomophantom >=2
+    - astra-toolbox >=1.9.9.dev5
+    - tigre >=2.4
+    - ccpi-regulariser >=24.0.1
 
 about:
   home: https://TomographicImaging.github.io/CIL


### PR DESCRIPTION
## Description
Follows on from #2183 and #2090 to remove the pinning on optional dependencies. 
closes #2034 

After this we will be more flexible in creating environments, but maintain a 'tested and recommended' table. 
## Example Usage
<!--minimal working example-->

:heart: *Thanks for your contribution!*
