### PR TITLE
remove unused kwargs being passed to DataContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
     - `axpby` (alias of `sapyb`)
     - `shape` setter in `DataContainer` and `ImageGeometry`
     - use of integer compression in `NEXUSDataWriter`
-    - `suppress_warning` internally passed as an unused kwarg to ImageData and AcquisitionData (#2206)
+    - Removed unused kwargs passed to ImageData and AcquisitionData, including `suppress_warning` (#2206)
   - Changes that break backwards compatibility:
     - Updated `RANDOM` and `RANDOM_INT` `DataContainer.fill()` and `geometry.allocate()` methods to use numpy default random number generator, old methods can be accessed with `RANDOM_DEPRECATED` AND `RANDOM_INT_DEPRECATED`. Random methods can now be accessed from `fill()` and `allocate()` (#2037)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
     - Allow FluxNormaliser.preview_configuration() even if flux contains zeros (#2177)
     - Check if kwargs are used in AcquisitionData and ImageData initialisation (#2178)
     - Added a flag to `show_geometry` that allows for disabling the call to `plt.show()` (#2195)
-
   - Testing:
     - Developers can now run the full CI matrix [via the web UI](https://github.com/TomographicImaging/CIL/actions/workflows/build.yml) (#2160)
     - Added tests for ProjectionOperator inputs that use `unittest-parametrize` module (#1990)
@@ -55,6 +54,7 @@
     - `axpby` (alias of `sapyb`)
     - `shape` setter in `DataContainer` and `ImageGeometry`
     - use of integer compression in `NEXUSDataWriter`
+    - `suppress_warning` internally passed as an unused kwarg to ImageData and AcquisitionData (#2206)
   - Changes that break backwards compatibility:
     - Updated `RANDOM` and `RANDOM_INT` `DataContainer.fill()` and `geometry.allocate()` methods to use numpy default random number generator, old methods can be accessed with `RANDOM_DEPRECATED` AND `RANDOM_INT_DEPRECATED`. Random methods can now be accessed from `fill()` and `allocate()` (#2037)
 

--- a/Wrappers/Python/cil/framework/acquisition_data.py
+++ b/Wrappers/Python/cil/framework/acquisition_data.py
@@ -164,7 +164,7 @@ class AcquisitionData(DataContainer, Partitioner):
         if len(out.shape) == 1 or geometry_new is None:
             return out
         else:
-            return AcquisitionData(out.array, deep_copy=False, geometry=geometry_new, suppress_warning=True)
+            return AcquisitionData(out.array, deep_copy=False, geometry=geometry_new)
         
     
     def get_slice(self, *args, **kwargs):

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -179,7 +179,7 @@ class DataContainer(object):
                 new_array = new_array.take(indices=value, axis=axis)
 
         if new_array.ndim > 1:
-            return DataContainer(new_array, False, dimension_labels_list, suppress_warning=True)
+            return DataContainer(new_array, False, dimension_labels_list)
         from .vector_data import VectorData
         return VectorData(new_array, dimension_labels=dimension_labels_list)
 
@@ -499,14 +499,15 @@ class DataContainer(object):
                 out = pwop(self.as_array() , x2 , *args, **kwargs )
             else:
                 raise TypeError('Expected x2 type as number or DataContainer, got {}'.format(type(x2)))
-            geom = self.geometry
-            if geom is not None:
-                geom = self.geometry.copy()
+            
+            if self.geometry is None:
+                return type(self)(out,
+                    deep_copy=False,
+                    dimension_labels=self.dimension_labels)
+            
             return type(self)(out,
-                   deep_copy=False,
-                   dimension_labels=self.dimension_labels,
-                   geometry= None if self.geometry is None else self.geometry.copy(),
-                   suppress_warning=True)
+                deep_copy=False,
+                geometry=self.geometry)
 
 
         elif issubclass(type(out), DataContainer) and issubclass(type(x2), DataContainer):
@@ -733,8 +734,7 @@ class DataContainer(object):
             return type(self)(out,
                        deep_copy=False,
                        dimension_labels=self.dimension_labels,
-                       geometry=self.geometry,
-                       suppress_warning=True)
+                       geometry=self.geometry)
         elif issubclass(type(out), DataContainer):
             if self.check_dimensions(out):
                 kwargs['out'] = out.as_array()

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -731,10 +731,16 @@ class DataContainer(object):
         out = kwargs.get('out', None)
         if out is None:
             out = pwop(self.as_array() , *args, **kwargs )
+
+            if self.geometry is None:
+                return type(self)(out,
+                    deep_copy=False,
+                    dimension_labels=self.dimension_labels)
+            
             return type(self)(out,
                        deep_copy=False,
-                       dimension_labels=self.dimension_labels,
                        geometry=self.geometry)
+        
         elif issubclass(type(out), DataContainer):
             if self.check_dimensions(out):
                 kwargs['out'] = out.as_array()

--- a/Wrappers/Python/cil/framework/image_data.py
+++ b/Wrappers/Python/cil/framework/image_data.py
@@ -155,7 +155,7 @@ class ImageData(DataContainer):
         if len(out.shape) == 1 or geometry_new is None:
             return out
         else:
-            return ImageData(out.array, deep_copy=False, geometry=geometry_new, suppress_warning=True)
+            return ImageData(out.array, deep_copy=False, geometry=geometry_new)
 
 
     def apply_circular_mask(self, radius=0.99, in_place=True):

--- a/Wrappers/Python/cil/io/TIFF.py
+++ b/Wrappers/Python/cil/io/TIFF.py
@@ -535,9 +535,9 @@ class TIFFStackReader(object):
 
     def _return_appropriate_data(self, data, geometry):
         if isinstance (geometry, ImageGeometry):
-            return ImageData(data, deep=True, geometry=geometry.copy(), suppress_warning=True)
+            return ImageData(data, deep=True, geometry=geometry.copy())
         elif isinstance (geometry, AcquisitionGeometry):
-            return AcquisitionData(data, deep=True, geometry=geometry.copy(), suppress_warning=True)
+            return AcquisitionData(data, deep=True, geometry=geometry.copy())
         else:
             raise TypeError("Unsupported Geometry type. Expected ImageGeometry or AcquisitionGeometry, got {}"\
                 .format(type(geometry)))

--- a/Wrappers/Python/cil/io/TIFF.py
+++ b/Wrappers/Python/cil/io/TIFF.py
@@ -535,9 +535,9 @@ class TIFFStackReader(object):
 
     def _return_appropriate_data(self, data, geometry):
         if isinstance (geometry, ImageGeometry):
-            return ImageData(data, deep=True, geometry=geometry.copy())
+            return ImageData(data, deep_copy=True, geometry=geometry.copy())
         elif isinstance (geometry, AcquisitionGeometry):
-            return AcquisitionData(data, deep=True, geometry=geometry.copy())
+            return AcquisitionData(data, deep_copy=True, geometry=geometry.copy())
         else:
             raise TypeError("Unsupported Geometry type. Expected ImageGeometry or AcquisitionGeometry, got {}"\
                 .format(type(geometry)))

--- a/Wrappers/Python/cil/io/ZEISSDataReader.py
+++ b/Wrappers/Python/cil/io/ZEISSDataReader.py
@@ -271,7 +271,7 @@ class ZEISSDataReader(object):
                     (int(self._metadata['x-shifts'][num]),int(self._metadata['y-shifts'][num])), \
                     axis=(1,0))
 
-            acq_data = AcquisitionData(array=data, deep_copy=False, geometry=self._geometry.copy(),suppress_warning=True)
+            acq_data = AcquisitionData(array=data, deep_copy=False, geometry=self._geometry.copy())
             return acq_data
         else:
             ig_data = ImageData(array=data, deep_copy=False, geometry=self._geometry.copy())

--- a/Wrappers/Python/cil/plugins/TomoPhantom.py
+++ b/Wrappers/Python/cil/plugins/TomoPhantom.py
@@ -189,6 +189,6 @@ def get_ImageData(num_model, geometry):
             raise ValueError('Wrong ImageGeometry')
 
 
-    im_data = ImageData(phantom_arr, geometry=ig, suppress_warning=True)
+    im_data = ImageData(phantom_arr, geometry=ig)
     im_data.reorder(list(geometry.dimension_labels))
     return im_data

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector2D.py
@@ -114,7 +114,7 @@ class AstraBackProjector2D(DataProcessor):
 
         arr_out = np.squeeze(arr_out)
         if out is None:
-            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
+            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy())
         else:
             out.fill(arr_out)
         return out

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraBackProjector3D.py
@@ -113,7 +113,7 @@ class AstraBackProjector3D(DataProcessor):
         arr_out = np.squeeze(arr_out)
 
         if out is None:
-            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
+            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy())
         else:
             out.fill(arr_out)
         return out

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector2D.py
@@ -117,7 +117,7 @@ class AstraForwardProjector2D(DataProcessor):
 
         arr_out = np.squeeze(arr_out)
         if out is None:
-            out = AcquisitionData(arr_out, deep_copy=False, geometry=self.sinogram_geometry.copy(), suppress_warning=True)
+            out = AcquisitionData(arr_out, deep_copy=False, geometry=self.sinogram_geometry.copy())
         else:
             out.fill(arr_out)
         return out

--- a/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector3D.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/AstraForwardProjector3D.py
@@ -114,7 +114,7 @@ class AstraForwardProjector3D(DataProcessor):
         arr_out = np.squeeze(arr_out)
 
         if out is None:
-            out = AcquisitionData(arr_out, deep_copy=False, geometry=self.sinogram_geometry.copy(), suppress_warning=True)
+            out = AcquisitionData(arr_out, deep_copy=False, geometry=self.sinogram_geometry.copy())
         else:
             out.fill(arr_out)
         return out

--- a/Wrappers/Python/cil/plugins/astra/processors/FBP_Flexible.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FBP_Flexible.py
@@ -184,7 +184,7 @@ class FBP_CPU(Processor):
 
         arr_out = np.flip(arr_out, 0)
         if out is None:
-            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
+            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy())
         else:
             out.fill(arr_out)
         return out

--- a/Wrappers/Python/cil/plugins/astra/processors/FDK_Flexible.py
+++ b/Wrappers/Python/cil/plugins/astra/processors/FDK_Flexible.py
@@ -113,7 +113,7 @@ class FDK_Flexible(DataProcessor):
             arr_out = np.squeeze(arr_out, axis=0)
 
         if out is None:
-            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
+            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy())
         else:
             out.fill(arr_out)
         return out

--- a/Wrappers/Python/cil/plugins/tigre/FBP.py
+++ b/Wrappers/Python/cil/plugins/tigre/FBP.py
@@ -111,7 +111,7 @@ class FBP(DataProcessor):
                 arr_out = fbp(self.get_input().as_array(), self.tigre_geom, self.tigre_angles)
 
         if out is None:
-            out = ImageData(arr_out, deep_copy=False, geometry=self.image_geometry.copy(), suppress_warning=True)
+            out = ImageData(arr_out, deep_copy=False, geometry=self.image_geometry.copy())
             return out
         else:
             out.fill(arr_out)

--- a/Wrappers/Python/cil/plugins/tigre/ProjectionOperator.py
+++ b/Wrappers/Python/cil/plugins/tigre/ProjectionOperator.py
@@ -201,8 +201,7 @@ class ProjectionOperator_ag(ProjectionOperator):
         if out is None:
             out = AcquisitionData(arr_out,
                                   deep_copy=False,
-                                  geometry=self._range_geometry.copy(),
-                                  suppress_warning=True)
+                                  geometry=self._range_geometry.copy())
         else:
             out.fill(arr_out)
         return out
@@ -234,8 +233,7 @@ class ProjectionOperator_ag(ProjectionOperator):
         if out is None:
             out = ImageData(arr_out,
                             deep_copy=False,
-                            geometry=self._domain_geometry.copy(),
-                            suppress_warning=True)
+                            geometry=self._domain_geometry.copy())
         else:
             out.fill(arr_out)
         return out

--- a/Wrappers/Python/cil/processors/CofR_image_sharpness.py
+++ b/Wrappers/Python/cil/processors/CofR_image_sharpness.py
@@ -348,7 +348,7 @@ class CofR_image_sharpness(Processor):
         log.info("Return new dataset with centred geometry")
 
         if out is None:
-            return AcquisitionData(array=data_full, deep_copy=True, geometry=new_geometry, supress_warning=True)
+            return AcquisitionData(array=data_full, deep_copy=True, geometry=new_geometry)
         else:
             out.geometry = new_geometry
             return out

--- a/Wrappers/Python/cil/processors/CofR_xcorrelation.py
+++ b/Wrappers/Python/cil/processors/CofR_xcorrelation.py
@@ -174,7 +174,7 @@ class CofR_xcorrelation(Processor):
         log.info("Return new dataset with centred geometry")
 
         if out is None:
-            return AcquisitionData(array = data_full, deep_copy = True, geometry = new_geometry, supress_warning=True)
+            return AcquisitionData(array = data_full, deep_copy = True, geometry = new_geometry)
         else:
             out.geometry = new_geometry
             return out

--- a/Wrappers/Python/cil/processors/MaskGenerator.py
+++ b/Wrappers/Python/cil/processors/MaskGenerator.py
@@ -378,7 +378,7 @@ class MaskGenerator(DataProcessor):
                 geometry = data.geometry.copy()
             else:
                 geometry = None
-            out = type(data)(mask, deep_copy=False, dtype=mask.dtype, geometry=geometry, suppress_warning=True, dimension_labels=data.dimension_labels)
+            out = type(data)(mask, deep_copy=False, dtype=mask.dtype, geometry=geometry, dimension_labels=data.dimension_labels)
         else:
             out.fill(mask)
         

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -385,8 +385,8 @@ class TestDataContainer(CCPiTestClass):
     def test_exp_log(self):
         a0 = np.ones(2*3*4)
 
-        ds0 = DataContainer(np.reshape(a0,(2,3,4)), suppress_warning=True)
-        # ds1 = DataContainer(np.reshape(a1,(2,3,4)), suppress_warning=True)
+        ds0 = DataContainer(np.reshape(a0,(2,3,4)))
+        # ds1 = DataContainer(np.reshape(a1,(2,3,4)))
         b = ds0.exp().log()
         np.testing.assert_allclose(ds0.as_array(), b.as_array())
 


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->

`AcquisitionData` and `ImageData` historically raised a warning when they were initialised directly and not via `geom.allocate()`. There was an argument to supress the warning called `suppress_warning`.

https://github.com/TomographicImaging/CIL/blob/b70febf37b215dd6672ddc38b05effdecfb6a086/Wrappers/Python/cil/framework/framework.py#L2673-L2675

Since then the warning has been removed, but internal calls still passed 'suppress_warning' as a kwarg.

https://github.com/TomographicImaging/CIL/pull/2178 then checked for unused kwargs and raised an error.

This PR removes the kwarg "suppress_warning" which is passed internally.

It additionally stopped `dimension_labels` being passed when it was not used in `pixel_wise_binary` and removes an unnecessary `geom.copy()`

Other kwargs have been fixed or removed, a few typos!

## Example Usage
<!--minimal working example-->

:heart: *Thanks for your contribution!*
