### PR TITLE
CI: Use conda-build instead of conda mambabuild (boa)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ The jobs are:
   + uses default (GitHub-hosted) runners to run tests on the min & max supported Python & NumPy versions
   + `python -m unittest discover -v ./Wrappers/Python/test`
 - `conda`
-  + uses `mambabuild` to build the conda package (saved as a build artifact named `cil-py3.m-OS`)
+  + uses `conda-build` to build the conda package (saved as a build artifact named `cil-py3.m-OS`)
 - `docs`
   + uses `docs/docs_environment.yml` plus `make -C docs` to build the documentation (saved as a build artifact named `DocumentationHTML`)
   + renders to the `gh-pages` branch on `master` (nightly) pushes or on tag (release) pushes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,10 +138,10 @@ jobs:
         mamba-version: "*"
         channels: conda-forge
         conda-remove-defaults: "true"
-    - run: conda install boa
+    - run: conda install conda-build
     - name: conda build
       run: >
-        conda mambabuild -c conda-forge -c https://software.repos.intel.com/python/conda -c ccpi --override-channels --python=${{ matrix.python-version }}
+        conda build -c conda-forge -c https://software.repos.intel.com/python/conda -c ccpi --override-channels --python=${{ matrix.python-version }}
         --no-test --output-folder dist recipe
     - uses: actions/upload-artifact@v4
       with:
@@ -165,14 +165,14 @@ jobs:
         mamba-version: "*"
         channels: conda-forge
         conda-remove-defaults: "true"
-    - run: conda install boa
+    - run: conda install conda-build
     - uses: actions/download-artifact@v4
       with:
         name: cil-py${{ matrix.python-version }}-${{ matrix.os }}
         path: dist
     - name: conda test
       run: >
-        conda mambabuild -c conda-forge  -c https://software.repos.intel.com/python/conda -c ccpi --override-channels --python=${{ matrix.python-version }}
+        conda build -c conda-forge  -c https://software.repos.intel.com/python/conda -c ccpi --override-channels --python=${{ matrix.python-version }}
         --test dist/*/cil-*.tar.bz2 --extra-deps numpy=${{ matrix.numpy-version }}
   conda-upload:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
## Description
Updates CI to use conda-build.

Closes https://github.com/TomographicImaging/CIL/issues/2035

Addresses an issue we have on the numpy 2 branch where boa couldn't be installed: https://github.com/TomographicImaging/CIL/issues/2035#issuecomment-4389452570

## Contribution Notes

<!-- Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions. -->

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


## Testing you performed
All actions have been run and pass: https://github.com/TomographicImaging/CIL/actions/runs/25448277299

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers

