### PR TITLE
Convert scale and offset to string for JSON

### DIFF
--- a/Wrappers/Python/cil/io/TIFF.py
+++ b/Wrappers/Python/cil/io/TIFF.py
@@ -47,7 +47,7 @@ def save_scale_offset(fname, scale, offset):
     '''
     dirname = os.path.dirname(fname)
     txt = os.path.join(dirname, 'scaleoffset.json')
-    d = {'scale': scale, 'offset': offset}
+    d = {'scale': str(scale), 'offset': str(offset)}
     utilities.save_dict_to_file(txt, d)
 
 class TIFFWriter(object):


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->

## Example Usage
<!--minimal working example-->

## Contribution Notes

<!-- Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions. -->

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

:heart: *Thanks for your contribution!*








## Changes
Save the string representation of a float to JSON as `numpy.float32` is not supported.

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links
- Closes #2030

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
