### PR TITLE
fix `update_objective_interval`

### DIFF
--- a/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
+++ b/Wrappers/Python/cil/optimisation/algorithms/Algorithm.py
@@ -223,7 +223,7 @@ class Algorithm:
     @update_objective_interval.setter
     def update_objective_interval(self, value):
         '''sets the update_objective_interval'''
-        if not isinstance(value, Integral) or value < 0:
+        if not ((isinstance(value, Integral) and value >= 0) or np.isposinf(value)):
             raise ValueError('interval must be an integer >= 0')
         self.__update_objective_interval = value
 


### PR DESCRIPTION
Follow-up to #1659; related to [PETRIC2](https://github.com/SyneRBI/PETRIC2)

- allow `update_objective_interval=np.inf`
- allow `update_objective_interval=0`
- For debate: deprecate `Algorithm(update_objective_interval)` in favour of `Algorithm.run(update_objective_interval)`?
  + [ ] rename to just `interval`?
  + [ ] update tests