### PR TITLE
conda: restore buildnum

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,7 @@ jobs:
     - uses: prefix-dev/rattler-build-action@v0.2.37
       with:
         recipe-path: recipe.yaml
+        rattler-build-version: v0.65.0 # https://github.com/prefix-dev/rattler-build/pull/2484
         build-args: --experimental -c conda-forge -c https://software.repos.intel.com/python/conda -c ccpi -c astra-toolbox --variant python=${{ matrix.python-version }}
         artifact-name: conda-py${{ matrix.python-version }}-${{ matrix.os }}
   conda-upload:

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -2,8 +2,8 @@ schema_version: 1
 
 context:
   name: ${{ load_from_file("pyproject.toml").project.name }} # ratter-build --experimental
-  build_number: 0
-  version: ${{ git.latest_tag(".") | replace("v", "") }} # .dev${{ build_number }}+g${{ git.head_rev(".") }} # ratter-build --experimental
+  build_number: ${{ git.latest_tag_distance(".") }} # ratter-build>=0.65 --experimental
+  version: ${{ git.latest_tag(".") | replace("v", "") }} # ratter-build --experimental
   test_gpu: ${{ env.get("TESTS_FORCE_GPU", default="") | bool }}
   # used multiple times, so defined once here to avoid repetition
   ipp_version: '2021.12.*'


### PR DESCRIPTION
Thanks to https://github.com/prefix-dev/rattler-build/pull/2484 -> [v0.65](https://github.com/prefix-dev/rattler-build/releases/tag/v0.65.0)
