### PR TITLE
Update FluxNormaliser for Flex geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
     - Add prefix argument to TIFFStackReader to load a subset of TIFF files in
     a folder (#2239)
     - Update ASTRA interface to `direct_FP3D/BP3D` removing copies for GPU `ProjectionOperator` calls (#2134)
+    - Update `FluxNormaliser` to work with `Cone3D_Flex` (#2347)
   - Removes the following code which had been deprecated since v24.3.0 or earlier:
     - Removes `max_iteration` and `log_file` input parameters to `Algorithm`s. 
     - Removes `max_iteration_stop_criterion`, `objective_to_string`, `verbose_output` and `verbose_header` methods from `Algorithm`s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
     - LSQR algorithm added to the CIL algorithm class (#1975)
     - Add `VolumeShrinker` tool to reduce the size of the reconstruction volume from an `AcquisitionData` (#2221)
     - LaminographyGeometryCorrector tool added to processors (#2259)
+    - `FluxNormaliser` can be used on `Cone3D_Flex` data (#2347)
   - Bug fixes:
     - `CentreOfRotationCorrector.image_sharpness` data is now correctly smoothed to reduce aliasing artefacts and improve robustness. (#2202)
     - `PaganinProcessor` now correctly applies scaling with magnification for cone-beam geometry (#2225)
@@ -34,7 +35,6 @@
     - Add prefix argument to TIFFStackReader to load a subset of TIFF files in
     a folder (#2239)
     - Update ASTRA interface to `direct_FP3D/BP3D` removing copies for GPU `ProjectionOperator` calls (#2134)
-    - Update `FluxNormaliser` to work with `Cone3D_Flex` (#2347)
   - Removes the following code which had been deprecated since v24.3.0 or earlier:
     - Removes `max_iteration` and `log_file` input parameters to `Algorithm`s. 
     - Removes `max_iteration_stop_criterion`, `objective_to_string`, `verbose_output` and `verbose_header` methods from `Algorithm`s.

--- a/Wrappers/Python/cil/processors/FluxNormaliser.py
+++ b/Wrappers/Python/cil/processors/FluxNormaliser.py
@@ -245,7 +245,7 @@ class FluxNormaliser(Processor):
             raise TypeError("Target must be string or a number, found {}"
                             .format(type(self.target)))
             
-    def preview_configuration(self, angle=None, channel=None, log=False):
+    def preview_configuration(self, projection_idx=None, channel=None, log=False, **kwargs):
         '''
         Preview the FluxNormalisation processor configuration for roi mode.
         Plots the region of interest on the image and the mean, maximum and 
@@ -255,8 +255,8 @@ class FluxNormaliser(Processor):
         
         Parameters:
         -----------
-        angle: float, optional
-            Index of the angle/projection to plot, default=None displays the data with the 
+        projection_idx: int, optional
+            Index of the projection to plot, default=None displays the data with the 
             minimum and maximum pixel values in the roi. For 2D data, the roi is 
             plotted on the sinogram.
 
@@ -267,12 +267,26 @@ class FluxNormaliser(Processor):
         log: bool, default=False
             If True, plot the image with a log scale, default is False
 
+        **kwargs:
+            angle: int, optional
+                Deprecated alias for `projection_idx`. Use `projection_idx` instead.
+
         Returns:
         --------
         matplotlib.figure.Figure
             The figure object created to plot the configuration
         '''
         import matplotlib.pyplot as plt
+        
+        if 'angle' in kwargs:
+            if projection_idx is not None:
+                raise TypeError("Both projection_idx and angle were specified; angle is deprecated, use projection_idx instead")
+            projection_idx = kwargs.pop('angle')
+            warnings.warn(
+                "The 'angle' keyword argument is deprecated and will be removed in a future version; use 'projection_idx' instead.",
+                DeprecationWarning, stacklevel=2)
+        if kwargs:
+            raise TypeError(f"preview_configuration() got unexpected keyword arguments {list(kwargs)}")
 
         self._calculate_flux()
 
@@ -304,7 +318,7 @@ class FluxNormaliser(Processor):
         
             plt.figure(figsize=(8,8))
             if data.geometry.dimension == '3D':
-                if angle is None:
+                if projection_idx is None:
                     if 'angle' in data.dimension_labels or 'projection' in data.dimension_labels:
                         self._plot_slice_roi(angle_index=numpy.argmin(min), channel_index=channel, log=log, ax=221)
                         self._plot_slice_roi(angle_index=numpy.argmax(max), channel_index=channel, log=log, ax=222)
@@ -312,16 +326,16 @@ class FluxNormaliser(Processor):
                         self._plot_slice_roi(log=log, channel_index=channel, ax=211)
                 else:
                     if 'angle' in data.dimension_labels or 'projection' in data.dimension_labels:
-                        self._plot_slice_roi(angle_index=angle, channel_index=channel, log=log, ax=211)
+                        self._plot_slice_roi(angle_index=projection_idx, channel_index=channel, log=log, ax=211)
                     else:
                         self._plot_slice_roi(log=log, channel_index=channel, ax=211)
                         
             # if data is 2D plot roi on all angles
             elif data.geometry.dimension == '2D':
-                if angle is None:
+                if projection_idx is None:
                     self._plot_slice_roi(channel_index=channel, log=log, ax=211)
                 else:
-                    raise ValueError("Cannot plot ROI for a single angle on 2D data, please specify angle=None to plot ROI on the sinogram")
+                    raise ValueError("Cannot plot ROI for a single projection on 2D data, please specify projection_idx=None to plot ROI on the sinogram")
             
             plt.subplot(212)
             if data.geometry.num_projections==1:

--- a/Wrappers/Python/cil/processors/FluxNormaliser.py
+++ b/Wrappers/Python/cil/processors/FluxNormaliser.py
@@ -116,10 +116,7 @@ class FluxNormaliser(Processor):
         if not (type(dataset), AcquisitionData):
             raise TypeError("Expected AcquistionData, found {}"
                             .format(type(dataset)))
-        
-        if dataset.geometry.geom_type & AcquisitionType.CONE_FLEX:
-            raise NotImplementedError("FluxNormaliser does not yet support CONE3D_FLEX data")
-        
+
         image_axes = 0
         if 'vertical' in dataset.dimension_labels:
             self.v_axis = dataset.get_dimension_axis('vertical')
@@ -259,7 +256,7 @@ class FluxNormaliser(Processor):
         Parameters:
         -----------
         angle: float, optional
-            Index of the angle to plot, default=None displays the data with the 
+            Index of the angle/projection to plot, default=None displays the data with the 
             minimum and maximum pixel values in the roi. For 2D data, the roi is 
             plotted on the sinogram.
 
@@ -308,13 +305,13 @@ class FluxNormaliser(Processor):
             plt.figure(figsize=(8,8))
             if data.geometry.dimension == '3D':
                 if angle is None:
-                    if 'angle' in data.dimension_labels:
+                    if 'angle' in data.dimension_labels or 'projection' in data.dimension_labels:
                         self._plot_slice_roi(angle_index=numpy.argmin(min), channel_index=channel, log=log, ax=221)
                         self._plot_slice_roi(angle_index=numpy.argmax(max), channel_index=channel, log=log, ax=222)
                     else:
                         self._plot_slice_roi(log=log, channel_index=channel, ax=211)
                 else:
-                    if 'angle' in data.dimension_labels:
+                    if 'angle' in data.dimension_labels or 'projection' in data.dimension_labels:
                         self._plot_slice_roi(angle_index=angle, channel_index=channel, log=log, ax=211)
                     else:
                         self._plot_slice_roi(log=log, channel_index=channel, ax=211)
@@ -332,23 +329,24 @@ class FluxNormaliser(Processor):
                 plt.plot(0, min,'.k', label='Minimum')
                 plt.plot(0, max,'.k', label='Maximum')
             else:
-                indices = range(data.get_dimension_size('angle'))
+                indices = range(data.geometry.num_projections)
                 plt.plot(indices, flux_array, 'r', label='Mean')
                 plt.plot(indices, min,'--k', label='Minimum')
                 plt.plot(indices, max,'--k', label='Maximum')
 
             plt.legend()
-            plt.xlabel('angle index')
+            plt.xlabel('projection index')
             plt.ylabel('Intensity in roi')
             plt.grid()
 
             ax1 = plt.gca()
-            ax2 = ax1.twiny()
-            valid_ticks = [int(tick) for tick in ax1.get_xticks() if 0 <= tick < data.geometry.num_projections]
-            ax2.set_xticks(valid_ticks)
-            ax2.set_xbound(ax1.get_xbound())
-            ax2.set_xticklabels([data.geometry.angles[tick] for tick in valid_ticks])
-            ax2.set_xlabel('angle')
+            if 'angle' in data.geometry.dimension_labels:
+                ax2 = ax1.twiny()
+                valid_ticks = [int(tick) for tick in ax1.get_xticks() if 0 <= tick < data.geometry.num_projections]
+                ax2.set_xticks(valid_ticks)
+                ax2.set_xbound(ax1.get_xbound())
+                ax2.set_xticklabels([data.geometry.angles[tick] for tick in valid_ticks])
+                ax2.set_xlabel('angle')
             
             plt.tight_layout()
             
@@ -363,7 +361,7 @@ class FluxNormaliser(Processor):
         Parameters:
         -----------
         angle_index: int, optional
-            Index of the angle to plot
+            Index of the projection to plot
         channel_index: int, optional
             Index of the channel to plot
         log: bool, optional
@@ -376,6 +374,8 @@ class FluxNormaliser(Processor):
         data = self.get_input()
         if angle_index is not None and 'angle' in data.dimension_labels:
             data_slice = data.get_slice(angle=angle_index)
+        elif angle_index is not None and 'projection' in data.dimension_labels:
+            data_slice = data.get_slice(projection=angle_index)
         else:
             data_slice = data
         
@@ -383,7 +383,7 @@ class FluxNormaliser(Processor):
             data_slice = data_slice.get_slice(channel=channel_index)
 
         if len(data_slice.shape) != 2:
-            raise ValueError("Data shape not compatible with preview_configuration(), data must have at least two of 'horizontal', 'vertical' and 'angle'")
+            raise ValueError("Data shape not compatible with preview_configuration(), data must have at least two of 'horizontal', 'vertical' and 'angle'/'projection'")
         
         # if horizontal and vertical are not specified in the roi, get the
         # min and max extent from the full size of the dimension
@@ -409,14 +409,14 @@ class FluxNormaliser(Processor):
         v = data_slice.dimension_labels[0]
 
         # get the box to plot from the roi
-        if h == 'angle':
+        if h == 'angle' or h == 'projection':
             h_min = min_angle
             h_max = max_angle
         else:
             h_min = self.roi[h][0]
             h_max = self.roi[h][1]
 
-        if v == 'angle':
+        if v == 'angle' or v == 'projection':
             v_min = min_angle
             v_max = max_angle
         else:
@@ -431,8 +431,12 @@ class FluxNormaliser(Processor):
         ax1.plot([h_max, h_max],[v_min, v_max],'--r')
         
         title = 'ROI'
-        if angle_index is not None:
+        if angle_index is not None and 'angle' in  data_slice.dimension_labels:
             title += ' angle = ' + str(data.geometry.angles[angle_index])
+
+        if angle_index is not None and 'projection' in  data_slice.dimension_labels:
+            title += ' projection = ' + str(angle_index)
+
         if channel_index is not None:
             title += ' channel = ' + str(channel_index)
         ax1.set_title(title)

--- a/Wrappers/Python/cil/processors/FluxNormaliser.py
+++ b/Wrappers/Python/cil/processors/FluxNormaliser.py
@@ -245,7 +245,7 @@ class FluxNormaliser(Processor):
             raise TypeError("Target must be string or a number, found {}"
                             .format(type(self.target)))
             
-    def preview_configuration(self, projection_idx=None, channel=None, log=False, **kwargs):
+    def preview_configuration(self, projection_index=None, channel=None, log=False, **kwargs):
         '''
         Preview the FluxNormalisation processor configuration for roi mode.
         Plots the region of interest on the image and the mean, maximum and 
@@ -255,7 +255,7 @@ class FluxNormaliser(Processor):
         
         Parameters:
         -----------
-        projection_idx: int, optional
+        projection_index: int, optional
             Index of the projection to plot, default=None displays the data with the 
             minimum and maximum pixel values in the roi. For 2D data, the roi is 
             plotted on the sinogram.
@@ -269,7 +269,7 @@ class FluxNormaliser(Processor):
 
         **kwargs:
             angle: int, optional
-                Deprecated alias for `projection_idx`. Use `projection_idx` instead.
+                Deprecated alias for `projection_index`. Use `projection_index` instead.
 
         Returns:
         --------
@@ -279,11 +279,11 @@ class FluxNormaliser(Processor):
         import matplotlib.pyplot as plt
         
         if 'angle' in kwargs:
-            if projection_idx is not None:
-                raise TypeError("Both projection_idx and angle were specified; angle is deprecated, use projection_idx instead")
-            projection_idx = kwargs.pop('angle')
+            if projection_index is not None:
+                raise TypeError("Both projection_index and angle were specified; angle is deprecated, use projection_index instead")
+            projection_index = kwargs.pop('angle')
             warnings.warn(
-                "The 'angle' keyword argument is deprecated and will be removed in a future version; use 'projection_idx' instead.",
+                "The 'angle' keyword argument is deprecated and will be removed in a future version; use 'projection_index' instead.",
                 DeprecationWarning, stacklevel=2)
         if kwargs:
             raise TypeError(f"preview_configuration() got unexpected keyword arguments {list(kwargs)}")
@@ -318,7 +318,7 @@ class FluxNormaliser(Processor):
         
             plt.figure(figsize=(8,8))
             if data.geometry.dimension == '3D':
-                if projection_idx is None:
+                if projection_index is None:
                     if 'angle' in data.dimension_labels or 'projection' in data.dimension_labels:
                         self._plot_slice_roi(angle_index=numpy.argmin(min), channel_index=channel, log=log, ax=221)
                         self._plot_slice_roi(angle_index=numpy.argmax(max), channel_index=channel, log=log, ax=222)
@@ -326,16 +326,16 @@ class FluxNormaliser(Processor):
                         self._plot_slice_roi(log=log, channel_index=channel, ax=211)
                 else:
                     if 'angle' in data.dimension_labels or 'projection' in data.dimension_labels:
-                        self._plot_slice_roi(angle_index=projection_idx, channel_index=channel, log=log, ax=211)
+                        self._plot_slice_roi(angle_index=projection_index, channel_index=channel, log=log, ax=211)
                     else:
                         self._plot_slice_roi(log=log, channel_index=channel, ax=211)
                         
             # if data is 2D plot roi on all angles
             elif data.geometry.dimension == '2D':
-                if projection_idx is None:
+                if projection_index is None:
                     self._plot_slice_roi(channel_index=channel, log=log, ax=211)
                 else:
-                    raise ValueError("Cannot plot ROI for a single projection on 2D data, please specify projection_idx=None to plot ROI on the sinogram")
+                    raise ValueError("Cannot plot ROI for a single projection on 2D data, please specify projection_index=None to plot ROI on the sinogram")
             
             plt.subplot(212)
             if data.geometry.num_projections==1:

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -3595,8 +3595,8 @@ class TestFluxNormaliser(unittest.TestCase):
         detector_position_set=[[0,0,0]]*3
         detector_direction_x_set=[[1, 0, 0]]*3
         detector_direction_y_set=[[0, 0, 1]]*3
-        cone_flex_ag = AcquisitionGeometry.create_Cone3D_Flex(source_position_set, detector_position_set, detector_direction_x_set, detector_direction_y_set).set_panel([3,3])
-        self.cone_flex  = AcquisitionData(arr, geometry=cone_flex_ag)
+        cone_flex_ag = AcquisitionGeometry.create_Cone3D_Flex(source_position_set, detector_position_set, detector_direction_x_set, detector_direction_y_set).set_panel([128,128])
+        self.cone_flex  = cone_flex_ag.allocate(1)
 
     def error_message(self,processor, test_parameter):
             return "Failed with processor " + str(processor) + " on test parameter " + test_parameter
@@ -3809,92 +3809,8 @@ class TestFluxNormaliser(unittest.TestCase):
 
         # Test no error with preview_configuration with different data shapes
         for data in [self.data_cone, self.data_parallel, self.data_multichannel, 
-                     self.data_slice, self.data_reorder, self.data_single_angle]:
-            mock_show.reset_mock()
-
-            roi = {'horizontal':(25,40)}
-            processor = FluxNormaliser(roi=roi)
-            processor.set_input(data)
-            fig = processor.preview_configuration()
-            
-            mock_show.assert_called_once()
-
-            # for 3D, check no error specifying a single angle to plot
-            if data.geometry.dimension == '3D':
-                processor.preview_configuration(angle=1)
-            # if 2D, attempt to plot single angle should cause error
-            else:
-                with self.assertRaises(ValueError):
-                    processor.preview_configuration(angle=1)
-
-            # if data is multichannel, check no error specifying a single channel to plot
-            if 'channel' in data.dimension_labels:
-                processor.preview_configuration(angle=1, channel=1)
-                processor.preview_configuration(channel=1)
-            # if single channel, check specifying channel causes an error
-            else:
-                with self.assertRaises(ValueError):
-                    processor.preview_configuration(channel=1)
-
-        # Re-enable logging
-        logging.disable(logging.NOTSET)
-
-    @unittest.skipIf(not has_matplotlib, "matplotlib not installed")
-    @patch('matplotlib.pyplot.show')
-    def test_preview_configuration_flex(self, mock_show):
-        
-        # Suppress backround range warning
-        logging.disable(logging.CRITICAL)
-
-        # Test correct data is plotted
-        roi = {'horizontal':(0,3),'vertical':(0,1)}
-        processor = FluxNormaliser(roi=roi)
-        processor.set_input(self.cone_flex)
-        
-        fig = processor.preview_configuration()
-        
-        # Check slice plots
-        slice_plot1 = fig.axes[0].images[0].get_array().data
-        slice_plot2 = fig.axes[2].images[0].get_array().data
-        numpy.testing.assert_allclose(self.data_simple.array[0], slice_plot1)
-        numpy.testing.assert_allclose(self.data_simple.array[2], slice_plot2)
-
-        # Check ROI plots
-        for f in [fig.axes[0], fig.axes[2]]:
-            roi_x_lower = f.lines[0].get_xdata()
-            roi_x_upper = f.lines[1].get_xdata()
-            roi_y_lower = f.lines[0].get_ydata()
-            roi_y_upper = f.lines[1].get_ydata()
-            numpy.testing.assert_allclose(roi_x_lower, [0,3])
-            numpy.testing.assert_allclose(roi_x_upper, [0,3])
-            numpy.testing.assert_allclose(roi_y_lower, [0,0])
-            numpy.testing.assert_allclose(roi_y_upper, [1,1])
-
-            roi_x_left = f.lines[2].get_xdata()
-            roi_x_right = f.lines[3].get_xdata()
-            roi_y_left = f.lines[2].get_ydata()
-            roi_y_right = f.lines[3].get_ydata()
-            numpy.testing.assert_allclose(roi_x_left, [0,0])
-            numpy.testing.assert_allclose(roi_x_right, [3,3])
-            numpy.testing.assert_allclose(roi_y_left, [0,1])
-            numpy.testing.assert_allclose(roi_y_right, [0,1])
-
-        # Check line data
-        data_mean = self.data_simple.get_slice(vertical=1).array.mean(axis=1)
-        plot_mean = fig.axes[4].lines[0].get_ydata()
-        numpy.testing.assert_allclose(data_mean, plot_mean)
-
-        data_min = self.data_simple.get_slice(vertical=1).array.min(axis=1)
-        plot_min = fig.axes[4].lines[1].get_ydata()
-        numpy.testing.assert_allclose(data_min, plot_min)
-
-        data_max = self.data_simple.get_slice(vertical=1).array.max(axis=1)
-        plot_max = fig.axes[4].lines[2].get_ydata()
-        numpy.testing.assert_allclose(data_max, plot_max)
-
-        # Test no error with preview_configuration with different data shapes
-        for data in [self.data_cone, self.data_parallel, self.data_multichannel, 
-                     self.data_slice, self.data_reorder, self.data_single_angle]:
+                     self.data_slice, self.data_reorder, self.data_single_angle,
+                     self.cone_flex]:
             mock_show.reset_mock()
 
             roi = {'horizontal':(25,40)}

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -3822,15 +3822,15 @@ class TestFluxNormaliser(unittest.TestCase):
 
             # for 3D, check no error specifying a single angle to plot
             if data.geometry.dimension == '3D':
-                processor.preview_configuration(projection_idx=1)
+                processor.preview_configuration(projection_index=1)
             # if 2D, attempt to plot single angle should cause error
             else:
                 with self.assertRaises(ValueError):
-                    processor.preview_configuration(projection_idx=1)
+                    processor.preview_configuration(projection_index=1)
 
             # if data is multichannel, check no error specifying a single channel to plot
             if 'channel' in data.dimension_labels:
-                processor.preview_configuration(projection_idx=1, channel=1)
+                processor.preview_configuration(projection_index=1, channel=1)
                 processor.preview_configuration(channel=1)
             # if single channel, check specifying channel causes an error
             else:
@@ -3852,10 +3852,10 @@ class TestFluxNormaliser(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             processor.preview_configuration(angle=1)
 
-        processor.preview_configuration(projection_idx=1)
+        processor.preview_configuration(projection_index=1)
 
         with self.assertRaises(TypeError):
-            processor.preview_configuration(projection_idx=1, angle=1)
+            processor.preview_configuration(projection_index=1, angle=1)
 
         logging.disable(logging.NOTSET)
 

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -3588,7 +3588,7 @@ class TestFluxNormaliser(unittest.TestCase):
             .set_panel([3,3])
         arr = numpy.array([[[1,2,3],[1,2,3],[1,2,3]],
                         [[4,5,6],[4,5,6],[4,5,6]], 
-                        [[7,8,9],[7,8,9],[7,8,9]]])
+                        [[7,8,9],[7,8,9],[7,8,9]]],dtype=numpy.float32)
         self.data_simple = AcquisitionData(arr, geometry=ag)
 
         source_position_set=[[0,-100000,0]]*3
@@ -3622,11 +3622,6 @@ class TestFluxNormaliser(unittest.TestCase):
         processor = FluxNormaliser()
         with self.assertRaises(ValueError):
             processor.check_input(self.data_cone)
-
-        # check there's a not implemented error if cone flex geom is used:
-        processor = FluxNormaliser(flux=[1,2,3])
-        with self.assertRaises(NotImplementedError):
-            processor.check_input(self.cone_flex)
 
     def test_calculate_flux(self):
         # check there is an error if flux array size is not equal to the number of angles in data
@@ -3844,6 +3839,91 @@ class TestFluxNormaliser(unittest.TestCase):
         # Re-enable logging
         logging.disable(logging.NOTSET)
 
+    @unittest.skipIf(not has_matplotlib, "matplotlib not installed")
+    @patch('matplotlib.pyplot.show')
+    def test_preview_configuration_flex(self, mock_show):
+        
+        # Suppress backround range warning
+        logging.disable(logging.CRITICAL)
+
+        # Test correct data is plotted
+        roi = {'horizontal':(0,3),'vertical':(0,1)}
+        processor = FluxNormaliser(roi=roi)
+        processor.set_input(self.cone_flex)
+        
+        fig = processor.preview_configuration()
+        
+        # Check slice plots
+        slice_plot1 = fig.axes[0].images[0].get_array().data
+        slice_plot2 = fig.axes[2].images[0].get_array().data
+        numpy.testing.assert_allclose(self.data_simple.array[0], slice_plot1)
+        numpy.testing.assert_allclose(self.data_simple.array[2], slice_plot2)
+
+        # Check ROI plots
+        for f in [fig.axes[0], fig.axes[2]]:
+            roi_x_lower = f.lines[0].get_xdata()
+            roi_x_upper = f.lines[1].get_xdata()
+            roi_y_lower = f.lines[0].get_ydata()
+            roi_y_upper = f.lines[1].get_ydata()
+            numpy.testing.assert_allclose(roi_x_lower, [0,3])
+            numpy.testing.assert_allclose(roi_x_upper, [0,3])
+            numpy.testing.assert_allclose(roi_y_lower, [0,0])
+            numpy.testing.assert_allclose(roi_y_upper, [1,1])
+
+            roi_x_left = f.lines[2].get_xdata()
+            roi_x_right = f.lines[3].get_xdata()
+            roi_y_left = f.lines[2].get_ydata()
+            roi_y_right = f.lines[3].get_ydata()
+            numpy.testing.assert_allclose(roi_x_left, [0,0])
+            numpy.testing.assert_allclose(roi_x_right, [3,3])
+            numpy.testing.assert_allclose(roi_y_left, [0,1])
+            numpy.testing.assert_allclose(roi_y_right, [0,1])
+
+        # Check line data
+        data_mean = self.data_simple.get_slice(vertical=1).array.mean(axis=1)
+        plot_mean = fig.axes[4].lines[0].get_ydata()
+        numpy.testing.assert_allclose(data_mean, plot_mean)
+
+        data_min = self.data_simple.get_slice(vertical=1).array.min(axis=1)
+        plot_min = fig.axes[4].lines[1].get_ydata()
+        numpy.testing.assert_allclose(data_min, plot_min)
+
+        data_max = self.data_simple.get_slice(vertical=1).array.max(axis=1)
+        plot_max = fig.axes[4].lines[2].get_ydata()
+        numpy.testing.assert_allclose(data_max, plot_max)
+
+        # Test no error with preview_configuration with different data shapes
+        for data in [self.data_cone, self.data_parallel, self.data_multichannel, 
+                     self.data_slice, self.data_reorder, self.data_single_angle]:
+            mock_show.reset_mock()
+
+            roi = {'horizontal':(25,40)}
+            processor = FluxNormaliser(roi=roi)
+            processor.set_input(data)
+            fig = processor.preview_configuration()
+            
+            mock_show.assert_called_once()
+
+            # for 3D, check no error specifying a single angle to plot
+            if data.geometry.dimension == '3D':
+                processor.preview_configuration(angle=1)
+            # if 2D, attempt to plot single angle should cause error
+            else:
+                with self.assertRaises(ValueError):
+                    processor.preview_configuration(angle=1)
+
+            # if data is multichannel, check no error specifying a single channel to plot
+            if 'channel' in data.dimension_labels:
+                processor.preview_configuration(angle=1, channel=1)
+                processor.preview_configuration(channel=1)
+            # if single channel, check specifying channel causes an error
+            else:
+                with self.assertRaises(ValueError):
+                    processor.preview_configuration(channel=1)
+
+        # Re-enable logging
+        logging.disable(logging.NOTSET)
+
     def test_FluxNormaliser(self, accelerated=False):
 
         # Suppress backround range warning
@@ -3855,6 +3935,12 @@ class TestFluxNormaliser(unittest.TestCase):
         data_norm = processor.get_output()
         numpy.testing.assert_allclose(data_norm.array, self.data_cone.array)
         
+        #Test flux with no target on ConeFlex
+        processor = FluxNormaliser(flux=1, accelerated=accelerated)
+        processor.set_input(self.cone_flex)
+        data_norm = processor.get_output()
+        numpy.testing.assert_allclose(data_norm.array, self.cone_flex.array)
+
         #Test flux with target
         processor = FluxNormaliser(flux=10, target=5.0, accelerated=accelerated)
         processor.set_input(self.data_cone)

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -3822,15 +3822,15 @@ class TestFluxNormaliser(unittest.TestCase):
 
             # for 3D, check no error specifying a single angle to plot
             if data.geometry.dimension == '3D':
-                processor.preview_configuration(angle=1)
+                processor.preview_configuration(projection_idx=1)
             # if 2D, attempt to plot single angle should cause error
             else:
                 with self.assertRaises(ValueError):
-                    processor.preview_configuration(angle=1)
+                    processor.preview_configuration(projection_idx=1)
 
             # if data is multichannel, check no error specifying a single channel to plot
             if 'channel' in data.dimension_labels:
-                processor.preview_configuration(angle=1, channel=1)
+                processor.preview_configuration(projection_idx=1, channel=1)
                 processor.preview_configuration(channel=1)
             # if single channel, check specifying channel causes an error
             else:
@@ -3838,6 +3838,25 @@ class TestFluxNormaliser(unittest.TestCase):
                     processor.preview_configuration(channel=1)
 
         # Re-enable logging
+        logging.disable(logging.NOTSET)
+
+    @unittest.skipIf(not has_matplotlib, "matplotlib not installed")
+    @patch('matplotlib.pyplot.show')
+    def test_preview_configuration_deprecated_angle(self, mock_show):
+        logging.disable(logging.CRITICAL)
+
+        roi = {'horizontal':(25,40)}
+        processor = FluxNormaliser(roi=roi)
+        processor.set_input(self.data_cone)
+
+        with self.assertWarns(DeprecationWarning):
+            processor.preview_configuration(angle=1)
+
+        processor.preview_configuration(projection_idx=1)
+
+        with self.assertRaises(TypeError):
+            processor.preview_configuration(projection_idx=1, angle=1)
+
         logging.disable(logging.NOTSET)
 
     def test_FluxNormaliser(self, accelerated=False):


### PR DESCRIPTION
## Changes
Updated FluxNormaliser to work with Cone_Flex3D data. Mostly this is the preview not defaulting to `angles`

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc

Added unit test. Ran on cone flex dragon data (see below) and checked no changes to the standard FluxNormaliser notebook in misc.

<img width="787" height="790" alt="image" src="https://github.com/user-attachments/assets/cd063711-ce36-4e70-885a-c1a8b0e25233" />

## Related issues/links
closes #2349

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
