### PR TITLE
Add methods to get angles and set initial angle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 * x.x.x
   - New features:
     - Added `Huber Loss` function (#2281)
-    - `AcquisitionGeometry.get_angles` returns the angles in the requested unit, optionally including the initial angle (#2364)
-    - `AcquisitionGeometry.set_initial_angle` updates the initial angle without re-setting the angle data (#2364)
+    - `AcquisitionGeometry.get_angles` returns the angles in the requested unit, optionally including the initial angle (#2368)
+    - `AcquisitionGeometry.set_initial_angle` updates the initial angle without re-setting the angle data (#2368)
   - Enhancements:
     - `GenericFilteredBackProjection`'s `plot_filter` returns a `matplotlib.figure.Figure` instead of a `matplotlib.pyplot` (#2360)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 * x.x.x
   - New features:
     - Added `Huber Loss` function (#2281)
+    - `AcquisitionGeometry.get_angles` returns the angles in the requested unit, optionally including the initial angle (#2364)
+    - `AcquisitionGeometry.set_initial_angle` updates the initial angle without re-setting the angle data (#2364)
   - Enhancements:
     - `GenericFilteredBackProjection`'s `plot_filter` returns a `matplotlib.figure.Figure` instead of a `matplotlib.pyplot` (#2360)
 

--- a/Wrappers/Python/cil/framework/acquisition_geometry.py
+++ b/Wrappers/Python/cil/framework/acquisition_geometry.py
@@ -1918,6 +1918,46 @@ class AcquisitionGeometry(metaclass=BackwardCompat):
         else:
             return self.config.angles.angle_data
 
+    def get_angles(self, angle_unit='degree', include_initial_angle=False):
+        '''Returns the angular positions of the acquisition data, converted to the requested units
+
+        Parameters
+        ----------
+        angle_unit : string, default='degree'
+            The units to return the angles in, 'degree' or 'radian'
+
+        include_initial_angle : bool, default=False
+            If True the initial angle is added to each angle. The initial angle rotates
+            the reconstruction grid relative to the first projection.
+
+        Returns
+        -------
+        numpy.ndarray
+            A copy of the angular positions. None for `Cone3D_Flex` geometry, where the
+            rotation is described by the system geometry instead.
+
+        Examples
+        --------
+        >>> geometry.get_angles('radian', include_initial_angle=True)
+
+        '''
+        if AcquisitionType.CONE_FLEX & self.geom_type:
+            return None
+
+        angles = self.config.angles.angle_data.copy()
+
+        if include_initial_angle:
+            angles += self.config.angles.initial_angle
+
+        angle_unit = AngleUnit(angle_unit)
+        if angle_unit != AngleUnit(self.config.angles.angle_unit):
+            if angle_unit == AngleUnit.RADIAN:
+                angles = numpy.deg2rad(angles)
+            else:
+                angles = numpy.rad2deg(angles)
+
+        return angles
+
     @property
     def dist_source_center(self):
         """
@@ -2217,6 +2257,44 @@ class AcquisitionGeometry(metaclass=BackwardCompat):
             warnings.warn("Angles cannot be set for Cone3D_Flex geometry.", UserWarning, stacklevel=2)
         else:
             self.config.angles = Angles(angles, initial_angle, angle_unit)
+        return self
+
+    def set_initial_angle(self, initial_angle, angle_unit='degree'):
+        '''Updates the initial angle of an AcquisitionGeometry object, leaving the angles unchanged
+
+        The initial angle rotates the reconstruction grid relative to the first projection.
+
+        Parameters
+        ----------
+        initial_angle : float
+            The angular offset of the object from the reference frame
+
+        angle_unit : string, default='degree'
+            The units `initial_angle` is given in, 'degree' or 'radian'. It is converted
+            and stored in the units the angles are stored in.
+
+        Returns
+        -------
+        AcquisitionGeometry
+            Returns the configured AcquisitionGeometry object
+
+        Examples
+        --------
+        >>> geometry.set_initial_angle(5.0)
+
+        '''
+        if AcquisitionType.CONE_FLEX & self.geom_type:
+            warnings.warn("Angles cannot be set for Cone3D_Flex geometry.", UserWarning, stacklevel=2)
+            return self
+
+        angle_unit = AngleUnit(angle_unit)
+        if angle_unit != AngleUnit(self.config.angles.angle_unit):
+            if angle_unit == AngleUnit.DEGREE:
+                initial_angle = numpy.deg2rad(initial_angle)
+            else:
+                initial_angle = numpy.rad2deg(initial_angle)
+
+        self.config.angles.initial_angle = initial_angle
         return self
 
     def set_panel(self, num_pixels, pixel_size=(1,1), origin='bottom-left'):

--- a/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_2D.py
+++ b/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_2D.py
@@ -51,9 +51,6 @@ def convert_geometry_to_astra_vec_2D(volume_geometry, sinogram_geometry_in):
     system = sinogram_geometry.config.system
     panel = sinogram_geometry.config.panel
 
-    #get units
-    degrees = angles.angle_unit == AngleUnit.DEGREE
-
     #create a 2D astra geom from 2D CIL geometry, 2D astra geometry has axis flipped compared to 3D
     volume_geometry_temp = volume_geometry.copy()
 
@@ -80,10 +77,10 @@ def convert_geometry_to_astra_vec_2D(volume_geometry, sinogram_geometry_in):
 
     vectors = np.zeros((angles.num_positions, 6))
 
-    for i, theta in enumerate(angles.angle_data):
-        ang = + angles.initial_angle + theta
+    for i, theta in enumerate(sinogram_geometry.get_angles(AngleUnit.RADIAN, include_initial_angle=True)):
+        ang = + theta
 
-        rotation_matrix = rotation_matrix_z_from_euler(ang, degrees=degrees)
+        rotation_matrix = rotation_matrix_z_from_euler(ang, degrees=False)
 
         vectors[i, :2]  = rotation_matrix.dot(src).reshape(2)
         vectors[i, 2:4] = rotation_matrix.dot(det).reshape(2)

--- a/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_3D.py
+++ b/Wrappers/Python/cil/plugins/astra/utilities/convert_geometry_to_astra_vec_3D.py
@@ -71,7 +71,6 @@ def convert_standard_geometry_to_astra_vec_3D(volume_geometry, sinogram_geometry
 
     sinogram_geometry.config.system.align_reference_frame('cil')
     angles = sinogram_geometry.config.angles
-    degrees = angles.angle_unit == AngleUnit.DEGREE
 
     system = sinogram_geometry.config.system
     panel = sinogram_geometry.config.panel
@@ -129,10 +128,10 @@ def convert_standard_geometry_to_astra_vec_3D(volume_geometry, sinogram_geometry
     #Build for astra 3D only
     vectors = np.zeros((angles.num_positions, 12))
 
-    for i, theta in enumerate(angles.angle_data):
-        ang = - angles.initial_angle - theta
+    for i, theta in enumerate(sinogram_geometry.get_angles(AngleUnit.RADIAN, include_initial_angle=True)):
+        ang = - theta
 
-        rotation_matrix = rotation_matrix_z_from_euler(ang, degrees=degrees)
+        rotation_matrix = rotation_matrix_z_from_euler(ang, degrees=False)
 
         vectors[i, :3]  = rotation_matrix.dot(src).reshape(3)
         vectors[i, 3:6] = rotation_matrix.dot(det).reshape(3)

--- a/Wrappers/Python/cil/plugins/tigre/Geometry.py
+++ b/Wrappers/Python/cil/plugins/tigre/Geometry.py
@@ -30,10 +30,7 @@ class CIL2TIGREGeometry(object):
         tg = TIGREGeometry(ig, ag)
 
         #angles
-        angles = ag.config.angles.angle_data + ag.config.angles.initial_angle
-
-        if ag.config.angles.angle_unit == AngleUnit.DEGREE:
-            angles *= (np.pi/180.)
+        angles = ag.get_angles(AngleUnit.RADIAN, include_initial_angle=True)
 
         #convert CIL to TIGRE angles s
         angles += np.pi/2 + tg.theta

--- a/Wrappers/Python/cil/processors/CofR_xcorrelation.py
+++ b/Wrappers/Python/cil/processors/CofR_xcorrelation.py
@@ -101,9 +101,7 @@ class CofR_xcorrelation(Processor):
             if angle< 0  or angle>=data.geometry.config.angles.num_positions:
                 raise ValueError('projection_index is out of range. Must be between 0 and {0}. Got {1}'.format(data.geometry.config.angles.num_positions-1, self.projection_index))
 
-        angles_deg = data.geometry.config.angles.angle_data.copy()
-        if data.geometry.config.angles.angle_unit == "radian":
-                angles_deg *= 180/np.pi
+        angles_deg = data.geometry.get_angles('degree')
 
         # if there is only 1 index specified, find the angle in the list closest to 180 degrees away from the index
         if len(index) == 1:

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -370,6 +370,87 @@ class Test_AcquisitionGeometry(unittest.TestCase):
         self.assertEqual(AG.config.angles.initial_angle, 0.1)
         self.assertEqual(AG.config.angles.angle_unit, 'radian')
 
+    def test_set_initial_angle(self):
+
+        AG = AcquisitionGeometry.create_Parallel2D()
+        angles = np.linspace(0, 360, 10, dtype=np.float32)
+        AG.set_angles(angles, 10.0, 'degree')
+
+        #as configured
+        self.assertEqual(AG.config.angles.initial_angle, 10.0)
+
+        #update it, angles are untouched
+        self.assertIs(AG.set_initial_angle(20.0), AG)
+        self.assertEqual(AG.config.angles.initial_angle, 20.0)
+        np.testing.assert_allclose(AG.config.angles.angle_data, angles, rtol=1E-6)
+        self.assertEqual(AG.config.angles.angle_unit, 'degree')
+
+        #given in the other unit, stored in the geometry's unit
+        AG.set_initial_angle(np.pi, 'radian')
+        self.assertAlmostEqual(AG.config.angles.initial_angle, 180.0, places=5)
+        self.assertEqual(AG.config.angles.angle_unit, 'degree')
+
+        #on a radian geometry
+        AG.set_angles(angles, 0.5, 'radian')
+        self.assertEqual(AG.config.angles.initial_angle, 0.5)
+
+        #the default is still degrees, and is converted on the way in
+        AG.set_initial_angle(180.0)
+        self.assertAlmostEqual(AG.config.angles.initial_angle, np.pi, places=5)
+        self.assertEqual(AG.config.angles.angle_unit, 'radian')
+
+        AG.set_initial_angle(np.pi/2, 'radian')
+        self.assertAlmostEqual(AG.config.angles.initial_angle, np.pi/2, places=5)
+
+        #units are not case sensitive
+        AG.set_initial_angle(np.pi/4, 'RaDiAn')
+        self.assertAlmostEqual(AG.config.angles.initial_angle, np.pi/4, places=5)
+
+        with self.assertRaises(ValueError):
+            AG.set_initial_angle(1.0, 'gradian')
+
+    def test_get_angles(self):
+
+        AG = AcquisitionGeometry.create_Parallel2D()
+        angles = np.linspace(0, 360, 10, dtype=np.float32)
+        AG.set_angles(angles, 10.0, 'degree')
+
+        #as configured
+        np.testing.assert_allclose(AG.config.angles.angle_data, angles, rtol=1E-6)
+        self.assertEqual(AG.config.angles.initial_angle, 10.0)
+        self.assertEqual(AG.config.angles.angle_unit, 'degree')
+
+        #defaults to degrees, without the initial angle
+        np.testing.assert_allclose(AG.get_angles(), angles, rtol=1E-6)
+
+        #the returned array is a copy
+        AG.get_angles()[:] = 0
+        np.testing.assert_allclose(AG.config.angles.angle_data, angles, rtol=1E-6)
+
+        np.testing.assert_allclose(AG.get_angles('degree'), angles, rtol=1E-6)
+        np.testing.assert_allclose(AG.get_angles('radian'), np.deg2rad(angles), rtol=1E-6)
+
+        np.testing.assert_allclose(AG.get_angles(include_initial_angle=True), angles + 10.0, rtol=1E-6)
+        np.testing.assert_allclose(AG.get_angles('radian', include_initial_angle=True),
+                                   np.deg2rad(angles + 10.0), rtol=1E-6)
+
+        #stored in radians
+        AG.set_angles(np.deg2rad(angles), np.deg2rad(10.0), 'radian')
+        np.testing.assert_allclose(AG.config.angles.angle_data, np.deg2rad(angles), rtol=1E-6)
+        self.assertEqual(AG.config.angles.angle_unit, 'radian')
+
+        #the default is still degrees
+        np.testing.assert_allclose(AG.get_angles(), angles, rtol=1E-5)
+        np.testing.assert_allclose(AG.get_angles('degree', include_initial_angle=True), angles + 10.0, rtol=1E-5)
+        np.testing.assert_allclose(AG.get_angles('radian', include_initial_angle=True),
+                                   np.deg2rad(angles + 10.0), rtol=1E-5)
+
+        #units are not case sensitive
+        np.testing.assert_allclose(AG.get_angles('DeGrEe'), angles, rtol=1E-5)
+
+        with self.assertRaises(ValueError):
+            AG.get_angles('gradian')
+
     def test_set_panel(self):
         AG = AcquisitionGeometry.create_Parallel3D()
 

--- a/docs/source/framework.rst
+++ b/docs/source/framework.rst
@@ -88,6 +88,10 @@ For circular geometries, we must set the angles of the projections. This is not 
 
 .. automethod:: cil.framework.AcquisitionGeometry.set_angles
 
+The initial angle can be updated on its own, leaving the angles unchanged:
+
+.. automethod:: cil.framework.AcquisitionGeometry.set_initial_angle
+
 
 Set the detector parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Changes
Adds a way to set the initial angle without having to pass the angle data again. Adds a getter so angles are converted as required on read.

## Testing you performed
> Please add any demo scripts to https://github.com/TomographicImaging/CIL-Demos/tree/main/misc


## Related issues/links


## Checklist

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have updated the relevant documentation
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
