### PR TITLE
fix: version.local field can be none!

### DIFF
--- a/Wrappers/Python/cil/version.py
+++ b/Wrappers/Python/cil/version.py
@@ -1,27 +1,8 @@
-#  Copyright 2026 United Kingdom Research and Innovation
-#  Copyright 2026 The University of Manchester
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
-# Authors:
-# CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
-# Jeppe Klitgaard (DTU)
-
 import importlib.metadata
 from packaging.version import Version
 version = importlib.metadata.version("cil")
 
 __v = Version(version)
 major, minor, patch = __v.major, __v.minor, __v.micro
-commit_hash = __v.local.split(".", 1)[0]
-num_commit = __v.dev
+commit_hash = "" if __v.local is None else __v.local.split(".", 1)[0]
+num_commit = __v.dev or 9_999

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,3 @@
-#  Copyright 2024 United Kingdom Research and Innovation
-#  Copyright 2024 The University of Manchester
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
-# Authors:
-# CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
-# Jeppe Klitgaard (DTU)
-
 [build-system]
 requires = [
     "setuptools>=64",


### PR DESCRIPTION
Despite best efforts, the version.py change can still be broken in some settings. This should fix that.

The current setup is not conducive to local testing for things like this, so it snuck through in one of the polishing commits on #2269 

