### PR TITLE
Update version test for tag version format

### DIFF
--- a/Wrappers/Python/test/test_version.py
+++ b/Wrappers/Python/test/test_version.py
@@ -47,6 +47,6 @@ class TestModuleBase(unittest.TestCase):
         from cil import version
         self.assertTrue(isinstance(version.commit_hash, str))
         try: # tagged release
-            self.assertEqual((version.commit_hash, version.num_commit), ('None', 0))
+            self.assertEqual((version.commit_hash, version.num_commit), ('', 9999))
         except AssertionError: # dev build
             self.assertEqual(version.commit_hash[0], 'g')


### PR DESCRIPTION
There is a new version file this release, and the unit test logic was referring to the old tag version structure. Passed on dev builds, but failed on tags. Updated the unittest to new format, but we might want to discuss why the change happened.

https://github.com/TomographicImaging/CIL/blob/master/Wrappers/Python/cil/version.py 





