### PR TITLE
delay `tigre` import

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -73,7 +73,8 @@ The [docs](./build.yml#L124) job:
 > python -m http.server
 > ```
 >
-> Then open a browser and navigate to <http://localhost:8000/CIL/> to view the documentation.
+> Then open a browser and navigate to <http://localhost:8000/CIL/{PR_NUMBER}_merge/> to view the documentation,
+> where `{PR_NUMBER}` is the number of the PR that was built (e.g. `1234`).
 
 ## [skip.yml](./skip.yml)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
     - uses: actions/checkout@v4
       with: {fetch-depth: 0, submodules: recursive}
     - name: set requirements
-      run: sed -ri -e '/ python /d' -e 's/(.* numpy) .*/\1=${{ matrix.numpy-version }}/' -e 's/=cuda*//' -e '/tigre/d' scripts/cil_development.yml
+      run: sed -ri -e '/ python /d' -e 's/(.* numpy) .*/\1=${{ matrix.numpy-version }}/' -e 's/cuda*//' -e '/tigre/d' scripts/cil_development.yml
     - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
@@ -224,6 +224,7 @@ jobs:
     - name: install dependencies
       run: |
         mamba install -c conda-forge -yq conda-merge
+        sed -ri -e 's/cuda*//' -e '/tigre/d' ../scripts/cil_development.yml
         conda-merge ../scripts/cil_development.yml docs_environment.yml > environment.yml
         mamba env update -n test --file environment.yml
         conda list

--- a/Wrappers/Python/cil/plugins/tigre/FBP.py
+++ b/Wrappers/Python/cil/plugins/tigre/FBP.py
@@ -24,12 +24,6 @@ from cil.framework import DataProcessor, ImageData
 from cil.framework.labels import AcquisitionDimension, ImageDimension
 from cil.plugins.tigre import CIL2TIGREGeometry
 
-try:
-    from tigre.algorithms import fdk, fbp
-except ModuleNotFoundError:
-    raise ModuleNotFoundError("This plugin requires the additional package TIGRE\n" +
-            "Please install it via conda as tigre from the ccpi channel")
-
 class FBP(DataProcessor):
 
     '''FBP Filtered Back Projection is a reconstructor for 2D and 3D parallel and cone-beam geometries.
@@ -82,7 +76,7 @@ class FBP(DataProcessor):
 
         AcquisitionDimension.check_order_for_engine('tigre', dataset.geometry)
         return True
-    
+
     def _set_up(self):
         """
         Configure processor attributes that require the data to setup
@@ -91,7 +85,12 @@ class FBP(DataProcessor):
         self._shape_out = self.image_geometry.shape
 
     def process(self, out=None):
-
+        try:
+            from tigre.algorithms import fdk, fbp
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "This plugin requires the additional package TIGRE\n"
+                "Please install it via conda as tigre from the ccpi channel")
         if self.tigre_geom.is2D:
             data_temp = np.expand_dims(self.get_input().as_array(), axis=1)
 

--- a/Wrappers/Python/cil/plugins/tigre/Geometry.py
+++ b/Wrappers/Python/cil/plugins/tigre/Geometry.py
@@ -22,8 +22,7 @@ import numpy as np
 try:
     from tigre.utilities.geometry import Geometry
 except ModuleNotFoundError:
-    raise ModuleNotFoundError("This plugin requires the additional package TIGRE\n" +
-            "Please install it via conda as tigre from the ccpi channel")
+    Geometry = object
 
 class CIL2TIGREGeometry(object):
     @staticmethod
@@ -50,10 +49,12 @@ class CIL2TIGREGeometry(object):
         return tg, angles
 
 class TIGREGeometry(Geometry):
-
     def __init__(self, ig, ag):
-
-        Geometry.__init__(self)
+        if Geometry is object:
+            raise ModuleNotFoundError(
+                "This plugin requires the additional package TIGRE\n"
+                "Please install it via conda as tigre from the ccpi channel")
+        super().__init__()
 
         if ag.geom_type not in ['cone', 'parallel']:
             raise ValueError(f"CIL cannot use TIGRE to process geometries of type {ag.geom_type}.")

--- a/Wrappers/Python/cil/plugins/tigre/ProjectionOperator.py
+++ b/Wrappers/Python/cil/plugins/tigre/ProjectionOperator.py
@@ -27,15 +27,6 @@ from cil.plugins.tigre import CIL2TIGREGeometry
 log = logging.getLogger(__name__)
 
 try:
-    from _Atb import _Atb_ext as Atb
-    from _Ax import _Ax_ext as Ax
-
-except ModuleNotFoundError:
-    raise ModuleNotFoundError(
-        "This plugin requires the additional package TIGRE\n" +
-        "Please install it via conda as tigre from the ccpi channel")
-
-try:
     from tigre.utilities.gpu import GpuIds
     has_gpu_sel = True
 except ModuleNotFoundError:
@@ -176,6 +167,13 @@ class ProjectionOperator_ag(ProjectionOperator):
             self.gpuids = GpuIds()
 
     def __call_Ax(self, data):
+        try:
+            from _Ax import _Ax_ext as Ax
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "This plugin requires the additional package TIGRE\n"
+                "Please install it via conda as tigre from the ccpi channel")
+
         if has_gpu_sel:
             return Ax(data, self.tigre_geom, self.tigre_geom.angles,
                       self.method['direct'], self.tigre_geom.mode, self.gpuids)
@@ -207,6 +205,13 @@ class ProjectionOperator_ag(ProjectionOperator):
         return out
 
     def __call_Atb(self, data):
+        try:
+            from _Atb import _Atb_ext as Atb
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "This plugin requires the additional package TIGRE\n"
+                "Please install it via conda as tigre from the ccpi channel")
+
         if has_gpu_sel:
             return Atb(data, self.tigre_geom, self.tigre_geom.angles,
                        self.method['adjoint'], self.tigre_geom.mode,


### PR DESCRIPTION
- delay `tigre` imports so that documentation builds without TIGRE (fixes #2322)
- fix cuda packages not required for some CI jobs

Probably related/required for:
- #2321
- #2317
- #2218
- #2309

## Testing

Manually verified that the `docs` CI action:

- [x] does not install `tigre`
- [x] produces `DocumentationHTML` art[ie]fact which contains tigre plugin:

```sh
mkdir CIL; unzip -d CIL ~/Downloads/DocumentationHTML.zip
python -m http.server &
$BROWSER "http://localhost:8000/CIL/2323_merge/plugins/#tigre"
```

<img width="889" height="735" alt="image" src="https://github.com/user-attachments/assets/519b5413-8ed4-48de-8c94-c059fba9ce9b" />
