### PR TITLE
Fix Show2D incomplete rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
     - `cilacc` path lookup no longer broken for editable installations (#2257)
     - update `version.py` to use `importlib` & fix tagless installation #2255 (#2269)
     - Fixed behaviour of `ZeissDataReader` when negative values are passed in the ROI (#2244)
-    - Fix Show2D truncating plots when count is not a multiple of num_cols
+    - Fix `show2D` truncating plots when count is not a multiple of `num_cols` (#2315)
   - Dependencies:
     - olefile and dxchange are optional dependencies, instead of required (#2209)
     - dxchange minimum version set to 0.2.1 to fix #2256 (#2268)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - `cilacc` path lookup no longer broken for editable installations (#2257)
     - update `version.py` to use `importlib` & fix tagless installation #2255 (#2269)
     - Fixed behaviour of `ZeissDataReader` when negative values are passed in the ROI (#2244)
+    - Fix Show2D truncating plots when count is not a multiple of num_cols
   - Dependencies:
     - olefile and dxchange are optional dependencies, instead of required (#2209)
     - dxchange minimum version set to 0.2.1 to fix #2256 (#2268)

--- a/Wrappers/Python/cil/utilities/display.py
+++ b/Wrappers/Python/cil/utilities/display.py
@@ -626,7 +626,7 @@ class show2D(show_base):
         if num_plots < num_cols:
             num_cols = num_plots
 
-        num_rows = int(round((num_plots+0.5)/num_cols))
+        num_rows = num_plots // num_cols + (num_plots % num_cols > 0)
         fig, (ax) = plt.subplots(num_rows, num_cols, figsize=size)
         axes = ax.flatten()
 


### PR DESCRIPTION
## Changes
<img width="1489" height="1428" alt="image" src="https://github.com/user-attachments/assets/4a5be0c4-f32c-4004-997a-db1b4abba541" />

Now shows non-complete rows if the number of plots isn't devisble by num_cols.

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers

