### PR TITLE
Restrict cvxpy version to one which supports numpy <2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - olefile and dxchange are optional dependencies, instead of required (#2209)
     - dxchange minimum version set to 0.2.1 to fix #2256 (#2268)
     - improve `tqdm` notebook support (#2241)
+    - cvxpy maximum version set to 1.7.5 to fix #2303 (#2304)
   - Documentation:
     - Render the user showcase notebooks in the documentation (#2189)
   - Enhancements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ gpu = [
 [dependency-groups]
 test = [
     #"ccpi-regulariser=24.0.1", # [not osx] # missing from PyPI
-    "cvxpy",
+    "cvxpy<=1.7.5",
     "matplotlib-base>=3.3",
     "packaging",
     "scikit-image",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ test:
   requires:
     - pip
     - python-wget
-    - cvxpy                   # [linux]
+    - cvxpy <= 1.7.5                  # [linux]
     - scikit-image
     - tomophantom 2.0.0       # [linux]
     - tigre 2.6

--- a/scripts/create_local_env_for_cil_development.sh
+++ b/scripts/create_local_env_for_cil_development.sh
@@ -84,7 +84,7 @@ else
     astra-toolbox=2.1=cuda*
     ccpi-regulariser=24.0.1
     cil-data
-    cvxpy
+    cvxpy<=1.7.5
     ipywidgets
     packaging
     python-wget

--- a/scripts/requirements-test-windows.yml
+++ b/scripts/requirements-test-windows.yml
@@ -24,7 +24,7 @@ dependencies:
   - ccpi::ccpi-regulariser 24.0.1
   - ccpi::tomophantom 2.0.0
   - astra-toolbox 2.1 cuda*
-  - cvxpy
+  - cvxpy <= 1.7.5
   - python-wget
   - scikit-image
   - packaging

--- a/scripts/requirements-test.yml
+++ b/scripts/requirements-test.yml
@@ -25,7 +25,7 @@ dependencies:
   - ccpi::ccpi-regulariser 24.0.1
   - ccpi::tomophantom 2.0.0
   - astra-toolbox 2.1 cuda*
-  - cvxpy
+  - cvxpy <= 1.7.5
   - python-wget
   - scikit-image
   - packaging


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->
Addresses #2303 

This is a temporary fix to get the GitHub actions working, until this is resolved: https://github.com/conda-forge/cvxpy-feedstock/pull/125.

## Example Usage
<!--minimal working example-->

## Contribution Notes

<!-- Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions. -->

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


## Changes


## Testing you performed
I used the 'Run workflow' button to perform all tests:
https://github.com/TomographicImaging/CIL/actions/runs/24084855444

## Related issues/links


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers

