### PR TITLE
Fix Parallel2D system_description precision error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
     - `cilacc` path lookup no longer broken for editable installations (#2257)
     - update `version.py` to use `importlib` & fix tagless installation #2255 (#2269)
     - Fixed behaviour of `ZeissDataReader` when negative values are passed in the ROI (#2244)
-    - Fix `Parallel2D` `system_description` raising exception for near-zero vectors
+    - Fix `Parallel2D` `system_description` raising exception for near-zero vectors (#2316)
   - Dependencies:
     - olefile and dxchange are optional dependencies, instead of required (#2209)
     - dxchange minimum version set to 0.2.1 to fix #2256 (#2268)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - `cilacc` path lookup no longer broken for editable installations (#2257)
     - update `version.py` to use `importlib` & fix tagless installation #2255 (#2269)
     - Fixed behaviour of `ZeissDataReader` when negative values are passed in the ROI (#2244)
+    - Fix `Parallel2D` `system_description` raising exception for near-zero vectors
   - Dependencies:
     - olefile and dxchange are optional dependencies, instead of required (#2209)
     - dxchange minimum version set to 0.2.1 to fix #2256 (#2268)

--- a/Wrappers/Python/cil/framework/acquisition_geometry.py
+++ b/Wrappers/Python/cil/framework/acquisition_geometry.py
@@ -448,24 +448,17 @@ class Parallel2D(SystemConfiguration):
             \nReturns `advanced` if the the geometry has rotated or tilted rotation axis or detector, can also have offsets
         '''
 
+        if not ComponentDescription.test_parallel(self.ray.direction, self.detector.normal):
+            return SystemConfiguration.SYSTEM_ADVANCED
+        
+        vec = ComponentDescription.create_vector(self.detector.position - self.rotation_axis.position)
+        dot_product = vec.dot(vec)
 
-        rays_perpendicular_detector = ComponentDescription.test_parallel(self.ray.direction, self.detector.normal)
-
-        #rotation axis position + ray direction hits detector position
-        if numpy.allclose(self.rotation_axis.position, self.detector.position): #points are equal so on ray path
-            rotation_axis_centred = True
+        if abs(dot_product) < 1e-8:
+            return SystemConfiguration.SYSTEM_SIMPLE
+        
         else:
-            vec_a = ComponentDescription.create_unit_vector(self.detector.position - self.rotation_axis.position)
-            rotation_axis_centred = ComponentDescription.test_parallel(self.ray.direction, vec_a)
-
-        if not rays_perpendicular_detector:
-            config = SystemConfiguration.SYSTEM_ADVANCED
-        elif not rotation_axis_centred:
-            config =  SystemConfiguration.SYSTEM_OFFSET
-        else:
-            config =  SystemConfiguration.SYSTEM_SIMPLE
-
-        return config
+            return SystemConfiguration.SYSTEM_OFFSET
 
 
     def rotation_axis_on_detector(self):


### PR DESCRIPTION
## Changes
Fixed Parallel2D geometry raising exception in system_description due to near-zero vector when rotation axis and detector positions are close but not equal.

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

## Related issues/links


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
