### PR TITLE
BM3D denoiser

### DIFF
--- a/Wrappers/Python/cil/optimisation/functions/BM3DFunction.py
+++ b/Wrappers/Python/cil/optimisation/functions/BM3DFunction.py
@@ -5,9 +5,11 @@ import warnings
 try:
     from bm3d import bm3d, BM3DStages
     _HAS_BM3D = True
+    ALL_STAGES = BM3DStages.ALL_STAGES
 except ImportError:
     bm3d = None
     BM3DStages = None
+    ALL_STAGES = None
     _HAS_BM3D = False
 
     warnings.warn(
@@ -25,7 +27,7 @@ class BM3DFunction(Function):
     Maybe add damping: (1-gamma) z + gamma * BM3D(z).
     """
 
-    def __init__(self, sigma,  profile="np", stage_arg=BM3DStages.ALL_STAGES, 
+    def __init__(self, sigma,  profile="np", stage_arg=ALL_STAGES, 
                  positivity=True):
         
         

--- a/Wrappers/Python/cil/optimisation/functions/BM3DFunction.py
+++ b/Wrappers/Python/cil/optimisation/functions/BM3DFunction.py
@@ -20,53 +20,91 @@ except ImportError:
 
 
 class BM3DFunction(Function):
-    """
-    PnP 'regulariser' whose proximal applies BM3D denoising.
 
-    Use in PnP-ISTA/FISTA
-    Maybe add damping: (1-gamma) z + gamma * BM3D(z).
+    r"""
+    Plug-and-Play (PnP) BM3D prior.
+
+    This class is meant to be used in proximal-gradient
+    schemes (PnP-ISTA / PnP-FISTA), where the proximal operator is replaced
+    by a BM3D denoiser:
+    \[
+        \operatorname{prox}_{\tau g}(x) \approx D_\sigma(x),
+    \]
+    with ``sigma`` interpreted as the assumed noise standard deviation in the image domain.
+
+    Notes
+    -----
+    * The function value ``g(x)`` is not defined for PnP; therefore
+      ``__call__`` returns ``0.0``.
+    * Optionally enforces non-negativity by projecting the denoised output
+      onto ``\{x \ge 0\}``.
+
+    Parameters
+    ----------
+    sigma : float
+        BM3D noise standard deviation (same units as the image). Must be > 0.
+
+    profile : str, default="np"
+        BM3D profile passed to ``bm3d`` (speed/quality trade-off). Available
+        profiles are ``('np', 'refilter', 'vn', 'vn_old', 'high', 'deb')
+
+    stage_arg : BM3DStages or np.ndarray, default=BM3DStages.ALL_STAGES
+        Controls which BM3D stage(s) are executed, or provides a pilot image:
+        - ``BM3DStages.ALL_STAGES``: hard-thresholding + Wiener filtering.
+        - ``BM3DStages.HARD_THRESHOLDING``: hard-thresholding only.
+        - ``np.ndarray``: a pilot estimate of the noise-free image (used by BM3D).
+
+    positivity : bool, default=True
+        If ``True``, clip the denoised image to be non-negative.
+
+    Note
+    ----------
+    Reference: Dabov,  K. and Foi,  A. and Katkovnik, V. and Egiazarian, K., 2007. Image Denoising by Sparse 3-D Transform-Domain Collaborative Filtering. IEEE Transactions on Image Processing. http://dx.doi.org/10.1109/TIP.2007.901238. 
+
     """
+ 
 
     def __init__(self, sigma,  profile="np", stage_arg=ALL_STAGES, 
                  positivity=True):
         
-        
-        # self.gamma = float(gamma)      # damping in (0,1]
-        # if not (0.0 < self.gamma <= 1.0):
-            # raise ValueError("gamma must be in (0,1].")
         self.sigma = sigma
         if self.sigma<=0:
-            raise ValueError("pos")
+            raise ValueError("Need a positive value for sigma")
         self.profile = profile
         self.stage_arg = stage_arg
         self.positivity = positivity
+        self._warned_call = False
 
         super(BM3DFunction, self).__init__(L=None)
 
     def __call__(self, x):
-        # does not exist, return 0 for now, add warning
+        if not self._warned_call:
+            warnings.warn(
+                "BM3DFunction does not define objective value; returning 0.0.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            self._warned_call = True
         return 0.0
 
 
     def _denoise(self, znp: np.ndarray) -> np.ndarray:
         z = np.asarray(znp, dtype=np.float32)
-        # BM3D expects sigma as noise std (same units as the image)
         return bm3d(z, sigma_psd=self.sigma, profile=self.profile,
                     stage_arg=self.stage_arg).astype(np.float32)
 
-    def proximal(self, x, tau, out=None):
+    def proximal(self, x, tau=1., out=None):
 
         ## TODO asarray for SIRF?
         z = x.array.astype(np.float32, copy=False)
         den_bm3d_np = self._denoise(z)
 
-        # damping/relaxation (oscillations)
-        # u = (1.0 - self.gamma) * z + self.gamma * d
-
+        ## TODO maybe we need a more general constraint?
         if self.positivity:
             np.maximum(den_bm3d_np, 0.0, out=den_bm3d_np)
 
         if out is None:
             out = x * 0.0
         out.fill(den_bm3d_np)
+
         return out

--- a/Wrappers/Python/cil/optimisation/functions/BM3DFunction.py
+++ b/Wrappers/Python/cil/optimisation/functions/BM3DFunction.py
@@ -1,0 +1,70 @@
+import numpy as np
+from cil.optimisation.functions import Function
+import warnings
+
+try:
+    from bm3d import bm3d, BM3DStages
+    _HAS_BM3D = True
+except ImportError:
+    bm3d = None
+    BM3DStages = None
+    _HAS_BM3D = False
+
+    warnings.warn(
+        "Optional dependency 'bm3d' is not installed.  Install via `pip install bm3d.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+
+class BM3DFunction(Function):
+    """
+    PnP 'regulariser' whose proximal applies BM3D denoising.
+
+    Use in PnP-ISTA/FISTA
+    Maybe add damping: (1-gamma) z + gamma * BM3D(z).
+    """
+
+    def __init__(self, sigma,  profile="np", stage_arg=BM3DStages.ALL_STAGES, 
+                 positivity=True):
+        
+        
+        # self.gamma = float(gamma)      # damping in (0,1]
+        # if not (0.0 < self.gamma <= 1.0):
+            # raise ValueError("gamma must be in (0,1].")
+        self.sigma = sigma
+        if self.sigma<=0:
+            raise ValueError("pos")
+        self.profile = profile
+        self.stage_arg = stage_arg
+        self.positivity = positivity
+
+        super(BM3DFunction, self).__init__(L=None)
+
+    def __call__(self, x):
+        # does not exist, return 0 for now, add warning
+        return 0.0
+
+
+    def _denoise(self, znp: np.ndarray) -> np.ndarray:
+        z = np.asarray(znp, dtype=np.float32)
+        # BM3D expects sigma as noise std (same units as the image)
+        return bm3d(z, sigma_psd=self.sigma, profile=self.profile,
+                    stage_arg=self.stage_arg).astype(np.float32)
+
+    def proximal(self, x, tau, out=None):
+
+        ## TODO asarray for SIRF?
+        z = x.array.astype(np.float32, copy=False)
+        den_bm3d_np = self._denoise(z)
+
+        # damping/relaxation (oscillations)
+        # u = (1.0 - self.gamma) * z + self.gamma * d
+
+        if self.positivity:
+            np.maximum(den_bm3d_np, 0.0, out=den_bm3d_np)
+
+        if out is None:
+            out = x * 0.0
+        out.fill(den_bm3d_np)
+        return out

--- a/Wrappers/Python/cil/optimisation/functions/BM3DFunction.py
+++ b/Wrappers/Python/cil/optimisation/functions/BM3DFunction.py
@@ -98,6 +98,7 @@ class BM3DFunction(Function):
         ## TODO asarray for SIRF?
         z = x.array.astype(np.float32, copy=False)
         den_bm3d_np = self._denoise(z)
+        
 
         ## TODO maybe we need a more general constraint?
         if self.positivity:

--- a/Wrappers/Python/cil/optimisation/functions/__init__.py
+++ b/Wrappers/Python/cil/optimisation/functions/__init__.py
@@ -40,4 +40,5 @@ from .SGFunction import SGFunction
 from .SVRGFunction import SVRGFunction, LSVRGFunction
 from .SAGFunction import SAGFunction, SAGAFunction
 from .AbsFunction import FunctionOfAbs
+from .BM3DFunction import BM3DFunction
 

--- a/Wrappers/Python/test/test_functions.py
+++ b/Wrappers/Python/test/test_functions.py
@@ -2249,6 +2249,7 @@ class TestBM3D(unittest.TestCase):
 
     @unittest.skipUnless(_HAS_BM3D, "Optional dependency 'bm3d'.")
     def test_proximal_(self):
+        
         data = dataexample.SHAPES.get()
 
         G = BM3DFunction(sigma=0.1, positivity=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ gpu = [
 [dependency-groups]
 test = [
     #"ccpi-regulariser=24.0.1", # [not osx] # missing from PyPI
-    "cvxpy",
+    "cvxpy", "bm3d",
     "matplotlib-base>=3.3",
     "packaging",
     "scikit-image",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ test:
     - pip
     - python-wget
     - cvxpy                   # [linux]
-    - bm3d                    # [linux]
     - scikit-image
     - tomophantom 2.0.0       # [linux]
     - tigre 2.6
@@ -31,6 +30,7 @@ test:
 
   commands:
     - pip install unittest-parametrize
+    - pip install bm3d
     - python -m unittest discover -v -s Wrappers/Python/test
 
 {% set ipp_version = '2021.12' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ test:
     - pip
     - python-wget
     - cvxpy                   # [linux]
+    - bm3d                    # [linux]
     - scikit-image
     - tomophantom 2.0.0       # [linux]
     - tigre 2.6

--- a/scripts/requirements-test-windows.yml
+++ b/scripts/requirements-test-windows.yml
@@ -44,7 +44,6 @@ dependencies:
   - numba
   - tqdm
   - zenodo_get >=1.6
-  - bm3d
   - pip
   - pip:
     - unittest-parametrize

--- a/scripts/requirements-test-windows.yml
+++ b/scripts/requirements-test-windows.yml
@@ -44,6 +44,7 @@ dependencies:
   - numba
   - tqdm
   - zenodo_get >=1.6
+  - bm3d
   - pip
   - pip:
     - unittest-parametrize

--- a/scripts/requirements-test.yml
+++ b/scripts/requirements-test.yml
@@ -45,6 +45,7 @@ dependencies:
   - numba
   - tqdm
   - zenodo_get >=1.6
+  - bm3d
   - pip
   - pip:
     - unittest-parametrize

--- a/scripts/requirements-test.yml
+++ b/scripts/requirements-test.yml
@@ -45,7 +45,7 @@ dependencies:
   - numba
   - tqdm
   - zenodo_get >=1.6
-  - bm3d
   - pip
   - pip:
     - unittest-parametrize
+    - bm3d


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->

Implements BM3D denoiser, used as a Plug and Play (PnP) for ISTA/FISTA algorithms. Atm, is for 2D arrays and uses 
https://pypi.org/project/bm3d/. For 3D, we need to wrap https://pypi.org/project/bm4d/.

close #2275

## Example Usage
[Deblurring_PnP_BM3D_FISTA](https://github.com/TomographicImaging/CIL-Demos/blob/epapoutsellis-patch-1/misc/Deblurring_PnP_BM3D_FISTA_hackathon_2026.ipynb)

## Contribution Notes

<!-- Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions. -->

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

:heart: *Thanks for your contribution!*







<!-- please IGNORE the below if you aren't a CIL team member

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers

--->
