### PR TITLE
fixed bugs in PaganinProcessor #2214

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -78,6 +78,7 @@ Satwik Pani (2025) - 15
 Hok Shing Wong (2025) - 7
 Francis M Watson (2025) - 3
 Hussam Alhassan (2025) - 1
+Adam Doherty (2025) - 5
 
 CIL Advisory Board:
 Llion Evans - 9

--- a/Wrappers/Python/cil/processors/Masker.py
+++ b/Wrappers/Python/cil/processors/Masker.py
@@ -15,6 +15,7 @@
 #
 # Authors:
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
+# Adam Doherty (UCL)
 
 from cil.framework import DataProcessor, AcquisitionData, ImageData, ImageGeometry, DataContainer
 import numpy
@@ -164,7 +165,7 @@ class Masker(DataProcessor):
 
         if not (data.shape == self.mask.shape):
             raise Exception("Mask and Data must have the same shape." +
-                            "{} != {}".format(self.mask.mask, data.shape))
+                            "{} != {}".format(self.mask.shape, data.shape))
 
         if hasattr(self.mask, 'dimension_labels') and data.dimension_labels != self.mask.dimension_labels:
             raise Exception("Mask and Data must have the same dimension labels." +

--- a/Wrappers/Python/cil/processors/PaganinProcessor.py
+++ b/Wrappers/Python/cil/processors/PaganinProcessor.py
@@ -108,35 +108,37 @@ class PaganinProcessor(Processor):
     al. [1] to retrieve the sample thickness
 
     .. math:: T(x,y) = - \frac{1}{\mu}\ln\left (\mathcal{F}^{-1}\left
-        (\frac{\mathcal{F}\left ( M^2I_{norm}(x, y,z = \Delta) \right )}{1 +
+        (\frac{\mathcal{F}\left ( I_{norm}(x, y,z = \Delta) \right )}{1 +
           \alpha\left ( k_x^2 + k_y^2 \right )}  \right )\right ),
 
     where
 
         - :math:`T`, is the sample thickness,
         - :math:`\mu = \frac{4\pi\beta}{\lambda}` is the material linear
-        attenuation coefficient where :math:`\beta` is the complex part of the
-        material refractive index and :math:`\lambda=\frac{hc}{E}` is the probe
-        wavelength,
-        - :math:`M` is the magnification at the detector,
+          attenuation coefficient where :math:`\beta` is the complex part of the
+          material refractive index [2] and :math:`\lambda=\frac{hc}{E}` is the 
+          probe wavelength,
         - :math:`I_{norm}` is the input image which is expected to be the
-        normalised transmission data,
-        - :math:`\Delta` is the propagation distance,
+          normalised transmission data,
+        - :math:`\Delta` is the propagation distance. In cone-beam geometry, 
+          :math:`\Delta` is scaled by the magnification :math:`M` as described 
+          in [1],
         - :math:`\alpha = \frac{\Delta\delta}{\mu}` is a parameter determining
-        the strength of the filter to be applied in Fourier space where
-        :math:`\delta` is the real part of the deviation of the material
-        refractive index from 1
+          the strength of the filter to be applied in Fourier space where
+          :math:`\delta` is the real part of the deviation of the material
+          refractive index from 1 [2].
         - :math:`k_x, k_y = \left ( \frac{2\pi p}{N_xW}, \frac{2\pi q}{N_yW}
-        \right )` where :math:`p` and :math:`q` are co-ordinates in a Fourier
-        mesh in the range :math:`-N_x/2` to :math:`N_x/2` for an image with
-        size :math:`N_x, N_y` and pixel size :math:`W`.
+          \right )` where :math:`p` and :math:`q` are co-ordinates in a Fourier
+          mesh in the range :math:`-N_x/2` to :math:`N_x/2` for an image with
+          size :math:`N_x, N_y` and pixel size :math:`W`. In cone-beam geometry,
+          the pixel size is scaled by the magnification :math:`M`.
 
     A generalised form of the Paganin phase retrieval method can be called
     using :code:`filter_type='generalised_paganin_method'`, which uses the
-    form of the algorithm described in [2]
+    form of the algorithm described in [3]
 
     .. math:: T(x,y) = -\frac{1}{\mu}\ln\left (\mathcal{F}^{-1}\left (\frac{
-        \mathcal{F}\left ( M^2I_{norm}(x, y,z = \Delta) \right )}{1 - \frac{2
+        \mathcal{F}\left (I_{norm}(x, y,z = \Delta) \right )}{1 - \frac{2
         \alpha}{W^2}\left ( \cos(Wk_x) + \cos(Wk_y) -2 \right )}  \right )
         \right )
 
@@ -505,7 +507,7 @@ class PaganinProcessor(Processor):
         Function to calculate alpha, a constant defining the Paganin filter
         strength
         '''
-        self.alpha = self.propagation_distance*self.delta/self.mu/self.magnification
+        self.alpha = (self.propagation_distance/self.magnification)*self.delta/self.mu
 
     def _energy_to_wavelength(self, energy, energy_units, return_units):
         '''

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ html_theme_options = {
     "logo": {
         "image_light": "https://ccpi.ac.uk/wp-content/uploads/2022/11/CIL-logo-RGB.svg",
         "image_dark": "https://ccpi.ac.uk/wp-content/uploads/2022/11/CIL-logo-RGB-reversed.svg",
-        "link": "/",
+        "link": "https://tomographicimaging.github.io/CIL",
         "alt_text": "CIL - Home",
     },
     "show_version_warning_banner": True,


### PR DESCRIPTION
## Description
Fixed bugs in Paganin Processor that gave incorrect output for cone-beam phase retrieval

## Example Usage
[sim_image3.tif](https://github.com/user-attachments/files/23018543/sim_image3.tif)

```
from cil.framework import AcquisitionGeometry, AcquisitionData, DataContainer
from cil.processors import PaganinProcessor
import os
import numpy as np
import matplotlib.pyplot as plt
from PIL import Image

# Load simulated paganin image 
corrected =  Image.open('sim_image3.tif')
corrected = np.array(corrected)

# Constants for the retrieval
Z_so = 15
Z_sd = 45
lx = 812
ly = 812
num_proj = 1
px = 8e-3
E = 13000
M = Z_sd/Z_so
x = np.linspace(0,lx*px,lx)

# Set up geometry
ag = AcquisitionGeometry.create_Cone3D(source_position=[0, -Z_so, 0],
                                        detector_position=[0, Z_sd - Z_so, 0],
                                        units='mm').set_panel(num_pixels=[lx, ly], pixel_size=px)\
    .set_angles(angles=[0])
Acq_data = AcquisitionData(corrected, geometry=ag, deep_copy=True)

# Phase retrieval using "paganin_method"
processor = PaganinProcessor(delta = 1e-6, beta = 1e-9, energy = E)
processor.set_input(Acq_data)
Acq_data_ret = processor.get_output()

phase = Image.fromarray(Acq_data_ret.as_array())
phase_np = np.array(phase)
plt.plot(x,phase_np[:,1])

# Phase retrieval using "generalised_paganin_method"
processor = PaganinProcessor(delta = 1e-6, beta = 1e-9, energy = E, filter_type = 'generalised_paganin_method')
processor.set_input(Acq_data)
Acq_data_ret = processor.get_output()

phase = Image.fromarray(Acq_data_ret.as_array())
phase_np = np.array(phase)
plt.plot(x,phase_np[:,1])
```

## Contribution Notes

I made three changes to Paganin_processor.py
1. Removed `mag2` variable as a scaling factor on the retrieved thickness
2. Defined a new variable as the demagnified pixel size `pixel_size_dmag` which defines the fourier mesh and filter, replacing use of `self.pixel_size`
3. Added `self.magnification` to the definition of `alpha`

<!-- Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions. -->

- [x ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [ x] I confirm that the contribution does not violate any intellectual property rights of third parties

:heart: *Thanks for your contribution!*







<!-- please IGNORE the below if you aren't a CIL team member

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers

--->
