### PR TITLE
Fix NaN usage in show_geometry function

### DIFF
--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -785,7 +785,7 @@ class _ShowGeometry(object):
         world_limits = self.ax.get_w_lims()
         self.ax.set_box_aspect((world_limits[1]-world_limits[0],world_limits[3]-world_limits[2],world_limits[5]-world_limits[4]))
 
-        l = self.ax.plot(np.NaN, np.NaN, '-', color='none', label='')[0]
+        l = self.ax.plot(np.nan, np.nan, '-', color='none', label='')[0]
 
         for i in range(3):
             self.handles.insert(2,l)


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->

Tested on the PETRIC2 docker image

## Example Usage
<!--minimal working example-->

## Contribution Notes

<!-- Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions. -->

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

:heart: *Thanks for your contribution!*







<!-- please IGNORE the below if you aren't a CIL team member

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers

--->
