### PR TITLE
Use ccpi channel instead of tomography mirror in actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
     - run: conda install boa
     - name: conda build
       run: >
-        conda mambabuild -c conda-forge -c https://tomography.stfc.ac.uk/conda --override-channels --python=${{ matrix.python-version }}
+        conda mambabuild -c conda-forge  -c https://software.repos.intel.com/python/conda -c ccpi --override-channels --python=${{ matrix.python-version }}
         --no-test --output-folder dist recipe
     - uses: actions/upload-artifact@v4
       with:
@@ -172,7 +172,7 @@ jobs:
         path: dist
     - name: conda test
       run: >
-        conda mambabuild -c conda-forge -c https://tomography.stfc.ac.uk/conda --override-channels --python=${{ matrix.python-version }}
+        conda mambabuild -c conda-forge  -c https://software.repos.intel.com/python/conda-c ccpi --override-channels --python=${{ matrix.python-version }}
         --test dist/*/cil-*.tar.bz2 --extra-deps numpy=${{ matrix.numpy-version }}
   conda-upload:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
     - run: conda install boa
     - name: conda build
       run: >
-        conda mambabuild -c conda-forge  -c https://software.repos.intel.com/python/conda -c ccpi --override-channels --python=${{ matrix.python-version }}
+        conda mambabuild -c conda-forge -c https://software.repos.intel.com/python/conda -c ccpi --override-channels --python=${{ matrix.python-version }}
         --no-test --output-folder dist recipe
     - uses: actions/upload-artifact@v4
       with:
@@ -172,7 +172,7 @@ jobs:
         path: dist
     - name: conda test
       run: >
-        conda mambabuild -c conda-forge  -c https://software.repos.intel.com/python/conda-c ccpi --override-channels --python=${{ matrix.python-version }}
+        conda mambabuild -c conda-forge  -c https://software.repos.intel.com/python/conda -c ccpi --override-channels --python=${{ matrix.python-version }}
         --test dist/*/cil-*.tar.bz2 --extra-deps numpy=${{ matrix.numpy-version }}
   conda-upload:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->
Using the ccpi channel instead of the tomography mirror as we had problems with timeout errors - see #2308 

The ccpi channel usage instead seems to  resolve or minimise time out issues

## Example Usage
<!--minimal working example-->

## Contribution Notes

<!-- Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions. -->

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc
Ran all tests and it passed first time: https://github.com/TomographicImaging/CIL/actions/runs/24522518083

## Related issues/links


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
