### PR TITLE
Pre-release update for v26.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* XX.X.X
+* 26.0.0
   - New features:
     - LSQR algorithm added to the CIL algorithm class (#1975)
     - Add `VolumeShrinker` tool to reduce the size of the reconstruction volume from an `AcquisitionData` (#2221)
@@ -16,7 +16,6 @@
     - dxchange minimum version set to 0.2.1 to fix #2256 (#2268)
     - improve `tqdm` notebook support (#2241)
     - cvxpy version set to !=1.8.2 to fix #2303 (#2306)
-    - Update to TomoPhantom v3.0 (#2287)
     - Handle regularisation toolkit CPU only package error message (#2302)
     - Update FindIPP.cmake to find IPP libraries in conda environments (#2286)
     - Update to ASTRA-TOOLBOX version v2.4 from the `astra-toolbox` channel (#2330)
@@ -34,17 +33,19 @@
     - Add prefix argument to TIFFStackReader to load a subset of TIFF files in
     a folder (#2239)
     - Update ASTRA interface to `direct_FP3D/BP3D` removing copies for GPU `ProjectionOperator` calls (#2134)
-  - Removes the following code which had been deprecated since v24.3.0 or earlier:
-    - Removes `max_iteration` and `log_file` input parameters to `Algorithm`s. 
-    - Removes `max_iteration_stop_criterion`, `objective_to_string`, `verbose_output` and `verbose_header` methods from `Algorithm`s.
-    - Removes `print_interval` and `callback` kwargs from `Algorithm.run` (note: `callbacks` kwarg remains)
-    - Removes `tolerance` input parameter to `CGLS`.
-    - Removes `should_stop` and `flag` methods from `CGLS`.
-    - Removes `alpha`, `beta`, `rtol` and `atol` kwargs from `GD`.
-    - Removes `should_stop` and `objective_function` methods from `GD`.
-    - Removes `norms` and `prob` kwargs from `SPDHG`.
-  - Testing:
-    - migrate from `conda build` to `rattler-build`
+  - Breaking Changes:
+    - CIL is no longer compatible with Tomophantom versions earlier than v3.1.4 (#2218)
+    - Removes the following code which had been deprecated since v24.3.0 or earlier:
+      - Removes `max_iteration` and `log_file` input parameters to `Algorithm`s. 
+      - Removes `max_iteration_stop_criterion`, `objective_to_string`, `verbose_output` and `verbose_header` methods from `Algorithm`s.
+      - Removes `print_interval` and `callback` kwargs from `Algorithm.run` (note: `callbacks` kwarg remains)
+      - Removes `tolerance` input parameter to `CGLS`.
+      - Removes `should_stop` and `flag` methods from `CGLS`.
+      - Removes `alpha`, `beta`, `rtol` and `atol` kwargs from `GD`.
+      - Removes `should_stop` and `objective_function` methods from `GD`.
+      - Removes `norms` and `prob` kwargs from `SPDHG`.
+  - Build changes:
+    - migrate from `conda build` to `rattler-build` (#2321)
 
 * 25.0.0
   - New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 * 26.0.0
   - New features:
-    - LSQR algorithm added to the CIL algorithm class (#1975)
+    - `LSQR` algorithm added to the CIL algorithm class (#1975)
     - Add `VolumeShrinker` tool to reduce the size of the reconstruction volume from an `AcquisitionData` (#2221)
-    - LaminographyGeometryCorrector tool added to processors (#2259)
+    - `LaminographyGeometryCorrector` tool added to processors (#2259)
     - `FluxNormaliser` can be used on `Cone3D_Flex` data (#2347)
+  - Enhancements:
+    - Add prefix argument to `TIFFStackReader` to load a subset of TIFF files in
+    a folder (#2239)
+    - Update ASTRA interface to `direct_FP3D/BP3D` removing copies for GPU `ProjectionOperator` calls (#2134)
   - Bug fixes:
     - `CentreOfRotationCorrector.image_sharpness` data is now correctly smoothed to reduce aliasing artefacts and improve robustness. (#2202)
     - `PaganinProcessor` now correctly applies scaling with magnification for cone-beam geometry (#2225)
@@ -16,9 +20,9 @@
     - fix missing `packaging` required dependency (#2321)
     - dxchange minimum version set to 0.2.1 to fix #2256 (#2268)
     - improve `tqdm` notebook support (#2241)
-    - cvxpy version set to !=1.8.2 to fix #2303 (#2306)
+    - `cvxpy` version set to !=1.8.2 to fix #2303 (#2306)
     - Handle regularisation toolkit CPU only package error message (#2302)
-    - Update FindIPP.cmake to find IPP libraries in conda environments (#2286)
+    - Update `FindIPP.cmake` to find IPP libraries in conda environments (#2286)
     - Update to ASTRA-TOOLBOX version v2.4 from the `astra-toolbox` channel (#2330)
     - Update to TIGRE v3.1.3 (#2317)
     - Added support for numpy 2 (#2218)
@@ -30,10 +34,6 @@
   - Documentation:
     - Render the user showcase notebooks in the documentation (#2189)
     - Update on build instructions in README and developer guide for all OS (#2286)
-  - Enhancements:
-    - Add prefix argument to TIFFStackReader to load a subset of TIFF files in
-    a folder (#2239)
-    - Update ASTRA interface to `direct_FP3D/BP3D` removing copies for GPU `ProjectionOperator` calls (#2134)
   - Breaking Changes:
     - CIL is no longer compatible with Tomophantom versions earlier than v3.1.4 (#2218)
     - Removes the following code which had been deprecated since v24.3.0 or earlier:

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -84,6 +84,7 @@ Adam Doherty (2025) - 5
 Evan Kiely (2025) - 10
 Jeppe Klitgaard (2026) - 2
 Willem Jan Palenstijn (2026) - 16
+Nalin Gupta (2026) - 1
 
 
 CIL Advisory Board:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ where `<env_name>` is `cil_demos`, `cil_demos_cpu` or whatever name you specifie
 #### Install CIL into an existing environment
 If you prefer to install CIL with minimal dependencies into an existing environment you can use:
 ```sh
-conda install -c conda-forge -c ccpi cil=25.0.0
+conda install -c conda-forge -c ccpi cil=26.0.0
 ```
 A number of additional dependencies are required for specific functionality in CIL, these should be added to your environment as necessary. See the dependency table below for details.
 

--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -41,8 +41,8 @@ Core Dependencies
      - `PSF-2.0 <https://docs.python.org/3/license.html>`_
 
    * - `Numpy <https://github.com/numpy/numpy>`_
-     - 2.0–2.4
-     - ``numpy>=2,<=2.4``
+     - 1.26–2.4
+     - ``numpy>=1.26,<=2.4``
      - 
      - `BSD-3-Clause <https://numpy.org/doc/stable/license.html>`_
 
@@ -85,7 +85,7 @@ Optional Dependencies
      - `Apache-2.0 <https://github.com/TomographicImaging/CCPi-Regularisation-Toolkit/blob/master/LICENSE>`_
 
    * - `TomoPhantom <https://github.com/dkazanc/TomoPhantom>`_
-     - 3.0.3–3.1.4
+     - 3.1.4
      - ``httomo::tomophantom=3.1.4``
      - Generates phantoms for test data
      - `Apache-2.0 <https://github.com/dkazanc/TomoPhantom/blob/master/LICENSE>`_

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -23,7 +23,7 @@ Building CIL from source code
 ==============================
 
 Getting the code
-^^^^^^^^^^^^^^^^
+-----------------
 
 In case of local development and testing it is useful to be able to build the software directly. 
 You should first clone this repository as:
@@ -37,10 +37,10 @@ See `git documentation <https://git-scm.com/docs/git-clone#Documentation/git-clo
 
 
 Building with ``pip``
-^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 Install Dependencies
-""""""""""""""""""
+""""""""""""""""""""
 
 We suggest creating a conda environment with all the dependencies for building CIL using the appropriate command for your operating system:
 
@@ -73,7 +73,7 @@ Activate the environment with:
    conda activate cil_dev
 
 Build CIL
-""""""""
+"""""""""
 
 A C++ compiler is required to build the source code. Let's suppose that the user is in the source directory, then the following commands should work:
 
@@ -123,7 +123,7 @@ Note: we tested these instructions with Visual Studio 2026 version 18.1.1
 
 
 Building with Docker
-^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 In the repository root, simply update submodules and run ``docker build``:
 
@@ -134,7 +134,7 @@ In the repository root, simply update submodules and run ``docker build``:
 
 
 Testing
-^^^^^^^
+--------
 
 Once installed, CIL functionality can be tested using the following command:
 

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -183,7 +183,8 @@ All methods should follow the convention of small caps underscore separated word
 
 Scalar Types
 -------------
-From numpy v2.0 onwards, [numpy data types are promoted in operations](https://numpy.org/doc/2.3/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion).
+
+From numpy v2.0 onwards, `numpy data types are promoted in operations <https://numpy.org/doc/2.3/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion>`_.
 Scalars should be stored as Python types (e.g. int, float) instead of numpy data types (e.g. np.int32, np.float64) to avoid unexpected behaviour in operations with variables with numpy types.
 
 Note: This convention is not fully adhered to across CIL yet, but new code should follow this convention.


### PR DESCRIPTION
## Description
<!--overview of changes, reason/motivation, issue link(s), etc.-->
Updates in line with the release checklist: https://github.com/TomographicImaging/CIL/issues/2344

The update to the documentation makes the headings render under 'Conventions on new CIL objects' in the developer guide, and makes the section on scalar variables render properly. Used to be like:

<img width="2502" height="1055" alt="image" src="https://github.com/user-attachments/assets/c7d4d659-c662-48a4-ad00-2fad017a833c" />

Now looks like:
<img width="2400" height="1060" alt="image" src="https://github.com/user-attachments/assets/25292092-17ae-4b32-90dc-998e6ed4dbb2" />

## Example Usage
<!--minimal working example-->

## Contribution Notes

<!-- Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide/) and local patterns and conventions. -->

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties


## Changes


## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links
Closes https://github.com/TomographicImaging/CIL/pull/2345

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers

