### PR TITLE
Add astra-toolbox channel, and astra 2.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
     - uses: prefix-dev/rattler-build-action@v0.2.37
       with:
         recipe-path: recipe.yaml
-        build-args: --experimental -c conda-forge -c https://software.repos.intel.com/python/conda -c ccpi --variant python=${{ matrix.python-version }}
+        build-args: --experimental -c conda-forge -c https://software.repos.intel.com/python/conda -c ccpi -c astra-toolbox --variant python=${{ matrix.python-version }}
         artifact-name: conda-py${{ matrix.python-version }}-${{ matrix.os }}
   conda-upload:
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - Update to TomoPhantom v3.0 (#2287)
     - Handle regularisation toolkit CPU only package error message (#2302)
     - Update FindIPP.cmake to find IPP libraries in conda environments (#2286)
+    - Update to ASTRA-TOOLBOX version v2.4 from the `astra-toolbox` channel (#2330)
   - Documentation:
     - Render the user showcase notebooks in the documentation (#2189)
     - Update on build instructions in README and developer guide for all OS (#2286)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source=https://github.com/TomographicImaging/CIL
 LABEL org.opencontainers.image.licenses="Apache-2.0 AND BSD-3-Clause AND GPL-3.0"
 
 # CUDA-specific packages
-ARG CIL_EXTRA_PACKAGES="tigre=2.6 astra-toolbox=2.1.0=cuda*"
+ARG CIL_EXTRA_PACKAGES="tigre=2.6 astra-toolbox=2.4"
 # build & runtime dependencies
 # TODO: sync scripts/create_local_env_for_cil_development.sh, scripts/cil_development.yml, recipe/meta.yaml (e.g. missing libstdcxx-ng _openmp_mutex pip)?
 # vis. https://github.com/TomographicImaging/CIL/pull/1590
@@ -18,7 +18,7 @@ COPY --chown="${NB_USER}" scripts/cil_development.yml environment.yml
 RUN sed -ri '/tigre|astra-toolbox| python /d' environment.yml \
   && for pkg in 'jupyter-server-proxy>4.1.0' $CIL_EXTRA_PACKAGES; do echo "  - $pkg" >> environment.yml; done \
   && conda config --env --set channel_priority strict \
-  && for ch in defaults nvidia ccpi https://software.repos.intel.com/python/conda conda-forge; do conda config --env --add channels $ch; done \
+  && for ch in defaults nvidia ccpi https://software.repos.intel.com/python/conda astra-toolbox conda-forge; do conda config --env --add channels $ch; done \
   && mamba env update -n base \
   && mamba clean -a -y -f \
   && rm environment.yml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ plugins = [
     #"tomophantom==2.0.0", # [linux] # missing from PyPI
 ]
 gpu = [
-    "astra-toolbox>=1.9.9.dev5,<=2.1", # [not osx]
+    "astra-toolbox>=1.9.9.dev5,<=2.4", # [not osx]
     #"tigre>=2.4,<=2.6", # missing from PyPI
 ]
 [dependency-groups]

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -96,7 +96,7 @@ tests:
         - if: test_gpu
           then:
           - tigre 2.6.*
-        - astra-toolbox 2.4
+        - astra-toolbox 2.4.*
         - matplotlib-base >=3.3
         - zenodo_get >=1.6
         - dxchange >=0.2.1

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -96,8 +96,7 @@ tests:
         - if: test_gpu
           then:
           - tigre 2.6.*
-          - astra-toolbox ${{ astra_version }} cuda*
-          else: astra-toolbox ${{ astra_version }} py*
+        - astra-toolbox 2.4
         - matplotlib-base >=3.3
         - zenodo_get >=1.6
         - dxchange >=0.2.1

--- a/scripts/cil_development.yml
+++ b/scripts/cil_development.yml
@@ -24,7 +24,7 @@ dependencies:
   - ccpi::tigre 2.6
   - ccpi::ccpi-regulariser 24.0.1
   - ccpi::tomophantom 3.0.3
-  - astra-toolbox 2.1 cuda*
+  - astra-toolbox::astra-toolbox 2.4
   - cvxpy!=1.8.2
   - python-wget
   - scikit-image


### PR DESCRIPTION
## Changes
Changes to build to get astra from the astra toolbox channel and bump to 2.4
Can't update the readme until release as it'll go line immediatly.

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

## Related issues/links

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the developer guide
- [ ] I have updated the relevant documentation
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers

