### PR TITLE
Remove debug print statements from Slicer.py

### DIFF
--- a/Wrappers/Python/cil/processors/Slicer.py
+++ b/Wrappers/Python/cil/processors/Slicer.py
@@ -414,9 +414,6 @@ class Slicer(DataProcessor):
         else:
             new_geometry = None
 
-        print("New geometry: ", new_geometry)
-        print("Shape out: ", self._shape_out)
-
         # return if just acting on geometry
         if not self._data_array:
             return new_geometry
@@ -425,7 +422,6 @@ class Slicer(DataProcessor):
         if out is None:
             if new_geometry is not None:
                 data_out = new_geometry.allocate(None)
-                print("New geometry shape: ", data_out.shape)
             else:
                 processed_array = np.empty(self._shape_out,dtype=np.float32)
                 data_out = DataContainer(processed_array,False, self._labels_out)


### PR DESCRIPTION
Removed debug print statements for geometry and shape.
Not sure how these ended up going into CIL when we added ConeFlex3D!

## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->

## Example Usage
<!--minimal working example-->

## Contribution Notes

<!-- Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions. -->

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

:heart: *Thanks for your contribution!*







<!-- please IGNORE the below if you aren't a CIL team member

## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers

--->
