### PR TITLE
Fix windows github action to use windows server 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
         path: dist/*/cil-*.tar.bz2
   conda-test:
     defaults: {run: {shell: 'bash -el {0}'}}
-    runs-on: ${{ matrix.os }}-${{ matrix.os == 'ubuntu' && '22.04' || '2022' }}
+    runs-on: ${{ matrix.os }}-${{ matrix.os == 'ubuntu' && '22.04' || 'latest' }}
     needs: [conda-matrix, conda-build]
     strategy:
       matrix:


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->
Recently windows-latest updated to use windows server 2025. Since then our action would run for 6 hours and time out.
So for now I have set that we use windows server 2022. We can open an issue that we'll need to come back to this at some point.

Details of windows server 2025: https://github.com/actions/runner-images/releases/tag/win25%2F20250929.44

## Example Usage
<!--minimal working example-->

## Contribution Notes

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


## Changes

## Testing you performed
Ran full version of build to make sure it ran the windows actions


## Related issues/links
Windows github actions failing on master

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers

--->
